### PR TITLE
Hardcode Plonk polynomials indices and blinding flags.

### DIFF
--- a/src/bin/bench_recursion.rs
+++ b/src/bin/bench_recursion.rs
@@ -8,7 +8,6 @@ use plonky2::fri::FriConfig;
 use plonky2::gates::constant::ConstantGate;
 use plonky2::gates::gmimc::GMiMCGate;
 use plonky2::hash::GMIMC_ROUNDS;
-use plonky2::prover::PLONK_BLINDING;
 use plonky2::witness::PartialWitness;
 
 fn main() {
@@ -41,7 +40,6 @@ fn bench_prove<F: Field + Extendable<D>, const D: usize>() {
             rate_bits: 3,
             reduction_arity_bits: vec![1],
             num_query_rounds: 1,
-            blinding: PLONK_BLINDING.to_vec(),
         },
     };
 

--- a/src/circuit_data.rs
+++ b/src/circuit_data.rs
@@ -7,7 +7,7 @@ use crate::gates::gate::GateRef;
 use crate::generator::WitnessGenerator;
 use crate::polynomial::commitment::ListPolynomialCommitment;
 use crate::proof::{Hash, HashTarget, Proof};
-use crate::prover::{prove, PLONK_BLINDING};
+use crate::prover::prove;
 use crate::verifier::verify;
 use crate::witness::PartialWitness;
 
@@ -38,7 +38,6 @@ impl Default for CircuitConfig {
                 rate_bits: 1,
                 reduction_arity_bits: vec![1],
                 num_query_rounds: 1,
-                blinding: vec![true],
             },
         }
     }
@@ -61,7 +60,6 @@ impl CircuitConfig {
                 rate_bits: 3,
                 reduction_arity_bits: vec![1],
                 num_query_rounds: 1,
-                blinding: PLONK_BLINDING.to_vec(),
             },
         }
     }

--- a/src/fri/mod.rs
+++ b/src/fri/mod.rs
@@ -1,5 +1,3 @@
-use crate::polynomial::commitment::SALT_SIZE;
-
 pub mod prover;
 mod recursive_verifier;
 pub mod verifier;
