### PR TITLE
Tweaks to CrandallField::product

### DIFF
--- a/src/field/crandall_field.rs
+++ b/src/field/crandall_field.rs
@@ -431,8 +431,9 @@ impl MulAssign for CrandallField {
 }
 
 impl Product for CrandallField {
+    #[inline]
     fn product<I: Iterator<Item = Self>>(iter: I) -> Self {
-        iter.fold(Self::ONE, |acc, x| acc * x)
+        iter.reduce(|acc, x| acc * x).unwrap_or(Self::ONE)
     }
 }
 


### PR DESCRIPTION
1. `#[inline]`
2. Use `.reduce` instead of `.fold` (saves one multiplication)

I measured this a bunch of times, and these two changes consistently speed up proofs by 2%, at least on Skylake. Inlining provides a 1.2-1.3% speedup and the switch to `.reduce` a further .7-.8%.