### PR TITLE
Remove access to "next" wire & constant values

### DIFF
--- a/src/circuit_builder.rs
+++ b/src/circuit_builder.rs
@@ -84,8 +84,7 @@ impl<F: Field> CircuitBuilder<F> {
 
         let index = self.gate_instances.len();
 
-        // TODO: Not passing next constants for now. Not sure if it's really useful...
-        self.add_generators(gate_type.0.generators(index, &constants, &[]));
+        self.add_generators(gate_type.0.generators(index, &constants));
 
         self.gate_instances.push(GateInstance {
             gate_type,

--- a/src/gates/arithmetic.rs
+++ b/src/gates/arithmetic.rs
@@ -64,7 +64,6 @@ impl<F: Field> Gate<F> for ArithmeticGate {
         &self,
         gate_index: usize,
         local_constants: &[F],
-        _next_constants: &[F],
     ) -> Vec<Box<dyn WitnessGenerator<F>>> {
         let gen = ArithmeticGenerator {
             gate_index,

--- a/src/gates/constant.rs
+++ b/src/gates/constant.rs
@@ -45,7 +45,6 @@ impl<F: Field> Gate<F> for ConstantGate {
         &self,
         gate_index: usize,
         local_constants: &[F],
-        _next_constants: &[F],
     ) -> Vec<Box<dyn WitnessGenerator<F>>> {
         let gen = ConstantGenerator {
             gate_index,

--- a/src/gates/gate.rs
+++ b/src/gates/gate.rs
@@ -37,7 +37,6 @@ pub trait Gate<F: Field>: 'static + Send + Sync {
         &self,
         gate_index: usize,
         local_constants: &[F],
-        next_constants: &[F],
     ) -> Vec<Box<dyn WitnessGenerator<F>>>;
 
     /// The number of wires used by this gate.

--- a/src/gates/gmimc.rs
+++ b/src/gates/gmimc.rs
@@ -126,7 +126,6 @@ impl<F: Field, const R: usize> Gate<F> for GMiMCGate<F, R> {
         &self,
         gate_index: usize,
         _local_constants: &[F],
-        _next_constants: &[F],
     ) -> Vec<Box<dyn WitnessGenerator<F>>> {
         let gen = GMiMCGenerator {
             gate_index,
@@ -304,7 +303,7 @@ mod tests {
             );
         }
 
-        let generators = gate.0.generators(0, &[], &[]);
+        let generators = gate.0.generators(0, &[]);
         generate_partial_witness(&mut witness, &generators);
 
         let expected_outputs: [F; W] =

--- a/src/gates/gmimc_eval.rs
+++ b/src/gates/gmimc_eval.rs
@@ -38,7 +38,6 @@ impl<F: Field> Gate<F> for GMiMCEvalGate {
         &self,
         gate_index: usize,
         local_constants: &[F],
-        _next_constants: &[F],
     ) -> Vec<Box<dyn WitnessGenerator<F>>> {
         let gen = GMiMCEvalGenerator::<F> {
             gate_index,

--- a/src/gates/noop.rs
+++ b/src/gates/noop.rs
@@ -35,7 +35,6 @@ impl<F: Field> Gate<F> for NoopGate {
         &self,
         _gate_index: usize,
         _local_constants: &[F],
-        _next_constants: &[F],
     ) -> Vec<Box<dyn WitnessGenerator<F>>> {
         Vec::new()
     }

--- a/src/prover.rs
+++ b/src/prover.rs
@@ -197,9 +197,7 @@ fn compute_vanishing_polys<F: Field>(
 
             let vars = EvaluationVars {
                 local_constants,
-                next_constants,
                 local_wires,
-                next_wires,
             };
             compute_vanishing_poly_entry(
                 common_data,

--- a/src/vars.rs
+++ b/src/vars.rs
@@ -4,15 +4,11 @@ use crate::target::Target;
 #[derive(Copy, Clone)]
 pub struct EvaluationVars<'a, F: Field> {
     pub(crate) local_constants: &'a [F],
-    pub(crate) next_constants: &'a [F],
     pub(crate) local_wires: &'a [F],
-    pub(crate) next_wires: &'a [F],
 }
 
 #[derive(Copy, Clone)]
 pub struct EvaluationTargets<'a> {
     pub(crate) local_constants: &'a [Target],
-    pub(crate) next_constants: &'a [Target],
     pub(crate) local_wires: &'a [Target],
-    pub(crate) next_wires: &'a [Target],
 }


### PR DESCRIPTION
As discussed, it seems like the batch opening argument will be a significant cost, and we can reduce that cost by not including shifted openings (except for `Z`s which need them).