### PR TITLE
Manually implement `eval_unfiltered_base` for all gates

### DIFF
--- a/src/gates/base_sum.rs
+++ b/src/gates/base_sum.rs
@@ -8,7 +8,7 @@ use crate::gates::gate::{Gate, GateRef};
 use crate::generator::{GeneratedValues, SimpleGenerator, WitnessGenerator};
 use crate::plonk_common::{reduce_with_powers, reduce_with_powers_recursive};
 use crate::target::Target;
-use crate::vars::{EvaluationTargets, EvaluationVars};
+use crate::vars::{EvaluationTargets, EvaluationVars, EvaluationVarsBase};
 use crate::witness::PartialWitness;
 
 /// A gate which can decompose a number into base B little-endian limbs,
@@ -53,6 +53,20 @@ impl<F: Extendable<D>, const D: usize, const B: usize> Gate<F, D> for BaseSumGat
                     .map(|i| limb - F::Extension::from_canonical_usize(i))
                     .product(),
             );
+        }
+        constraints
+    }
+
+    fn eval_unfiltered_base(&self, vars: EvaluationVarsBase<F>) -> Vec<F> {
+        let sum = vars.local_wires[Self::WIRE_SUM];
+        let reversed_sum = vars.local_wires[Self::WIRE_REVERSED_SUM];
+        let mut limbs = vars.local_wires[self.limbs()].to_vec();
+        let computed_sum = reduce_with_powers(&limbs, F::from_canonical_usize(B));
+        limbs.reverse();
+        let computed_reversed_sum = reduce_with_powers(&limbs, F::from_canonical_usize(B));
+        let mut constraints = vec![computed_sum - sum, computed_reversed_sum - reversed_sum];
+        for limb in limbs {
+            constraints.push((0..B).map(|i| limb - F::from_canonical_usize(i)).product());
         }
         constraints
     }

--- a/src/gates/constant.rs
+++ b/src/gates/constant.rs
@@ -5,7 +5,7 @@ use crate::field::field::Field;
 use crate::gates::gate::{Gate, GateRef};
 use crate::generator::{GeneratedValues, SimpleGenerator, WitnessGenerator};
 use crate::target::Target;
-use crate::vars::{EvaluationTargets, EvaluationVars};
+use crate::vars::{EvaluationTargets, EvaluationVars, EvaluationVarsBase};
 use crate::wire::Wire;
 use crate::witness::PartialWitness;
 
