### PR TITLE
Allow virtual targets to be routed

### DIFF
--- a/src/gadgets/split_join.rs
+++ b/src/gadgets/split_join.rs
@@ -9,14 +9,14 @@ use crate::wire::Wire;
 use crate::witness::PartialWitness;
 
 impl<F: Extendable<D>, const D: usize> CircuitBuilder<F, D> {
-    /// Split the given integer into a list of virtual advice targets, where each one represents a
-    /// bit of the integer, with little-endian ordering.
+    /// Split the given integer into a list of virtual targets, where each one represents a bit of
+    /// the integer, with little-endian ordering.
     ///
     /// Note that this only handles witness generation; it does not enforce that the decomposition
     /// is correct. The output should be treated as a "purported" decomposition which must be
     /// enforced elsewhere.
     pub(crate) fn split_le_virtual(&mut self, integer: Target, num_bits: usize) -> Vec<Target> {
-        let bit_targets = self.add_virtual_advice_targets(num_bits);
+        let bit_targets = self.add_virtual_targets(num_bits);
         self.add_generator(SplitGenerator {
             integer,
             bits: bit_targets.clone(),

--- a/src/permutation_argument.rs
+++ b/src/permutation_argument.rs
@@ -57,7 +57,7 @@ impl TargetPartitions {
     }
 
     pub fn to_wire_partitions(&self) -> WirePartitions {
-        // Here we just drop all CircuitInputs, leaving all GateInputs.
+        // Here we keep just the Wire targets, filtering out everything else.
         let mut partitions = Vec::new();
         let mut indices = HashMap::new();
 

--- a/src/target.rs
+++ b/src/target.rs
@@ -8,7 +8,10 @@ use crate::wire::Wire;
 pub enum Target {
     Wire(Wire),
     PublicInput { index: usize },
-    VirtualAdviceTarget { index: usize },
+    /// A target that doesn't have any inherent location in the witness (but it can be copied to
+    /// another target that does). This is useful for representing intermediate values in witness
+    /// generation.
+    VirtualTarget { index: usize },
 }
 
 impl Target {
@@ -20,7 +23,7 @@ impl Target {
         match self {
             Target::Wire(wire) => wire.is_routable(config),
             Target::PublicInput { .. } => true,
-            Target::VirtualAdviceTarget { .. } => false,
+            Target::VirtualTarget { .. } => true,
         }
     }
 

--- a/src/witness.rs
+++ b/src/witness.rs
@@ -30,7 +30,7 @@ impl<F: Field> Witness<F> {
         F: Extendable<D>,
     {
         for &(a, b) in copy_constraints {
-            // TODO: Take care of public inputs once they land.
+            // TODO: Take care of public inputs once they land, and virtual targets.
             if let (
                 Target::Wire(Wire {
                     gate: a_gate,


### PR DESCRIPTION
As in plonky1. The semantics of virtual targets in plonky1 were rather weird, but I think it's somewhat better here, since we already separate `generate_copy` and `assert_equal` methods. Users now make more of an explicit choice -- they can use a `VirtualTarget` for the witness generation only using `generate_copy`, or they can involve it in copy constraints.