### PR TITLE
Use num_checks zetas

### DIFF
--- a/src/bin/bench_recursion.rs
+++ b/src/bin/bench_recursion.rs
@@ -35,7 +35,7 @@ fn bench_prove<F: Field>() {
         num_routed_wires: 12,
         security_bits: 128,
         rate_bits: 3,
-        num_checks: 3,
+        num_challenges: 3,
         fri_config: FriConfig {
             proof_of_work_bits: 1,
             rate_bits: 3,

--- a/src/circuit_data.rs
+++ b/src/circuit_data.rs
@@ -15,8 +15,9 @@ pub struct CircuitConfig {
     pub num_routed_wires: usize,
     pub security_bits: usize,
     pub rate_bits: usize,
-    /// The number of times to repeat checks that have soundness errors of (roughly) `degree / |F|`.
-    pub num_checks: usize,
+    /// The number of challenge points to generate, for IOPs that have soundness errors of (roughly)
+    /// `degree / |F|`.
+    pub num_challenges: usize,
 
     // TODO: Find a better place for this.
     pub fri_config: FriConfig,
@@ -29,7 +30,7 @@ impl Default for CircuitConfig {
             num_routed_wires: 4,
             security_bits: 128,
             rate_bits: 3,
-            num_checks: 3,
+            num_challenges: 3,
             fri_config: FriConfig {
                 proof_of_work_bits: 1,
                 rate_bits: 1,
@@ -159,7 +160,7 @@ impl<F: Field> CommonCircuitData<F> {
 
     pub fn total_constraints(&self) -> usize {
         // 2 constraints for each Z check.
-        self.config.num_checks * 2 + self.num_gate_constraints
+        self.config.num_challenges * 2 + self.num_gate_constraints
     }
 }
 

--- a/src/prover.rs
+++ b/src/prover.rs
@@ -48,7 +48,7 @@ pub(crate) fn prove<F: Field>(
 
     let config = &common_data.config;
     let num_wires = config.num_wires;
-    let num_checks = config.num_checks;
+    let num_challenges = config.num_challenges;
     let quotient_degree = common_data.quotient_degree();
 
     let degree = common_data.degree();
@@ -73,8 +73,8 @@ pub(crate) fn prove<F: Field>(
     challenger.observe_hash(&common_data.circuit_digest);
 
     challenger.observe_hash(&wires_commitment.merkle_tree.root);
-    let betas = challenger.get_n_challenges(num_checks);
-    let gammas = challenger.get_n_challenges(num_checks);
+    let betas = challenger.get_n_challenges(num_challenges);
+    let gammas = challenger.get_n_challenges(num_challenges);
 
     let plonk_z_vecs = timed!(compute_zs(&common_data), "to compute Z's");
 
@@ -85,7 +85,7 @@ pub(crate) fn prove<F: Field>(
 
     challenger.observe_hash(&plonk_zs_commitment.merkle_tree.root);
 
-    let alphas = challenger.get_n_challenges(num_checks);
+    let alphas = challenger.get_n_challenges(num_challenges);
 
     let vanishing_polys = timed!(
         compute_vanishing_polys(
@@ -103,7 +103,7 @@ pub(crate) fn prove<F: Field>(
     // Compute the quotient polynomials, aka `t` in the Plonk paper.
     let quotient_polys_commitment = timed!(
         {
-            let mut all_quotient_poly_chunks = Vec::with_capacity(num_checks * quotient_degree);
+            let mut all_quotient_poly_chunks = Vec::with_capacity(num_challenges * quotient_degree);
             for vanishing_poly in vanishing_polys.into_iter() {
                 let vanishing_poly_coeff = ifft(vanishing_poly);
                 let quotient_poly_coeff = divide_by_z_h(vanishing_poly_coeff, degree);
@@ -118,7 +118,7 @@ pub(crate) fn prove<F: Field>(
 
     challenger.observe_hash(&quotient_polys_commitment.merkle_tree.root);
 
-    let zetas = challenger.get_n_challenges(config.num_checks);
+    let zetas = challenger.get_n_challenges(config.num_challenges);
 
     let (opening_proof, openings) = timed!(
         ListPolynomialCommitment::batch_open_plonk(
@@ -151,7 +151,7 @@ pub(crate) fn prove<F: Field>(
 }
 
 fn compute_zs<F: Field>(common_data: &CommonCircuitData<F>) -> Vec<PolynomialCoeffs<F>> {
-    (0..common_data.config.num_checks)
+    (0..common_data.config.num_challenges)
         .map(|i| compute_z(common_data, i))
         .collect()
 }
@@ -172,7 +172,7 @@ fn compute_vanishing_polys<F: Field>(
 ) -> Vec<PolynomialValues<F>> {
     let lde_size = common_data.lde_size();
     let lde_gen = common_data.lde_generator();
-    let num_checks = common_data.config.num_checks;
+    let num_challenges = common_data.config.num_challenges;
 
     let points = F::cyclic_subgroup_known_order(lde_gen, lde_size);
     let values: Vec<Vec<F>> = points
@@ -187,7 +187,7 @@ fn compute_vanishing_polys<F: Field>(
             let s_sigmas = prover_data.sigmas_commitment.leaf(i);
 
             debug_assert_eq!(local_wires.len(), common_data.config.num_wires);
-            debug_assert_eq!(local_plonk_zs.len(), num_checks);
+            debug_assert_eq!(local_plonk_zs.len(), num_challenges);
 
             let vars = EvaluationVars {
                 local_constants,
@@ -235,7 +235,7 @@ fn compute_vanishing_poly_entry<F: Field>(
     // The Z(x) f'(x) - g'(x) Z(g x) terms.
     let mut vanishing_v_shift_terms = Vec::new();
 
-    for i in 0..common_data.config.num_checks {
+    for i in 0..common_data.config.num_challenges {
         let z_x = local_plonk_zs[i];
         let z_gz = next_plonk_zs[i];
         vanishing_z_1_terms.push(eval_l_1(common_data.degree(), x) * (z_x - F::ONE));


### PR DESCRIPTION
The soundness error is (degree of combined constraints)/|F|, so 3 zetas should be appropriate for all practical circuit sizes. `num_checks` defaults to 3.