### PR TITLE
Couple fixes related to blinding

### DIFF
--- a/src/bin/bench_recursion.rs
+++ b/src/bin/bench_recursion.rs
@@ -32,7 +32,7 @@ fn bench_prove<F: Field + Extendable<D>, const D: usize>() {
         fri_config: FriConfig {
             proof_of_work_bits: 1,
             rate_bits: 3,
-            reduction_arity_bits: vec![1],
+            reduction_arity_bits: vec![1, 1, 1, 1],
             num_query_rounds: 1,
         },
     };

--- a/src/circuit_builder.rs
+++ b/src/circuit_builder.rs
@@ -259,7 +259,7 @@ impl<F: Extendable<D>, const D: usize> CircuitBuilder<F, D> {
     /// polynomials (which are opened at only one location) and for the Z polynomials (which are
     /// opened at two).
     fn blinding_counts(&self) -> (usize, usize) {
-        let num_gates = self.gates.len();
+        let num_gates = self.gate_instances.len();
         let mut degree_estimate = 1 << log2_ceil(num_gates);
 
         loop {

--- a/src/circuit_data.rs
+++ b/src/circuit_data.rs
@@ -39,7 +39,7 @@ impl Default for CircuitConfig {
             fri_config: FriConfig {
                 proof_of_work_bits: 1,
                 rate_bits: 1,
-                reduction_arity_bits: vec![1],
+                reduction_arity_bits: vec![1, 1, 1, 1],
                 num_query_rounds: 1,
             },
         }
@@ -61,7 +61,7 @@ impl CircuitConfig {
             fri_config: FriConfig {
                 proof_of_work_bits: 1,
                 rate_bits: 3,
-                reduction_arity_bits: vec![1],
+                reduction_arity_bits: vec![1, 1, 1, 1],
                 num_query_rounds: 1,
             },
         }


### PR DESCRIPTION
- `self.gates` -> `self.gate_instances`
- Some tests were using a single binary FRI reduction, which doesn't provide enough succinctness for our blinding scheme to work. This caused `blinding_counts` to continue until it overflowed.