### PR TITLE
Small fix in arithmetic_extension_special_cases

### DIFF
--- a/src/gadgets/arithmetic_extension.rs
+++ b/src/gadgets/arithmetic_extension.rs
@@ -143,7 +143,7 @@ impl<F: Extendable<D>, const D: usize> CircuitBuilder<F, D> {
                 }
             }
             if let Some(x) = mul_1_const {
-                if (x * const_1.into()).is_one() {
+                if (x * const_0.into()).is_one() {
                     return Some(multiplicand_0);
                 }
             }


### PR DESCRIPTION
This is detecting the case where we multiply something by 1 and add 0.  In that case we can just return the thing being multiplied by 1. We were using the wrong constant when checking if the constant times one multiplicand equals 1.

Reduces the cost of `compute_evaluation` from 8 to 6 gates.