### PR TITLE
FRI tweaks

### DIFF
--- a/src/gadgets/arithmetic.rs
+++ b/src/gadgets/arithmetic.rs
@@ -153,6 +153,15 @@ impl<F: Extendable<D>, const D: usize> CircuitBuilder<F, D> {
         product
     }
 
+    /// Exponentiate `base` to the power of `2^power_log`.
+    // TODO: Test
+    pub fn exp_power_of_2(&mut self, mut base: Target, power_log: usize) -> Target {
+        for _ in 0..power_log {
+            base = self.square(base);
+        }
+        base
+    }
+
     // TODO: Optimize this, maybe with a new gate.
     // TODO: Test
     /// Exponentiate `base` to the power of `exponent`, where `exponent < 2^num_bits`.

--- a/src/gadgets/arithmetic_extension.rs
+++ b/src/gadgets/arithmetic_extension.rs
@@ -292,7 +292,7 @@ impl<F: Extendable<D>, const D: usize> CircuitBuilder<F, D> {
 
     /// Exponentiate `base` to the power of `2^power_log`.
     // TODO: Test
-    pub fn exp_power_of_2(
+    pub fn exp_power_of_2_extension(
         &mut self,
         mut base: ExtensionTarget<D>,
         power_log: usize,

--- a/src/recursive_verifier.rs
+++ b/src/recursive_verifier.rs
@@ -59,7 +59,7 @@ impl<F: Extendable<D>, const D: usize> CircuitBuilder<F, D> {
         let s_sigmas = &proof.openings.plonk_sigmas;
         let partial_products = &proof.openings.partial_products;
 
-        let zeta_pow_deg = self.exp_power_of_2(zeta, inner_common_data.degree_bits);
+        let zeta_pow_deg = self.exp_power_of_2_extension(zeta, inner_common_data.degree_bits);
         let vanishing_polys_zeta = context!(
             self,
             "evaluate the vanishing polynomial at our challenge point, zeta.",


### PR DESCRIPTION
- Call `exp_power_of_2` instead of manual squaring
- Replace `evaluations[i]` with `evals`