### PR TITLE
Have `verify_merkle_proof` call `permute_swapped`

### DIFF
--- a/src/hash/hashing.rs
+++ b/src/hash/hashing.rs
@@ -12,7 +12,6 @@ pub(crate) const SPONGE_CAPACITY: usize = 4;
 pub(crate) const SPONGE_WIDTH: usize = SPONGE_RATE + SPONGE_CAPACITY;
 
 pub(crate) const HASH_FAMILY: HashFamily = HashFamily::Poseidon;
-pub(crate) type HashGate<F, const D: usize, const W: usize> = PoseidonGate<F, D, W>;
 
 pub(crate) enum HashFamily {
     GMiMC,


### PR DESCRIPTION
Rather than adding the gate "manually". I meant to do this when I added `permute_swapped`, just forgot earlier.