### PR TITLE
FRI refactor

### DIFF
--- a/src/fri/prover.rs
+++ b/src/fri/prover.rs
@@ -74,15 +74,12 @@ fn fri_committed_trees<F: Field + Extendable<D>, const D: usize>(
         let arity = 1 << config.reduction_arity_bits[i];
 
         reverse_index_bits_in_place(&mut values.values);
-        let tree = MerkleTree::new(
-            values
-                .values
-                .par_chunks(arity)
-                .map(|chunk: &[F::Extension]| flatten(chunk))
-                .collect(),
-            config.cap_height,
-            false,
-        );
+        let chunked_values = values
+            .values
+            .par_chunks(arity)
+            .map(|chunk: &[F::Extension]| flatten(chunk))
+            .collect();
+        let tree = MerkleTree::new(chunked_values, config.cap_height, false);
 
         challenger.observe_cap(&tree.cap);
         trees.push(tree);


### PR DESCRIPTION
I sort of "shifted" the loop in `fri_verifier_query_round` so that `fri_combine_initial` is called before the loop, and all `compute_evaluation` calls are in the loop (rather than the final one being outside). This lines up with my mental model of FRI, and I think it's more natural as it results in a loop with no branches, no `i - 1`s, and less state stored between iterations. Also added some comments etc.

Should be functionally equivalent to the old version.