### PR TITLE
Optimized transpose

### DIFF
--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -38,11 +38,6 @@ pub(crate) fn transpose_poly_values<F: Field>(polys: Vec<PolynomialValues<F>>) -
 pub fn transpose<F: Field>(matrix: &[Vec<F>]) -> Vec<Vec<F>> {
     let l = matrix.len();
     let w = matrix[0].len();
-    for j in 0..l {
-        if matrix[j].len() != w {
-            panic!("non-equal row lengths");
-        }
-    }
 
     let mut transposed = vec![vec![]; w];
     for i in 0..w {
@@ -58,20 +53,13 @@ pub fn transpose<F: Field>(matrix: &[Vec<F>]) -> Vec<Vec<F>> {
     if w >= l {
         for i in 0..w {
             for j in 0..l {
-                unsafe {
-                    // Avoid bounds checks.
-                    *transposed.get_unchecked_mut(i).get_unchecked_mut(j)
-                        = *matrix.get_unchecked(j).get_unchecked(i);
-                }
+                transposed[i][j] = matrix[j][i];
             }
         }
     } else {
         for j in 0..l {
             for i in 0..w {
-                unsafe {
-                    *transposed.get_unchecked_mut(i).get_unchecked_mut(j)
-                        = *matrix.get_unchecked(j).get_unchecked(i);
-                }
+                transposed[i][j] = matrix[j][i];
             }
         }
     }


### PR DESCRIPTION
I basically did all I could without changing the data structure. The main bottleneck is having a vector of vectors. The secondary bottleneck is the operation not being in-place. I did a bit of work on the transposition itself, but that’s only like a fraction of the computational expense.

The two changes are:
1. Do not initialize the vectors to 0.
2. Exchange the loop order based on data dimensions.

NB: this transposition could be done in a more cache-friendly way but it’s not worth it for matrices our size.