### PR TITLE
Trim final polynomial and check total FRI arity

### DIFF
--- a/src/circuit_builder.rs
+++ b/src/circuit_builder.rs
@@ -496,6 +496,16 @@ impl<F: Extendable<D>, const D: usize> CircuitBuilder<F, D> {
         self.blind_and_pad();
         let degree = self.gate_instances.len();
         info!("Degree after blinding & padding: {}", degree);
+        let degree_bits = log2_strict(degree);
+        assert!(
+            self.config
+                .fri_config
+                .reduction_arity_bits
+                .iter()
+                .sum::<usize>()
+                <= degree_bits,
+            "FRI total reduction arity is too large."
+        );
 
         let gates = self.gates.iter().cloned().collect();
         let (gate_tree, max_filtered_constraint_degree, num_constants) = Tree::from_gates(gates);
@@ -505,7 +515,6 @@ impl<F: Extendable<D>, const D: usize> CircuitBuilder<F, D> {
         );
         let prefixed_gates = PrefixedGate::from_tree(gate_tree);
 
-        let degree_bits = log2_strict(degree);
         let subgroup = F::two_adic_subgroup(degree_bits);
 
         let constant_vecs = self.constant_polys(&prefixed_gates, num_constants);

--- a/src/fri/prover.rs
+++ b/src/fri/prover.rs
@@ -95,6 +95,7 @@ fn fri_committed_trees<F: Field + Extendable<D>, const D: usize>(
         values = coeffs.clone().coset_fft(shift.into())
     }
 
+    coeffs.trim();
     challenger.observe_extension_elements(&coeffs.coeffs);
     (trees, coeffs)
 }

--- a/src/fri/recursive_verifier.rs
+++ b/src/fri/recursive_verifier.rs
@@ -80,12 +80,12 @@ impl<F: Extendable<D>, const D: usize> CircuitBuilder<F, D> {
         let total_arities = config.fri_config.reduction_arity_bits.iter().sum::<usize>();
         debug_assert_eq!(
             purported_degree_log,
-            log2_strict(proof.final_poly.len()) + total_arities - config.rate_bits,
+            log2_strict(proof.final_poly.len()) + total_arities,
             "Final polynomial has wrong degree."
         );
 
         // Size of the LDE domain.
-        let n = proof.final_poly.len() << total_arities;
+        let n = proof.final_poly.len() << (total_arities + config.rate_bits);
 
         self.set_context("Recover the random betas used in the FRI reductions.");
         let betas = proof

--- a/src/fri/verifier.rs
+++ b/src/fri/verifier.rs
@@ -81,13 +81,12 @@ pub fn verify_fri_proof<F: Field + Extendable<D>, const D: usize>(
     let config = &common_data.config;
     let total_arities = config.fri_config.reduction_arity_bits.iter().sum::<usize>();
     ensure!(
-        purported_degree_log
-            == log2_strict(proof.final_poly.len()) + total_arities - config.rate_bits,
+        purported_degree_log == log2_strict(proof.final_poly.len()) + total_arities,
         "Final polynomial has wrong degree."
     );
 
     // Size of the LDE domain.
-    let n = proof.final_poly.len() << total_arities;
+    let n = proof.final_poly.len() << (total_arities + config.rate_bits);
 
     // Recover the random betas used in the FRI reductions.
     let betas = proof

--- a/src/recursive_verifier.rs
+++ b/src/recursive_verifier.rs
@@ -329,7 +329,7 @@ mod tests {
             zero_knowledge: false,
             fri_config: FriConfig {
                 proof_of_work_bits: 1,
-                reduction_arity_bits: vec![2, 2, 2, 2, 2, 2, 2],
+                reduction_arity_bits: vec![2, 2, 2, 2, 2, 2],
                 num_query_rounds: 40,
             },
         };


### PR DESCRIPTION
As mentioned in #91, the final polynomial's coefficients in FRI consists of only `2^-rate_bits` non-zero elements. This PR trims this polynomial to keep only the non-zero element. This is more space-efficient, and also more circuit efficient as the coefficients are fed to Fiat-Shamir.  

I also added a small check in `CircuitBuilder::build` to ensure the total FRI arity is less than the size of the circuit. Otherwise the polynomials are reduced too much.