### PR TITLE
Fix intermittent inv_mod_xn failure

### DIFF
--- a/src/polynomial/division.rs
+++ b/src/polynomial/division.rs
@@ -128,7 +128,13 @@ impl<F: Field> PolynomialCoeffs<F> {
     /// Computes the inverse of `self` modulo `x^n`.
     pub(crate) fn inv_mod_xn(&self, n: usize) -> Self {
         assert!(self.coeffs[0].is_nonzero(), "Inverse doesn't exist.");
-        let mut h = self.padded(n);
+
+        let h = if self.len() < n {
+            self.padded(n)
+        } else {
+            self.clone()
+        };
+
         let mut a = Self::empty();
         a.coeffs.push(h.coeffs[0].inverse());
         for i in 0..log2_ceil(n) {


### PR DESCRIPTION
My recent change made `padded` panic if the padded length is less than the current length. I figured that might indicate that something unexpected was going on, so might be good to fail fast.

It looks like `inv_mod_xn` was relying on the old `padded` behavior, and it seems correct (i.e. in this case it wasn't a symptom of anything going wrong) as far as I can tell.

We could also restore the old behavior of `padded` if you prefer; let me know if you have a preferennce.