@@ -22,20 +20,6 @@ pub struct FriConfig {
 
     /// Number of query rounds to perform.
     pub num_query_rounds: usize,
-
-    /// Vector of the same length as the number of initial Merkle trees.
-    /// `blinding[i]==true` iff the i-th tree is salted.  
-    pub blinding: Vec<bool>,
-}
-
-impl FriConfig {
-    pub(crate) fn salt_size(&self, i: usize) -> usize {
-        if self.blinding[i] {
-            SALT_SIZE
-        } else {
-            0
-        }
-    }
 }
 
 fn fri_delta(rate_log: usize, conjecture: bool) -> f64 {

--- a/src/fri/recursive_verifier.rs
+++ b/src/fri/recursive_verifier.rs
@@ -6,6 +6,7 @@ use crate::field::extension_field::Extendable;
 use crate::field::field::Field;
 use crate::fri::FriConfig;
 use crate::plonk_challenger::RecursiveChallenger;
+use crate::plonk_common::PlonkPolynomials;
 use crate::proof::{
     FriInitialTreeProofTarget, FriProofTarget, FriQueryRoundTarget, HashTarget, OpeningSetTarget,
 };
@@ -157,11 +158,15 @@ impl<F: Extendable<D>, const D: usize> CircuitBuilder<F, D> {
         // - one for polynomials opened at `x` and `x.frobenius()`
 
         // Polynomials opened at `x`, i.e., the constants, sigmas and quotient polynomials.
-        let single_evals = [0, 1, 4]
-            .iter()
-            .flat_map(|&i| proof.unsalted_evals(i, config))
-            .map(|&e| self.convert_to_ext(e))
-            .collect::<Vec<_>>();
+        let single_evals = [
+            PlonkPolynomials::CONSTANTS,
+            PlonkPolynomials::SIGMAS,
+            PlonkPolynomials::QUOTIENT,
+        ]
+        .iter()
+        .flat_map(|&p| proof.unsalted_evals(p))
+        .map(|&e| self.convert_to_ext(e))
+        .collect::<Vec<_>>();
         let single_openings = os
             .constants
             .iter()
@@ -179,7 +184,7 @@ impl<F: Extendable<D>, const D: usize> CircuitBuilder<F, D> {
 
         // Polynomials opened at `x` and `g x`, i.e., the Zs polynomials.
         let zs_evals = proof
-            .unsalted_evals(3, config)
+            .unsalted_evals(PlonkPolynomials::ZS)
             .iter()
             .map(|&e| self.convert_to_ext(e))
             .collect::<Vec<_>>();
@@ -217,7 +222,7 @@ impl<F: Extendable<D>, const D: usize> CircuitBuilder<F, D> {
 
         // Polynomials opened at `x` and `x.frobenius()`, i.e., the wires polynomials.
         let wire_evals = proof
-            .unsalted_evals(2, config)
+            .unsalted_evals(PlonkPolynomials::WIRES)
             .iter()
             .map(|&e| self.convert_to_ext(e))
             .collect::<Vec<_>>();

--- a/src/gadgets/arithmetic.rs
+++ b/src/gadgets/arithmetic.rs
@@ -371,7 +371,6 @@ mod tests {
     use crate::field::extension_field::quartic::QuarticCrandallField;
     use crate::field::field::Field;
     use crate::fri::FriConfig;
-    use crate::prover::PLONK_BLINDING;
     use crate::witness::PartialWitness;
 
     #[test]

--- a/src/plonk_common.rs
+++ b/src/plonk_common.rs
@@ -6,9 +6,61 @@ use crate::field::extension_field::target::ExtensionTarget;
 use crate::field::extension_field::Extendable;
 use crate::field::field::Field;
 use crate::gates::gate::GateRef;
+use crate::polynomial::commitment::SALT_SIZE;
 use crate::polynomial::polynomial::PolynomialCoeffs;
 use crate::target::Target;
 use crate::vars::{EvaluationTargets, EvaluationVars, EvaluationVarsBase};
+
+/// Holds the Merkle tree index and blinding flag of a set of polynomials used in FRI.
+#[derive(Debug, Copy, Clone)]
+pub struct PolynomialsIndexBlinding {
+    pub(crate) index: usize,
+    pub(crate) blinding: bool,
+}
+impl PolynomialsIndexBlinding {
+    pub fn salt_size(&self) -> usize {
+        if self.blinding {
+            SALT_SIZE
+        } else {
+            0
+        }
+    }
+}
+/// Holds the indices and blinding flags of the Plonk polynomials.
+pub struct PlonkPolynomials;
+impl PlonkPolynomials {
+    pub const CONSTANTS: PolynomialsIndexBlinding = PolynomialsIndexBlinding {
+        index: 0,
+        blinding: false,
+    };
+    pub const SIGMAS: PolynomialsIndexBlinding = PolynomialsIndexBlinding {
+        index: 1,
+        blinding: false,
+    };
+    pub const WIRES: PolynomialsIndexBlinding = PolynomialsIndexBlinding {
+        index: 2,
+        blinding: true,
+    };
+    pub const ZS: PolynomialsIndexBlinding = PolynomialsIndexBlinding {
+        index: 3,
+        blinding: true,
+    };
+    pub const QUOTIENT: PolynomialsIndexBlinding = PolynomialsIndexBlinding {
+        index: 4,
+        blinding: true,
+    };
+
+    pub fn polynomials(i: usize) -> PolynomialsIndexBlinding {
+        match i {
+            0 => Self::CONSTANTS,
+            1 => Self::SIGMAS,
+            2 => Self::WIRES,
+            3 => Self::ZS,
+            4 => Self::QUOTIENT,
+            _ => panic!("There are only 5 sets of polynomials in Plonk."),
+        }
+    }
+}
 
 /// Evaluate the vanishing polynomial at `x`. In this context, the vanishing polynomial is a random
 /// linear combination of gate constraints, plus some other terms relating to the permutation

--- a/src/polynomial/commitment.rs
+++ b/src/polynomial/commitment.rs
@@ -260,9 +260,9 @@ pub struct OpeningProofTarget<const D: usize> {
 #[cfg(test)]
 mod tests {
     use anyhow::Result;
-    use rand::Rng;
 
     use super::*;
+    use crate::plonk_common::PlonkPolynomials;
 
     fn gen_random_test_case<F: Field + Extendable<D>, const D: usize>(
         k: usize,
@@ -288,17 +288,6 @@ mod tests {
         point
     }
 
-    fn gen_random_blindings() -> Vec<bool> {
-        let mut rng = rand::thread_rng();
-        vec![
-            rng.gen_bool(0.5),
-            rng.gen_bool(0.5),
-            rng.gen_bool(0.5),
-            rng.gen_bool(0.5),
-            rng.gen_bool(0.5),
-        ]
-    }
-
     fn check_batch_polynomial_commitment<F: Field + Extendable<D>, const D: usize>() -> Result<()> {
         let ks = [1, 2, 3, 5, 8];
         let degree_log = 11;
@@ -307,7 +296,6 @@ mod tests {
             rate_bits: 2,
             reduction_arity_bits: vec![2, 3, 1, 2],
             num_query_rounds: 3,
-            blinding: gen_random_blindings(),
         };
 
         let lpcs = (0..5)
@@ -315,7 +303,7 @@ mod tests {
                 ListPolynomialCommitment::<F>::new(
                     gen_random_test_case(ks[i], degree_log),
                     fri_config.rate_bits,
-                    fri_config.blinding[i],
+                    PlonkPolynomials::polynomials(i).blinding,
                 )
             })
             .collect::<Vec<_>>();

--- a/src/proof.rs
+++ b/src/proof.rs
@@ -3,9 +3,9 @@ use std::convert::TryInto;
 use crate::field::extension_field::target::ExtensionTarget;
 use crate::field::extension_field::Extendable;
 use crate::field::field::Field;
-use crate::fri::FriConfig;
 use crate::gadgets::polynomial::PolynomialCoeffsExtTarget;
 use crate::merkle_proofs::{MerkleProof, MerkleProofTarget};
+use crate::plonk_common::PolynomialsIndexBlinding;
 use crate::polynomial::commitment::{ListPolynomialCommitment, OpeningProof, OpeningProofTarget};
 use crate::polynomial::polynomial::PolynomialCoeffs;
 use crate::target::Target;
@@ -99,9 +99,9 @@ pub struct FriInitialTreeProof<F: Field> {
 }
 
 impl<F: Field> FriInitialTreeProof<F> {
-    pub(crate) fn unsalted_evals(&self, i: usize, config: &FriConfig) -> &[F] {
-        let evals = &self.evals_proofs[i].0;
-        &evals[..evals.len() - config.salt_size(i)]
+    pub(crate) fn unsalted_evals(&self, polynomials: PolynomialsIndexBlinding) -> &[F] {
+        let evals = &self.evals_proofs[polynomials.index].0;
+        &evals[..evals.len() - polynomials.salt_size()]
     }
 }
 
@@ -110,9 +110,9 @@ pub struct FriInitialTreeProofTarget {
 }
 
 impl FriInitialTreeProofTarget {
-    pub(crate) fn unsalted_evals(&self, i: usize, config: &FriConfig) -> &[Target] {
-        let evals = &self.evals_proofs[i].0;
-        &evals[..evals.len() - config.salt_size(i)]
+    pub(crate) fn unsalted_evals(&self, polynomials: PolynomialsIndexBlinding) -> &[Target] {
+        let evals = &self.evals_proofs[polynomials.index].0;
+        &evals[..evals.len() - polynomials.salt_size()]
     }
 }
 

--- a/src/prover.rs
+++ b/src/prover.rs
@@ -19,9 +19,6 @@ use crate::vars::EvaluationVarsBase;
 use crate::wire::Wire;
 use crate::witness::PartialWitness;
 
-/// Corresponds to constants - sigmas - wires - zs - quotient — polynomial commitments.
-pub const PLONK_BLINDING: [bool; 5] = [false, false, true, true, true];
-
 pub(crate) fn prove<F: Extendable<D>, const D: usize>(
     prover_data: &ProverOnlyCircuitData<F>,
     common_data: &CommonCircuitData<F, D>,


### PR DESCRIPTION
This adds a `PlonkPolynomials` struct containing the indices of the (sets of) polynomials used in Plonk, as well as whether they should be blinded or not. For example this
```rust
[0, 1, 4]
   .iter()
   .flat_map(|&i| proof.unsalted_evals(i, config))
```
becomes
```rust
[PlonkPolynomials::CONSTANTS,
 PlonkPolynomials::SIGMAS,
 PlonkPolynomials::QUOTIENT]
   .iter()
   .flat_map(|&p| proof.unsalted_evals(p))
```
which should make the code's intent clearer. It also makes it easier to rearrange polynomials if we ever need to.
Finally, this removes the `blinding` field in `FriConfig`, so that now `FriConfig` holds only parameters on how FRI is run and not on what data it is run on.  