### PR TITLE
Add a context for each gate evaluation

### DIFF
--- a/src/vanishing_poly.rs
+++ b/src/vanishing_poly.rs
@@ -236,10 +236,13 @@ pub fn evaluate_gate_constraints_recursively<F: Extendable<D>, const D: usize>(
 ) -> Vec<ExtensionTarget<D>> {
     let mut constraints = vec![builder.zero_extension(); num_gate_constraints];
     for gate in gates {
-        let gate_constraints = gate
-            .gate
-            .0
-            .eval_filtered_recursively(builder, vars, &gate.prefix);
+        let gate_constraints = context!(
+            builder,
+            &format!("evaluate {} constraints", gate.gate.0.id()),
+            gate.gate
+                .0
+                .eval_filtered_recursively(builder, vars, &gate.prefix)
+        );
         for (i, c) in gate_constraints.into_iter().enumerate() {
             constraints[i] = builder.add_extension(constraints[i], c);
         }


### PR DESCRIPTION
To give logs like

    [2021-07-20T15:29:29Z DEBUG plonky2::context_tree] | 2373 gates to evaluate the vanishing polynomial at our challenge point, zeta.
    [2021-07-20T15:29:29Z DEBUG plonky2::context_tree] | | 1284 gates to evaluate gate constraints
    [2021-07-20T15:29:29Z DEBUG plonky2::context_tree] | | | 79 gates to evaluate ArithmeticExtensionGate constraints
    [2021-07-20T15:29:29Z DEBUG plonky2::context_tree] | | | 1073 gates to evaluate <R=101> GMiMCGate {...} constraints
    [2021-07-20T15:29:29Z DEBUG plonky2::context_tree] | | | 4 gates to evaluate NoopGate constraints
    [2021-07-20T15:29:29Z DEBUG plonky2::context_tree] | | | 4 gates to evaluate ConstantGate constraints