### PR TITLE
Avoid rotating in `compute_evaluation`

### DIFF
--- a/src/fri/recursive_verifier.rs
+++ b/src/fri/recursive_verifier.rs
@@ -40,14 +40,14 @@ impl<F: Extendable<D>, const D: usize> CircuitBuilder<F, D> {
         // TODO: Once the exponentiation gate lands, we won't need the bits and will be able to compute
         // `g^(arity-rev_old_x_index)` directly.
         let start = self.exp_from_complement_bits(gt, &old_x_index_bits);
-        let start = self.mul_many(&[start, gt, x]);
+        let coset_start = self.mul_many(&[start, gt, x]);
 
         // The answer is gotten by interpolating {(x*g^i, P(x*g^i))} and evaluating at beta.
         let points = g
             .powers()
             .map(|y| {
                 let yt = self.constant(y);
-                self.mul(start, yt)
+                self.mul(coset_start, yt)
             })
             .zip(evals)
             .collect::<Vec<_>>();

--- a/src/fri/verifier.rs
+++ b/src/fri/verifier.rs
@@ -31,12 +31,12 @@ fn compute_evaluation<F: Field + Extendable<D>, const D: usize>(
     let mut evals = last_evals.to_vec();
     reverse_index_bits_in_place(&mut evals);
     let rev_old_x_index = reverse_bits(old_x_index, arity_bits);
-    let start = x * g.exp((arity - rev_old_x_index) as u64);
+    let coset_start = x * g.exp((arity - rev_old_x_index) as u64);
     // The answer is gotten by interpolating {(x*g^i, P(x*g^i))} and evaluating at beta.
     let points = g
         .powers()
         .zip(evals)
-        .map(|(y, e)| ((start * y).into(), e))
+        .map(|(y, e)| ((coset_start * y).into(), e))
         .collect::<Vec<_>>();
     let barycentric_weights = barycentric_weights(&points);
     interpolate(&points, beta, &barycentric_weights)

--- a/src/gadgets/arithmetic.rs
+++ b/src/gadgets/arithmetic.rs
@@ -174,6 +174,7 @@ impl<F: Extendable<D>, const D: usize> CircuitBuilder<F, D> {
         let mut product = self.one();
 
         for &bit in exponent_bits {
+            // TODO: Add base field select.
             let current_ext = self.convert_to_ext(current);
             let multiplicand = self.select(bit, current_ext, one_ext);
             product = self.mul(product, multiplicand.0[0]);
@@ -193,6 +194,7 @@ impl<F: Extendable<D>, const D: usize> CircuitBuilder<F, D> {
 
         for &bit in exponent_bits {
             let current_ext = self.convert_to_ext(current);
+            // TODO: Add base field select.
             let multiplicand = self.select(bit, one_ext, current_ext);
             product = self.mul(product, multiplicand.0[0]);
             current = self.mul(current, current);


### PR DESCRIPTION
The current version uses a rotation gadget in `compute_evaluation` to reorder the interpolation points. This PR implements a simpler solution based on finding the right exponent to start the interpolation points.
It brings the gate count of `compute_evaluation` from 23 down to 13. This will decrease further once we have an exponentiation gate.