### PR TITLE
Test `eval_unfiltered_*` functions

### DIFF
--- a/src/gates/arithmetic.rs
+++ b/src/gates/arithmetic.rs
@@ -250,12 +250,18 @@ impl<F: Extendable<D>, const D: usize> SimpleGenerator<F> for ArithmeticExtensio
 
 #[cfg(test)]
 mod tests {
+    use anyhow::Result;
+
     use crate::field::crandall_field::CrandallField;
     use crate::gates::arithmetic::ArithmeticExtensionGate;
-    use crate::gates::gate_testing::test_low_degree;
+    use crate::gates::gate_testing::{test_eval_fns, test_low_degree};
 
     #[test]
     fn low_degree() {
         test_low_degree::<CrandallField, _, 4>(ArithmeticExtensionGate)
+    }
+    #[test]
+    fn eval_fns() -> Result<()> {
+        test_eval_fns::<CrandallField, _, 4>(ArithmeticExtensionGate)
     }
 }

--- a/src/gates/base_sum.rs
+++ b/src/gates/base_sum.rs
@@ -184,12 +184,19 @@ impl<F: Field, const B: usize> SimpleGenerator<F> for BaseSplitGenerator<B> {
 
 #[cfg(test)]
 mod tests {
+    use anyhow::Result;
+
     use crate::field::crandall_field::CrandallField;
     use crate::gates::base_sum::BaseSumGate;
-    use crate::gates::gate_testing::test_low_degree;
+    use crate::gates::gate_testing::{test_eval_fns, test_low_degree};
 
     #[test]
     fn low_degree() {
         test_low_degree::<CrandallField, _, 4>(BaseSumGate::<6>::new(11))
+    }
+
+    #[test]
+    fn eval_fns() -> Result<()> {
+        test_eval_fns::<CrandallField, _, 4>(BaseSumGate::<6>::new(11))
     }
 }

--- a/src/gates/constant.rs
+++ b/src/gates/constant.rs
@@ -96,12 +96,19 @@ impl<F: Field> SimpleGenerator<F> for ConstantGenerator<F> {
 
 #[cfg(test)]
 mod tests {
+    use anyhow::Result;
+
     use crate::field::crandall_field::CrandallField;
     use crate::gates::constant::ConstantGate;
-    use crate::gates::gate_testing::test_low_degree;
+    use crate::gates::gate_testing::{test_eval_fns, test_low_degree};
 
     #[test]
     fn low_degree() {
         test_low_degree::<CrandallField, _, 4>(ConstantGate)
+    }
+
+    #[test]
+    fn eval_fns() -> Result<()> {
+        test_eval_fns::<CrandallField, _, 4>(ConstantGate)
     }
 }

--- a/src/gates/exponentiation.rs
+++ b/src/gates/exponentiation.rs
@@ -261,6 +261,7 @@ impl<F: Extendable<D>, const D: usize> SimpleGenerator<F> for ExponentiationGene
 mod tests {
     use std::marker::PhantomData;
 
+    use anyhow::Result;
     use rand::Rng;
 
     use crate::field::crandall_field::CrandallField;
@@ -268,7 +269,7 @@ mod tests {
     use crate::field::field_types::Field;
     use crate::gates::exponentiation::ExponentiationGate;
     use crate::gates::gate::Gate;
-    use crate::gates::gate_testing::test_low_degree;
+    use crate::gates::gate_testing::{test_eval_fns, test_low_degree};
     use crate::hash::hash_types::HashOut;
     use crate::plonk::circuit_data::CircuitConfig;
     use crate::plonk::vars::EvaluationVars;
@@ -300,6 +301,11 @@ mod tests {
         };
 
         test_low_degree::<CrandallField, _, 4>(ExponentiationGate::new(config));
+    }
+
+    #[test]
+    fn eval_fns() -> Result<()> {
+        test_eval_fns::<CrandallField, _, 4>(ExponentiationGate::new(CircuitConfig::large_config()))
     }
 
     #[test]

--- a/src/gates/gate_testing.rs
+++ b/src/gates/gate_testing.rs
@@ -1,8 +1,14 @@
-use crate::field::extension_field::Extendable;
+use anyhow::{ensure, Result};
+
+use crate::field::extension_field::{Extendable, FieldExtension};
 use crate::field::field_types::Field;
 use crate::gates::gate::Gate;
-use crate::hash::hash_types::HashOut;
-use crate::plonk::vars::EvaluationVars;
+use crate::hash::hash_types::{HashOut, HashOutTarget};
+use crate::iop::witness::PartialWitness;
+use crate::plonk::circuit_builder::CircuitBuilder;
+use crate::plonk::circuit_data::CircuitConfig;
+use crate::plonk::vars::{EvaluationTargets, EvaluationVars, EvaluationVarsBase};
+use crate::plonk::verifier::verify;
 use crate::polynomial::polynomial::{PolynomialCoeffs, PolynomialValues};
 use crate::util::{log2_ceil, transpose};
 
@@ -74,4 +80,78 @@ fn random_low_degree_values<F: Field>(rate_bits: usize) -> Vec<F> {
         .lde(rate_bits)
         .fft()
         .values
+}
+
+pub(crate) fn test_eval_fns<F: Extendable<D>, G: Gate<F, D>, const D: usize>(
+    gate: G,
+) -> Result<()> {
+    // Test that `eval_unfiltered` and `eval_unfiltered_base` are coherent.
+    let wires_base = F::rand_vec(gate.num_wires());
+    let constants_base = F::rand_vec(gate.num_constants());
+    let wires = wires_base
+        .iter()
+        .map(|&x| F::Extension::from_basefield(x))
+        .collect::<Vec<_>>();
+    let constants = constants_base
+        .iter()
+        .map(|&x| F::Extension::from_basefield(x))
+        .collect::<Vec<_>>();
+    let public_inputs_hash = HashOut::rand();
+
+    let vars_base = EvaluationVarsBase {
+        local_constants: &constants_base,
+        local_wires: &wires_base,
+        public_inputs_hash: &public_inputs_hash,
+    };
+    let vars = EvaluationVars {
+        local_constants: &constants,
+        local_wires: &wires,
+        public_inputs_hash: &public_inputs_hash,
+    };
+
+    let evals_base = gate.eval_unfiltered_base(vars_base);
+    let evals = gate.eval_unfiltered(vars);
+    ensure!(
+        evals
+            == evals_base
+                .into_iter()
+                .map(F::Extension::from_basefield)
+                .collect::<Vec<_>>()
+    );
+
+    // Test that `eval_unfiltered` and `eval_unfiltered_recursively` are coherent.
+    let wires = F::Extension::rand_vec(gate.num_wires());
+    let constants = F::Extension::rand_vec(gate.num_constants());
+
+    let config = CircuitConfig::large_config();
+    let mut builder = CircuitBuilder::<F, D>::new(config);
+    let mut pw = PartialWitness::new();
+
+    let wires_t = builder.add_virtual_extension_targets(wires.len());
+    let constants_t = builder.add_virtual_extension_targets(constants.len());
+    pw.set_extension_targets(&wires_t, &wires);
+    pw.set_extension_targets(&constants_t, &constants);
+    let public_inputs_hash_t = builder.add_virtual_hash();
+    pw.set_hash_target(public_inputs_hash_t, public_inputs_hash);
+
+    let vars = EvaluationVars {
+        local_constants: &constants,
+        local_wires: &wires,
+        public_inputs_hash: &HashOut {
+            elements: [F::ZERO; 4],
+        },
+    };
+    let evals = gate.eval_unfiltered(vars);
+
+    let vars_t = EvaluationTargets {
+        local_constants: &constants_t,
+        local_wires: &wires_t,
+        public_inputs_hash: &public_inputs_hash_t,
+    };
+    let evals_t = gate.eval_unfiltered_recursively(&mut builder, vars_t);
+    pw.set_extension_targets(&evals_t, &evals);
+
+    let data = builder.build();
+    let proof = data.prove(pw)?;
+    verify(proof, &data.verifier_only, &data.common)
 }

--- a/src/gates/insertion.rs
+++ b/src/gates/insertion.rs
@@ -319,11 +319,13 @@ impl<F: Extendable<D>, const D: usize> SimpleGenerator<F> for InsertionGenerator
 mod tests {
     use std::marker::PhantomData;
 
+    use anyhow::Result;
+
     use crate::field::crandall_field::CrandallField;
     use crate::field::extension_field::quartic::QuarticCrandallField;
     use crate::field::field_types::Field;
     use crate::gates::gate::Gate;
-    use crate::gates::gate_testing::test_low_degree;
+    use crate::gates::gate_testing::{test_eval_fns, test_low_degree};
     use crate::gates::insertion::InsertionGate;
     use crate::hash::hash_types::HashOut;
     use crate::plonk::vars::EvaluationVars;
@@ -350,6 +352,11 @@ mod tests {
     #[test]
     fn low_degree() {
         test_low_degree::<CrandallField, _, 4>(InsertionGate::new(4));
+    }
+
+    #[test]
+    fn eval_fns() -> Result<()> {
+        test_eval_fns::<CrandallField, _, 4>(InsertionGate::new(4))
     }
 
     #[test]

--- a/src/gates/interpolation.rs
+++ b/src/gates/interpolation.rs
@@ -286,11 +286,13 @@ impl<F: Extendable<D>, const D: usize> SimpleGenerator<F> for InterpolationGener
 mod tests {
     use std::marker::PhantomData;
 
+    use anyhow::Result;
+
     use crate::field::crandall_field::CrandallField;
     use crate::field::extension_field::quartic::QuarticCrandallField;
     use crate::field::field_types::Field;
     use crate::gates::gate::Gate;
-    use crate::gates::gate_testing::test_low_degree;
+    use crate::gates::gate_testing::{test_eval_fns, test_low_degree};
     use crate::gates::interpolation::InterpolationGate;
     use crate::hash::hash_types::HashOut;
     use crate::plonk::vars::EvaluationVars;
@@ -319,6 +321,11 @@ mod tests {
     #[test]
     fn low_degree() {
         test_low_degree::<CrandallField, _, 4>(InterpolationGate::new(4));
+    }
+
+    #[test]
+    fn eval_fns() -> Result<()> {
+        test_eval_fns::<CrandallField, _, 4>(InterpolationGate::new(4))
     }
 
     #[test]

--- a/src/gates/noop.rs
+++ b/src/gates/noop.rs
@@ -56,12 +56,19 @@ impl<F: Extendable<D>, const D: usize> Gate<F, D> for NoopGate {
 
 #[cfg(test)]
 mod tests {
+    use anyhow::Result;
+
     use crate::field::crandall_field::CrandallField;
-    use crate::gates::gate_testing::test_low_degree;
+    use crate::gates::gate_testing::{test_eval_fns, test_low_degree};
     use crate::gates::noop::NoopGate;
 
     #[test]
     fn low_degree() {
         test_low_degree::<CrandallField, _, 4>(NoopGate)
+    }
+
+    #[test]
+    fn eval_fns() -> anyhow::Result<()> {
+        test_eval_fns::<CrandallField, _, 4>(NoopGate)
     }
 }

--- a/src/gates/reducing.rs
+++ b/src/gates/reducing.rs
@@ -213,12 +213,19 @@ impl<F: Extendable<D>, const D: usize> SimpleGenerator<F> for ReducingGenerator<
 
 #[cfg(test)]
 mod tests {
+    use anyhow::Result;
+
     use crate::field::crandall_field::CrandallField;
-    use crate::gates::gate_testing::test_low_degree;
+    use crate::gates::gate_testing::{test_eval_fns, test_low_degree};
     use crate::gates::reducing::ReducingGate;
 
     #[test]
     fn low_degree() {
         test_low_degree::<CrandallField, _, 4>(ReducingGate::new(22));
+    }
+
+    #[test]
+    fn eval_fns() -> Result<()> {
+        test_eval_fns::<CrandallField, _, 4>(ReducingGate::new(22))
     }
 }

--- a/src/iop/witness.rs
+++ b/src/iop/witness.rs
@@ -115,6 +115,19 @@ impl<F: Field> PartialWitness<F> {
         });
     }
 
+    pub fn set_extension_targets<const D: usize>(
+        &mut self,
+        ets: &[ExtensionTarget<D>],
+        values: &[F::Extension],
+    ) where
+        F: Extendable<D>,
+    {
+        debug_assert_eq!(ets.len(), values.len());
+        ets.iter()
+            .zip(values)
+            .for_each(|(&et, &v)| self.set_extension_target(et, v));
+    }
+
     pub fn set_wire(&mut self, wire: Wire, value: F) {
         self.set_target(Target::Wire(wire), value)
     }


### PR DESCRIPTION
Every gate now has manual implementations of three methods to evaluate constraints: `eval_unfiltered{,_base,_recursively}`.
This PR adds tests to ensure that these methods are coherent with one another.