### PR TITLE
Faster transpose method

### DIFF
--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,5 +1,3 @@
-use rayon::prelude::*;
-
 use crate::field::field_types::Field;
 use crate::polynomial::polynomial::PolynomialValues;
 


### PR DESCRIPTION
Saves around 0.13s in the `transpose` calls on my machine. 
See #109 for smarter ideas.