### PR TITLE
Special cases for extension field arithmetic

### DIFF
--- a/src/field/extension_field/target.rs
+++ b/src/field/extension_field/target.rs
@@ -8,7 +8,7 @@ use crate::iop::target::Target;
 use crate::plonk::circuit_builder::CircuitBuilder;
 
 /// `Target`s representing an element of an extension field.
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
 pub struct ExtensionTarget<const D: usize>(pub [Target; D]);
 
 impl<const D: usize> ExtensionTarget<D> {


### PR DESCRIPTION
We previously checked for special cases, like arithmetic on constant Targets, in `arithmetic`. We can handle those cases without actually adding an `ArithmeticGate`.

Now that `arithmetic` just calls `arithmetic_extension`, it makes more sense to check for special cases in the latter method, so it applies to both base and extension field arithmetic.

Reduces gate count from 16149 to 15689.