### PR TITLE
Switched over from OsRng --> thread_rng

### DIFF
--- a/src/field/field.rs
+++ b/src/field/field.rs
@@ -267,7 +267,7 @@ pub trait Field:
     }
 
     fn rand() -> Self {
-        Self::rand_from_rng(&mut OsRng)
+        Self::rand_from_rng(&mut rand::thread_rng())
     }
 
     fn rand_vec(n: usize) -> Vec<Self> {


### PR DESCRIPTION
After generating a flamegraph for the test `bench_recursive`, it became apparent on my machine that ~20% of the time was spent inside an rng call. After talking about this with Daniel, we realized this was likely due to `OsRng` blocking on a rng Linux device (like `/dev/random`). `thread_rng`, on the other hand, does not block, and this PR replaces `OsRng` with `thread_rng`.

At least on my Linux machine, the improvements we're very significant (> 50%) after comparing the actual benchmark time differences. The most notable difference was with `witness & proof generation`:
```
With OsRng:
[2021-05-15T00:44:35Z INFO  plonky2::prover] 23.738s for overall witness & proof generation

With thread_rng():
[2021-05-15T01:42:47Z INFO  plonky2::prover] 4.399s for overall witness & proof generation
```

However, Daniel tested this on his Windows machine and the effect seemed negligible. Regardless, this is likely a needed change to run nicely on Linux machines. :sunglasses:

Full differences:
```
With OsRng:
[2021-05-15T00:44:11Z INFO  plonky2::circuit_builder] degree before blinding & padding: 10001
[2021-05-15T00:44:11Z INFO  plonky2::circuit_builder] degree after blinding & padding: 16384
[2021-05-15T00:44:11Z INFO  plonky2::polynomial::commitment] 0.030s to compute LDE
[2021-05-15T00:44:11Z INFO  plonky2::polynomial::commitment] 0.008s to transpose LDEs
[2021-05-15T00:44:11Z INFO  plonky2::polynomial::commitment] 0.049s to build Merkle tree
[2021-05-15T00:44:11Z INFO  plonky2::polynomial::commitment] 0.166s to compute LDE
[2021-05-15T00:44:11Z INFO  plonky2::polynomial::commitment] 0.020s to transpose LDEs
[2021-05-15T00:44:11Z INFO  plonky2::polynomial::commitment] 0.109s to build Merkle tree
[2021-05-15T00:44:11Z INFO  plonky2::circuit_builder] Building circuit took 0.5280408s
[2021-05-15T00:44:11Z INFO  plonky2::prover] Running 10001 generators
[2021-05-15T00:44:11Z INFO  plonky2::prover] 0.049s to generate witness
[2021-05-15T00:44:11Z INFO  plonky2::prover] 0.086s to compute wire polynomials
[2021-05-15T00:44:20Z INFO  plonky2::polynomial::commitment] 8.421s to compute LDE
[2021-05-15T00:44:20Z INFO  plonky2::polynomial::commitment] 0.224s to transpose LDEs
[2021-05-15T00:44:21Z INFO  plonky2::polynomial::commitment] 0.557s to build Merkle tree
[2021-05-15T00:44:21Z INFO  plonky2::prover] 9.206s to compute wires commitment
[2021-05-15T00:44:21Z INFO  plonky2::prover] 0.000s to compute Z's
[2021-05-15T00:44:27Z INFO  plonky2::polynomial::commitment] 6.668s to compute LDE
[2021-05-15T00:44:27Z INFO  plonky2::polynomial::commitment] 0.014s to transpose LDEs
[2021-05-15T00:44:27Z INFO  plonky2::polynomial::commitment] 0.083s to build Merkle tree
[2021-05-15T00:44:27Z INFO  plonky2::prover] 6.771s to commit to Z's
[2021-05-15T00:44:27Z INFO  plonky2::prover] 0.160s to compute vanishing polys
[2021-05-15T00:44:35Z INFO  plonky2::polynomial::commitment] 6.955s to compute LDE
[2021-05-15T00:44:35Z INFO  plonky2::polynomial::commitment] 0.043s to transpose LDEs
[2021-05-15T00:44:35Z INFO  plonky2::polynomial::commitment] 0.166s to build Merkle tree
[2021-05-15T00:44:35Z INFO  plonky2::prover] 7.328s to compute quotient polys and commit to them
[2021-05-15T00:44:35Z INFO  plonky2::prover] 0.139s to compute opening proofs
[2021-05-15T00:44:35Z INFO  plonky2::prover] 23.738s for overall witness & proof generation

With thread_rng:
[2021-05-15T01:42:42Z INFO  plonky2::circuit_builder] degree before blinding & padding: 10001
[2021-05-15T01:42:42Z INFO  plonky2::circuit_builder] degree after blinding & padding: 16384
[2021-05-15T01:42:42Z INFO  plonky2::polynomial::commitment] 0.022s to compute LDE
[2021-05-15T01:42:42Z INFO  plonky2::polynomial::commitment] 0.007s to transpose LDEs
[2021-05-15T01:42:43Z INFO  plonky2::polynomial::commitment] 0.055s to build Merkle tree
[2021-05-15T01:42:43Z INFO  plonky2::polynomial::commitment] 0.189s to compute LDE
[2021-05-15T01:42:43Z INFO  plonky2::polynomial::commitment] 0.022s to transpose LDEs
[2021-05-15T01:42:43Z INFO  plonky2::polynomial::commitment] 0.127s to build Merkle tree
[2021-05-15T01:42:43Z INFO  plonky2::circuit_builder] Building circuit took 0.5900737s
[2021-05-15T01:42:43Z INFO  plonky2::prover] Running 10001 generators
[2021-05-15T01:42:43Z INFO  plonky2::prover] 0.055s to generate witness
[2021-05-15T01:42:43Z INFO  plonky2::prover] 0.098s to compute wire polynomials
[2021-05-15T01:42:45Z INFO  plonky2::polynomial::commitment] 1.900s to compute LDE
[2021-05-15T01:42:45Z INFO  plonky2::polynomial::commitment] 0.259s to transpose LDEs
[2021-05-15T01:42:46Z INFO  plonky2::polynomial::commitment] 0.735s to build Merkle tree
[2021-05-15T01:42:46Z INFO  plonky2::prover] 2.898s to compute wires commitment
[2021-05-15T01:42:46Z INFO  plonky2::prover] 0.000s to compute Z's
[2021-05-15T01:42:46Z INFO  plonky2::polynomial::commitment] 0.053s to compute LDE
[2021-05-15T01:42:46Z INFO  plonky2::polynomial::commitment] 0.016s to transpose LDEs
[2021-05-15T01:42:46Z INFO  plonky2::polynomial::commitment] 0.091s to build Merkle tree
[2021-05-15T01:42:46Z INFO  plonky2::prover] 0.164s to commit to Z's
[2021-05-15T01:42:46Z INFO  plonky2::prover] 0.217s to compute vanishing polys
[2021-05-15T01:42:47Z INFO  plonky2::polynomial::commitment] 0.352s to compute LDE
[2021-05-15T01:42:47Z INFO  plonky2::polynomial::commitment] 0.048s to transpose LDEs
[2021-05-15T01:42:47Z INFO  plonky2::polynomial::commitment] 0.211s to build Merkle tree
[2021-05-15T01:42:47Z INFO  plonky2::prover] 0.803s to compute quotient polys and commit to them
[2021-05-15T01:42:47Z INFO  plonky2::prover] 0.164s to compute opening proofs
[2021-05-15T01:42:47Z INFO  plonky2::prover] 4.399s for overall witness & proof generation
```