### PR TITLE
Make MDS layer faster in width-12 Poseidon

### DIFF
--- a/src/hash/poseidon.rs
+++ b/src/hash/poseidon.rs
@@ -119,7 +119,8 @@ const ALL_ROUND_CONSTANTS: [u64; MAX_WIDTH * N_ROUNDS]  = [
 pub trait PoseidonInterface<const WIDTH: usize>: Field
 where
     // magic to get const generic expressions to work
-    [(); WIDTH - 1]: , [(); 2 * WIDTH - 1]: ,
+    [(); WIDTH - 1]: ,
+    [(); 2 * WIDTH - 1]: ,
 {
     // Total number of round constants required: width of the input
     // times number of rounds.
@@ -680,6 +681,7 @@ mod tests {
     where
         F: PoseidonInterface<WIDTH>,
         [(); WIDTH - 1]: ,
+        [(); 2 * WIDTH - 1]: ,
     {
         for (input_, expected_output_) in test_vectors.into_iter() {
             let mut input = [F::ZERO; WIDTH];
@@ -743,6 +745,7 @@ mod tests {
     where
         F: PoseidonInterface<WIDTH>,
         [(); WIDTH - 1]: ,
+        [(); 2 * WIDTH - 1]: ,
     {
         let mut input = [F::ZERO; WIDTH];
         for i in 0..WIDTH {


### PR DESCRIPTION
The MDS loop was spending a lot of time computing `% 12` in width-12. I only realized this after staring at the disassembly for like half an hour wondering where those 12 multiplications where coming from…

This makes width-12 Poseidon 20% faster, at least on my machine. It does not appear to have any effect on width-8 Poseidon.