### PR TITLE
Use batch inversion to compute the quoients for Z

### DIFF
--- a/src/plonk/vanishing_poly.rs
+++ b/src/plonk/vanishing_poly.rs
@@ -148,8 +148,9 @@ pub(crate) fn eval_vanishing_poly_base<F: Extendable<D>, const D: usize>(
                 wire_value + betas[i] * s_sigma + gammas[i]
             })
             .collect::<Vec<_>>();
+        let denominator_inverses = F::batch_multiplicative_inverse(&denominator_values);
         let quotient_values = (0..common_data.config.num_routed_wires)
-            .map(|j| numerator_values[j] / denominator_values[j])
+            .map(|j| numerator_values[j] * denominator_inverses[j])
             .collect::<Vec<_>>();
 
         // The partial products considered for this iteration of `i`.


### PR DESCRIPTION
Shaves about a second off the recursive proof time! Down to 2.45s on my laptop.