### PR TITLE
Vectorize Poseidon constant layer with NEON

### DIFF
--- a/src/field/mod.rs
+++ b/src/field/mod.rs
@@ -12,6 +12,9 @@ pub(crate) mod packed_field;
 #[cfg(target_feature = "avx2")]
 pub(crate) mod packed_avx2;
 
+#[cfg(target_feature = "neon")]
+pub(crate) mod packed_crandall_neon;
+
 #[cfg(test)]
 mod field_testing;
 #[cfg(test)]

--- a/src/hash/poseidon.rs
+++ b/src/hash/poseidon.rs
@@ -1,7 +1,7 @@
 //! Implementation of the Poseidon hash function, as described in
 //! https://eprint.iacr.org/2019/458.pdf
 
-#[cfg(target_feature = "avx2")]
+#[cfg(any(target_feature = "avx2", target_feature = "neon"))]
 use std::convert::TryInto;
 
 use unroll::unroll_for_loops;

--- a/src/hash/poseidon_neon.rs
+++ b/src/hash/poseidon_neon.rs
@@ -3,6 +3,7 @@ use core::arch::aarch64::*;
 use crate::field::crandall_field::CrandallField;
 use crate::field::field_types::PrimeField;
 use crate::field::packed_crandall_neon::PackedCrandallNeon;
+use crate::field::packed_field::PackedField;
 
 const EPSILON: u64 = 0u64.wrapping_sub(CrandallField::ORDER);
 
@@ -239,9 +240,8 @@ pub unsafe fn crandall_poseidon_const_neon<const PACKED_WIDTH: usize>(
     round_constants: [u64; 2 * PACKED_WIDTH],
 ) {
     let packed_state = PackedCrandallNeon::pack_slice_mut(state);
-    let packed_round_constants =
-        std::slice::from_raw_parts((&round_constants).as_ptr().cast::<__m256i>(), PACKED_WIDTH);
     for i in 0..PACKED_WIDTH {
-        packed_state[i] = packed_state[i].add_canonical_u64(packed_round_constants[i]);
+        let packed_round_const = vld1q_u64(round_constants[2 * i..2 * i + 2].as_ptr());
+        packed_state[i] = packed_state[i].add_canonical_u64(packed_round_const);
     }
 }


### PR DESCRIPTION
Decreases hash times by a modest 1% for width 8 and 6% for width 12.