### PR TITLE
No Copy on ReducingFactor

### DIFF
--- a/src/util/scaling.rs
+++ b/src/util/scaling.rs
@@ -16,7 +16,7 @@ use crate::polynomial::polynomial::PolynomialCoeffs;
 /// This struct abstract away these operations by implementing Horner's method and keeping track
 /// of the number of multiplications by `a` to compute the scaling factor.
 /// See https://github.com/mir-protocol/plonky2/pull/69 for more details and discussions.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Clone)]
 pub struct ReducingFactor<F: Field> {
     base: F,
     count: u64,
@@ -79,7 +79,7 @@ impl<F: Field> ReducingFactor<F> {
     }
 }
 
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Clone)]
 pub struct ReducingFactorTarget<const D: usize> {
     base: ExtensionTarget<D>,
     count: u64,


### PR DESCRIPTION
It feels a little dangerous; would be easy to "fork" one accidentally. We already clone explicitly, this just enforces that in the future.