@@ -28,6 +28,12 @@ impl<F: Extendable<D>, const D: usize> Gate<F, D> for ConstantGate {
     }
 
     fn eval_unfiltered(&self, vars: EvaluationVars<F, D>) -> Vec<F::Extension> {
+        let input = vars.local_constants[Self::CONST_INPUT];
+        let output = vars.local_wires[Self::WIRE_OUTPUT];
+        vec![output - input]
+    }
+
+    fn eval_unfiltered_base(&self, vars: EvaluationVarsBase<F>) -> Vec<F> {
         let input = vars.local_constants[Self::CONST_INPUT];
         let output = vars.local_wires[Self::WIRE_OUTPUT];
         vec![output - input]

--- a/src/gates/insertion.rs
+++ b/src/gates/insertion.rs
@@ -9,7 +9,7 @@ use crate::field::field::Field;
 use crate::gates::gate::{Gate, GateRef};
 use crate::generator::{GeneratedValues, SimpleGenerator, WitnessGenerator};
 use crate::target::Target;
-use crate::vars::{EvaluationTargets, EvaluationVars};
+use crate::vars::{EvaluationTargets, EvaluationVars, EvaluationVarsBase};
 use crate::wire::Wire;
 use crate::witness::PartialWitness;
 
@@ -105,6 +105,44 @@ impl<F: Extendable<D>, const D: usize> Gate<F, D> for InsertionGate<F, D> {
             already_inserted += insert_here;
             if r < self.vec_size {
                 new_item += list_items[r] * (F::Extension::ONE - already_inserted).into();
+            }
+
+            // Output constraint.
+            constraints.extend((new_item - output_list_items[r]).to_basefield_array());
+        }
+
+        constraints
+    }
+
+    fn eval_unfiltered_base(&self, vars: EvaluationVarsBase<F>) -> Vec<F> {
+        let insertion_index = vars.local_wires[self.wires_insertion_index()];
+        let list_items = (0..self.vec_size)
+            .map(|i| vars.get_local_ext(self.wires_original_list_item(i)))
+            .collect::<Vec<_>>();
+        let output_list_items = (0..=self.vec_size)
+            .map(|i| vars.get_local_ext(self.wires_output_list_item(i)))
+            .collect::<Vec<_>>();
+        let element_to_insert = vars.get_local_ext(self.wires_element_to_insert());
+
+        let mut constraints = Vec::new();
+        let mut already_inserted = F::ZERO;
+        for r in 0..=self.vec_size {
+            let cur_index = F::from_canonical_usize(r);
+            let difference = cur_index - insertion_index;
+            let equality_dummy = vars.local_wires[self.wires_equality_dummy_for_round_r(r)];
+            let insert_here = vars.local_wires[self.wires_insert_here_for_round_r(r)];
+
+            // The two equality constraints.
+            constraints.push(difference * equality_dummy - (F::ONE - insert_here));
+            constraints.push(insert_here * difference);
+
+            let mut new_item = element_to_insert * insert_here.into();
+            if r > 0 {
+                new_item += list_items[r - 1] * already_inserted.into();
+            }
+            already_inserted += insert_here;
+            if r < self.vec_size {
+                new_item += list_items[r] * (F::ONE - already_inserted).into();
             }
 
             // Output constraint.

--- a/src/gates/noop.rs
+++ b/src/gates/noop.rs
@@ -3,7 +3,7 @@ use crate::field::extension_field::target::ExtensionTarget;
 use crate::field::extension_field::Extendable;
 use crate::gates::gate::{Gate, GateRef};
 use crate::generator::WitnessGenerator;
-use crate::vars::{EvaluationTargets, EvaluationVars};
+use crate::vars::{EvaluationTargets, EvaluationVars, EvaluationVarsBase};
 
 /// A gate which does nothing.
 pub struct NoopGate;
@@ -20,6 +20,10 @@ impl<F: Extendable<D>, const D: usize> Gate<F, D> for NoopGate {
     }
 
     fn eval_unfiltered(&self, _vars: EvaluationVars<F, D>) -> Vec<F::Extension> {
+        Vec::new()
+    }
+
+    fn eval_unfiltered_base(&self, _vars: EvaluationVarsBase<F>) -> Vec<F> {
         Vec::new()
     }
 

--- a/src/gates/public_input.rs
+++ b/src/gates/public_input.rs
@@ -5,7 +5,7 @@ use crate::field::extension_field::target::ExtensionTarget;
 use crate::field::extension_field::Extendable;
 use crate::gates::gate::{Gate, GateRef};
 use crate::generator::WitnessGenerator;
-use crate::vars::{EvaluationTargets, EvaluationVars};
+use crate::vars::{EvaluationTargets, EvaluationVars, EvaluationVarsBase};
 
 /// A gate whose first four wires will be equal to a hash of public inputs.
 pub struct PublicInputGate;
@@ -29,6 +29,13 @@ impl<F: Extendable<D>, const D: usize> Gate<F, D> for PublicInputGate {
         Self::wires_public_inputs_hash()
             .zip(vars.public_inputs_hash.elements)
             .map(|(wire, hash_part)| vars.local_wires[wire] - hash_part.into())
+            .collect()
+    }
+
+    fn eval_unfiltered_base(&self, vars: EvaluationVarsBase<F>) -> Vec<F> {
+        Self::wires_public_inputs_hash()
+            .zip(vars.public_inputs_hash.elements)
+            .map(|(wire, hash_part)| vars.local_wires[wire] - hash_part)
             .collect()
     }
 

--- a/src/vars.rs
+++ b/src/vars.rs
@@ -3,7 +3,7 @@ use std::ops::Range;
 
 use crate::field::extension_field::algebra::ExtensionAlgebra;
 use crate::field::extension_field::target::{ExtensionAlgebraTarget, ExtensionTarget};
-use crate::field::extension_field::Extendable;
+use crate::field::extension_field::{Extendable, FieldExtension};
 use crate::field::field::Field;
 use crate::proof::{Hash, HashTarget};
 
@@ -37,6 +37,15 @@ impl<'a, F: Extendable<D>, const D: usize> EvaluationVars<'a, F, D> {
 }
 
 impl<'a, F: Field> EvaluationVarsBase<'a, F> {
+    pub fn get_local_ext<const D: usize>(&self, wire_range: Range<usize>) -> F::Extension
+    where
+        F: Extendable<D>,
+    {
+        debug_assert_eq!(wire_range.len(), D);
+        let arr = self.local_wires[wire_range].try_into().unwrap();
+        F::Extension::from_basefield_array(arr)
+    }
+
     pub fn remove_prefix(&mut self, prefix: &[bool]) {
         self.local_constants = &self.local_constants[prefix.len()..];
     }


### PR DESCRIPTION
Brings the time to compute the vanishing polynomial from 14s down to 4s on my machine.

Nothing fancy except copy-pasting `eval_unfiltered` and then running
- `s/get_local_ext_algebra/get_local_ext/g`
- `s/F::Extension::/F::/g`