### PR TITLE
Benchmark tweaks

### DIFF
--- a/src/bin/bench_recursion.rs
+++ b/src/bin/bench_recursion.rs
@@ -21,8 +21,6 @@ fn main() {
 }
 
 fn bench_prove<F: Field + Extendable<D>, const D: usize>() {
-    let gmimc_gate = GMiMCGate::<F, D, GMIMC_ROUNDS>::with_automatic_constants();
-
     let config = CircuitConfig {
         num_wires: 134,
         num_routed_wires: 27,
@@ -32,7 +30,7 @@ fn bench_prove<F: Field + Extendable<D>, const D: usize>() {
         fri_config: FriConfig {
             proof_of_work_bits: 1,
             rate_bits: 3,
-            reduction_arity_bits: vec![1, 1, 1, 1],
+            reduction_arity_bits: vec![2, 2, 2, 2, 2],
             num_query_rounds: 1,
         },
     };

--- a/src/circuit_builder.rs
+++ b/src/circuit_builder.rs
@@ -281,6 +281,10 @@ impl<F: Extendable<D>, const D: usize> CircuitBuilder<F, D> {
 
     fn blind_and_pad(&mut self) {
         let (regular_poly_openings, z_openings) = self.blinding_counts();
+        info!(
+            "Adding {} blinding terms for witness polynomials, and {}*2 for Z polynomials",
+            regular_poly_openings, z_openings
+        );
 
         let num_routed_wires = self.config.num_routed_wires;
         let num_wires = self.config.num_wires;
@@ -383,12 +387,12 @@ impl<F: Extendable<D>, const D: usize> CircuitBuilder<F, D> {
     pub fn build(mut self) -> CircuitData<F, D> {
         let start = Instant::now();
         info!(
-            "degree before blinding & padding: {}",
+            "Degree before blinding & padding: {}",
             self.gate_instances.len()
         );
         self.blind_and_pad();
         let degree = self.gate_instances.len();
-        info!("degree after blinding & padding: {}", degree);
+        info!("Degree after blinding & padding: {}", degree);
 
         let gates = self.gates.iter().cloned().collect();
         let (gate_tree, max_filtered_constraint_degree, num_constants) = Tree::from_gates(gates);

--- a/src/gadgets/arithmetic.rs
+++ b/src/gadgets/arithmetic.rs
@@ -1,7 +1,6 @@
 use crate::circuit_builder::CircuitBuilder;
 use crate::field::extension_field::Extendable;
 use crate::target::Target;
-use crate::util::bits_u64;
 
 impl<F: Extendable<D>, const D: usize> CircuitBuilder<F, D> {
     /// Computes `-x`.

--- a/src/gadgets/arithmetic_extension.rs
+++ b/src/gadgets/arithmetic_extension.rs
@@ -6,7 +6,7 @@ use num::Integer;
 
 use crate::circuit_builder::CircuitBuilder;
 use crate::field::extension_field::target::{ExtensionAlgebraTarget, ExtensionTarget};
-use crate::field::extension_field::{Extendable, FieldExtension, OEF};
+use crate::field::extension_field::{Extendable, OEF};
 use crate::field::field::Field;
 use crate::gates::arithmetic::ArithmeticExtensionGate;
 use crate::generator::SimpleGenerator;

--- a/src/gates/gate_tree.rs
+++ b/src/gates/gate_tree.rs
@@ -86,7 +86,7 @@ impl<F: Extendable<D>, const D: usize> Tree<GateRef<F, D>> {
                         }
                     }
                     info!(
-                        "Found tree with max degree {} and {} constants wires in {}s.",
+                        "Found tree with max degree {} and {} constants wires in {:.4}s.",
                         best_degree,
                         best_num_constants,
                         timer.elapsed().as_secs_f32()

--- a/src/polynomial/polynomial.rs
+++ b/src/polynomial/polynomial.rs
@@ -1,5 +1,3 @@
-use std::time::Instant;
-
 use std::cmp::max;
 use std::iter::Sum;
 use std::ops::{Add, AddAssign, Mul, MulAssign, Sub, SubAssign};
@@ -7,7 +5,7 @@ use std::ops::{Add, AddAssign, Mul, MulAssign, Sub, SubAssign};
 use anyhow::{ensure, Result};
 
 use crate::field::extension_field::Extendable;
-use crate::field::fft::{fft, ifft, fft_with_options};
+use crate::field::fft::{fft, fft_with_options, ifft};
 use crate::field::field::Field;
 use crate::util::log2_strict;
 

--- a/src/util/timing.rs
+++ b/src/util/timing.rs
@@ -7,7 +7,7 @@ macro_rules! timed {
 
         let timer = Instant::now();
         let res = $a;
-        info!("{:.3}s {}", timer.elapsed().as_secs_f32(), $msg);
+        info!("{:.4}s {}", timer.elapsed().as_secs_f32(), $msg);
         res
     }};
 }


### PR DESCRIPTION
- Configure FRI with a list of arities that's more appropriate for a 2^14 instance. The previous config resulted in a huge final polynomial.
- Log the blinding factors, and other logging tweaks.