### PR TITLE
Remove remaining `reverse_bits`

### DIFF
--- a/src/fri/verifier.rs
+++ b/src/fri/verifier.rs
@@ -142,7 +142,7 @@ fn fri_verify_initial_proof<F: Field>(
     initial_merkle_caps: &[MerkleCap<F>],
 ) -> Result<()> {
     for ((evals, merkle_proof), cap) in proof.evals_proofs.iter().zip(initial_merkle_caps) {
-        verify_merkle_proof(evals.clone(), x_index, cap, merkle_proof, false)?;
+        verify_merkle_proof(evals.clone(), x_index, cap, merkle_proof)?;
     }
 
     Ok(())
@@ -305,7 +305,6 @@ fn fri_verifier_query_round<F: Field + Extendable<D>, const D: usize>(
             coset_index,
             &proof.commit_phase_merkle_caps[i],
             &round_proof.steps[i].merkle_proof,
-            false,
         )?;
 
         // Update the point x to x^arity.

--- a/src/hash/merkle_proofs.rs
+++ b/src/hash/merkle_proofs.rs
@@ -34,13 +34,8 @@ pub(crate) fn verify_merkle_proof<F: Field>(
     leaf_index: usize,
     merkle_cap: &MerkleCap<F>,
     proof: &MerkleProof<F>,
-    reverse_bits: bool,
 ) -> Result<()> {
-    let mut index = if reverse_bits {
-        crate::util::reverse_bits(leaf_index, proof.siblings.len())
-    } else {
-        leaf_index
-    };
+    let mut index = leaf_index;
     let mut current_digest = hash_or_noop(leaf_data);
     for &sibling_digest in proof.siblings.iter() {
         let bit = index & 1;

--- a/src/hash/merkle_tree.rs
+++ b/src/hash/merkle_tree.rs
@@ -86,15 +86,11 @@ mod tests {
         (0..n).map(|_| F::rand_vec(k)).collect()
     }
 
-    fn verify_all_leaves<F: Field>(
-        leaves: Vec<Vec<F>>,
-        n: usize,
-        reverse_bits: bool,
-    ) -> Result<()> {
+    fn verify_all_leaves<F: Field>(leaves: Vec<Vec<F>>, n: usize) -> Result<()> {
         let tree = MerkleTree::new(leaves.clone(), 1);
         for i in 0..n {
             let proof = tree.prove(i);
-            verify_merkle_proof(leaves[i].clone(), i, &tree.cap, &proof, reverse_bits)?;
+            verify_merkle_proof(leaves[i].clone(), i, &tree.cap, &proof)?;
         }
         Ok(())
     }
@@ -107,7 +103,7 @@ mod tests {
         let n = 1 << log_n;
         let leaves = random_data::<F>(n, 7);
 
-        verify_all_leaves(leaves, n, false)?;
+        verify_all_leaves(leaves, n)?;
 
         Ok(())
     }


### PR DESCRIPTION
Remove `reverse_bits` flag from `verify_merkle_proof`. 