### PR TITLE
#[inline] add_assign in CrandallField

### DIFF
--- a/src/field/crandall_field.rs
+++ b/src/field/crandall_field.rs
@@ -224,6 +224,7 @@ impl Add for CrandallField {
 }
 
 impl AddAssign for CrandallField {
+    #[inline]
     fn add_assign(&mut self, rhs: Self) {
         *self = *self + rhs;
     }


### PR DESCRIPTION
This decreases the times in `bench_hash` by 10-18%, depending on the hash and width. This probably won’t improve prover runtimes (because it’s all the same crate so it Rustc can already inline) but it’s nice having representative benchmarks.