### PR TITLE
Field arithmetic benchmark improvements

### DIFF
--- a/benches/field_arithmetic.rs
+++ b/benches/field_arithmetic.rs
@@ -35,12 +35,36 @@ pub(crate) fn bench_field<F: Field>(c: &mut Criterion) {
 
     c.bench_function(&format!("add-throughput<{}>", type_name::<F>()), |b| {
         b.iter_batched(
-            || (F::rand(), F::rand(), F::rand(), F::rand()),
-            |(mut x, mut y, mut z, mut w)| {
-                for _ in 0..25 {
-                    (x, y, z, w) = (x + y, y + z, z + w, w + x);
+            || {
+                (
+                    F::rand(),
+                    F::rand(),
+                    F::rand(),
+                    F::rand(),
+                    F::rand(),
+                    F::rand(),
+                    F::rand(),
+                    F::rand(),
+                    F::rand(),
+                    F::rand(),
+                )
+            },
+            |(mut a, mut b, mut c, mut d, mut e, mut f, mut g, mut h, mut i, mut j)| {
+                for _ in 0..10 {
+                    (a, b, c, d, e, f, g, h, i, j) = (
+                        a + b,
+                        b + c,
+                        c + d,
+                        d + e,
+                        e + f,
+                        f + g,
+                        g + h,
+                        h + i,
+                        i + j,
+                        j + a,
+                    );
                 }
-                (x, y, z, w)
+                (a, b, c, d, e, f, g, h, i, j)
             },
             BatchSize::SmallInput,
         )


### PR DESCRIPTION
1. Improves `mul` benchmark. Instead of doing one multiplication per benchmark, we do 10. Importantly, we limit the number of dependencies between them to maximize instruction-level parallelism. This lets us get a more accurate picture of the throughput.
2. Adds a benchmark for `add`.