### PR TITLE
Update division calls

### DIFF
--- a/src/gadgets/interpolation.rs
+++ b/src/gadgets/interpolation.rs
@@ -19,7 +19,7 @@ impl<F: Extendable<D>, const D: usize> CircuitBuilder<F, D> {
         let x_m_a0 = self.sub_extension(evaluation_point, interpolation_points[0].0);
         let b1_m_a1 = self.sub_extension(interpolation_points[1].1, interpolation_points[0].1);
         let b0_m_a0 = self.sub_extension(interpolation_points[1].0, interpolation_points[0].0);
-        let quotient = self.div_unsafe_extension(b1_m_a1, b0_m_a0);
+        let quotient = self.div_extension(b1_m_a1, b0_m_a0);
 
         self.mul_add_extension(x_m_a0, quotient, interpolation_points[0].1)
     }

--- a/src/plonk_common.rs
+++ b/src/plonk_common.rs
@@ -119,6 +119,10 @@ pub(crate) fn eval_l_1<F: Field>(n: usize, x: F) -> F {
     eval_zero_poly(n, x) / (F::from_canonical_usize(n) * (x - F::ONE))
 }
 
+/// Evaluates the Lagrange basis L_1(x), which has L_1(1) = 1 and vanishes at all other points in
+/// the order-`n` subgroup.
+///
+/// Assumes `x != 1`; if `x` could be 1 then this is unsound.
 pub(crate) fn eval_l_1_recursively<F: Extendable<D>, const D: usize>(
     builder: &mut CircuitBuilder<F, D>,
     n: usize,

--- a/src/vanishing_poly.rs
+++ b/src/vanishing_poly.rs
@@ -253,6 +253,9 @@ pub fn evaluate_gate_constraints_recursively<F: Extendable<D>, const D: usize>(
 /// Evaluate the vanishing polynomial at `x`. In this context, the vanishing polynomial is a random
 /// linear combination of gate constraints, plus some other terms relating to the permutation
 /// argument. All such terms should vanish on `H`.
+///
+/// Assumes `x != 1`; if `x` could be 1 then this is unsound. This is fine if `x` is a random
+/// variable drawn from a sufficiently large domain.
 pub(crate) fn eval_vanishing_poly_recursively<F: Extendable<D>, const D: usize>(
     builder: &mut CircuitBuilder<F, D>,
     common_data: &CommonCircuitData<F, D>,
@@ -314,7 +317,7 @@ pub(crate) fn eval_vanishing_poly_recursively<F: Extendable<D>, const D: usize>(
             })
             .collect::<Vec<_>>();
         let quotient_values = (0..common_data.config.num_routed_wires)
-            .map(|j| builder.div_unsafe_extension(numerator_values[j], denominator_values[j]))
+            .map(|j| builder.div_extension(numerator_values[j], denominator_values[j]))
             .collect::<Vec<_>>();
 
         // The partial products considered for this iteration of `i`.


### PR DESCRIPTION
We have two division methods: one "unsafe" one, which permits 0/0 = anything, and one "safe" one, for which 0/0 results in an unsatisfiable instance. The latter is slightly more expensive.

I switched a few calls over to safe division, where unsafe division didn't seem sound (or at least it wasn't obvious). For calls where unsafe division did seem sound, I added comments explaining why.

Closes #97.