### PR TITLE
FFT optimization: special case for lg_m = 2

### DIFF
--- a/src/field/fft.rs
+++ b/src/field/fft.rs
@@ -174,7 +174,7 @@ pub(crate) fn fft_classic<F: Field>(input: &[F], r: usize, root_table: FftRootTa
 
     // First iteration of loop below. It's an easy case and it's separated out for efficiency.
     let mut i = r + 1;
-    if i == 1 {
+    if i == 1 && n > 1 {
         for k in (0..n).step_by(2) {
             let t = values[k + 1];
             let u = values[k];


### PR DESCRIPTION
The `lg_m = 2` iteration is a special, cheaper, case. This PR separates it out from the loop to avoid multiplication and the overhead of nested loops.

Makes FFT faster when r = 0. On average, we spend 10% less time on FFT, so proof times are reduced by 1%.