### PR TITLE
Fix `InterpolationGenerator` dependencies.

### DIFF
--- a/src/gates/interpolation.rs
+++ b/src/gates/interpolation.rs
@@ -209,11 +209,9 @@ impl<F: Extendable<D>, const D: usize> SimpleGenerator<F> for InterpolationGener
 
         let mut deps = Vec::new();
         deps.extend(local_targets(self.gate.wires_evaluation_point()));
-        deps.extend(local_targets(self.gate.wires_evaluation_value()));
         for i in 0..self.gate.num_points {
             deps.push(local_target(self.gate.wire_point(i)));
             deps.extend(local_targets(self.gate.wires_value(i)));
-            deps.extend(local_targets(self.gate.wires_coeff(i)));
         }
         deps
     }


### PR DESCRIPTION
Removes the evaluation value and the polynomial coefficients from the generator dependencies.