### PR TITLE
Put back generator check

### DIFF
--- a/src/iop/generator.rs
+++ b/src/iop/generator.rs
@@ -1,3 +1,4 @@
+use std::convert::identity;
 use std::fmt::Debug;
 
 use crate::field::extension_field::target::ExtensionTarget;
@@ -74,6 +75,11 @@ pub(crate) fn generate_partial_witness<F: Field>(
 
         pending_generator_indices = next_pending_generator_indices;
     }
+
+    assert!(
+        generator_is_expired.into_iter().all(identity),
+        "Some generators weren't run."
+    );
 }
 
 /// A generator participates in the generation of the witness.


### PR DESCRIPTION
Put the back the check that all generators are run. Since a circuit usually doesn't use all arithmetic operations available, we first need to fill those with `0*0+0=0`. This is done in a new `CircuitBuilder::fill_arithmetic_gates` function.  