### PR TITLE
Optimize witness generation a bit

### DIFF
--- a/src/gates/gmimc.rs
+++ b/src/gates/gmimc.rs
@@ -334,6 +334,7 @@ mod tests {
     use crate::iop::generator::generate_partial_witness;
     use crate::iop::wire::Wire;
     use crate::iop::witness::PartialWitness;
+    use crate::util::timing::TimingTree;
 
     #[test]
     fn generated_output() {
@@ -364,7 +365,7 @@ mod tests {
         }
 
         let generators = gate.generators(0, &[]);
-        generate_partial_witness(&mut witness, &generators);
+        generate_partial_witness(&mut witness, &generators, &mut TimingTree::default());
 
         let expected_outputs: [F; W] =
             gmimc_permute_naive(permutation_inputs.try_into().unwrap(), constants);

--- a/src/iop/challenger.rs
+++ b/src/iop/challenger.rs
@@ -350,6 +350,7 @@ mod tests {
     use crate::iop::witness::PartialWitness;
     use crate::plonk::circuit_builder::CircuitBuilder;
     use crate::plonk::circuit_data::CircuitConfig;
+    use crate::util::timing::TimingTree;
 
     #[test]
     fn no_duplicate_challenges() {
@@ -409,7 +410,11 @@ mod tests {
         }
         let circuit = builder.build();
         let mut witness = PartialWitness::new();
-        generate_partial_witness(&mut witness, &circuit.prover_only.generators);
+        generate_partial_witness(
+            &mut witness,
+            &circuit.prover_only.generators,
+            &mut TimingTree::default(),
+        );
         let recursive_output_values_per_round: Vec<Vec<F>> = recursive_outputs_per_round
             .iter()
             .map(|outputs| witness.get_targets(outputs))

--- a/src/iop/witness.rs
+++ b/src/iop/witness.rs
@@ -150,9 +150,7 @@ impl<F: Field> PartialWitness<F> {
     }
 
     pub fn extend<I: Iterator<Item = (Target, F)>>(&mut self, pairs: I) {
-        for (target, value) in pairs {
-            self.set_target(target, value);
-        }
+        self.target_values.extend(pairs);
     }
 
     pub fn full_witness(self, degree: usize, num_wires: usize) -> Witness<F> {

--- a/src/plonk/prover.rs
+++ b/src/plonk/prover.rs
@@ -37,7 +37,7 @@ pub(crate) fn prove<F: Extendable<D>, const D: usize>(
     timed!(
         timing,
         &format!("run {} generators", prover_data.generators.len()),
-        generate_partial_witness(&mut partial_witness, &prover_data.generators)
+        generate_partial_witness(&mut partial_witness, &prover_data.generators, &mut timing)
     );
 
     let public_inputs = partial_witness.get_targets(&prover_data.public_inputs);


### PR DESCRIPTION
Mainly storing pending generators in a Vec rather than a HashMap.  Requires an extra check to make sure we don't run one twice after adding it to the Vec twice.