### PR TITLE
Cache FFT roots

### DIFF
--- a/src/plonk/circuit_data.rs
+++ b/src/plonk/circuit_data.rs
@@ -4,6 +4,7 @@ use std::ops::{Range, RangeFrom};
 use anyhow::Result;
 
 use crate::field::extension_field::Extendable;
+use crate::field::fft::FftRootTable;
 use crate::field::field_types::{Field, RichField};
 use crate::fri::commitment::PolynomialBatchCommitment;
 use crate::fri::FriConfig;
@@ -157,6 +158,8 @@ pub(crate) struct ProverOnlyCircuitData<F: RichField + Extendable<D>, const D: u
     pub marked_targets: Vec<MarkedTargets<D>>,
     /// Partial witness holding the copy constraints information.
     pub partition_witness: PartitionWitness<F>,
+    /// Pre-computed roots for faster FFT.
+    pub fft_root_table: Option<FftRootTable<F>>,
 }
 
 /// Circuit data required by the verifier, but not the prover.

--- a/src/plonk/prover.rs
+++ b/src/plonk/prover.rs
@@ -74,6 +74,7 @@ pub(crate) fn prove<F: RichField + Extendable<D>, const D: usize>(
             config.zero_knowledge & PlonkPolynomials::WIRES.blinding,
             config.cap_height,
             &mut timing,
+            prover_data.fft_root_table.as_ref(),
         )
     );
 
@@ -119,6 +120,7 @@ pub(crate) fn prove<F: RichField + Extendable<D>, const D: usize>(
             config.zero_knowledge & PlonkPolynomials::ZS_PARTIAL_PRODUCTS.blinding,
             config.cap_height,
             &mut timing,
+            prover_data.fft_root_table.as_ref(),
         )
     );
 
@@ -167,7 +169,8 @@ pub(crate) fn prove<F: RichField + Extendable<D>, const D: usize>(
             config.rate_bits,
             config.zero_knowledge & PlonkPolynomials::QUOTIENT.blinding,
             config.cap_height,
-            &mut timing
+            &mut timing,
+            prover_data.fft_root_table.as_ref(),
         )
     );
 

--- a/src/polynomial/polynomial.rs
+++ b/src/polynomial/polynomial.rs
@@ -211,7 +211,7 @@ impl<F: Field> PolynomialCoeffs<F> {
     pub fn fft_with_options(
         &self,
         zero_factor: Option<usize>,
-        root_table: Option<FftRootTable<F>>,
+        root_table: Option<&FftRootTable<F>>,
     ) -> PolynomialValues<F> {
         fft_with_options(self, zero_factor, root_table)
     }
@@ -226,7 +226,7 @@ impl<F: Field> PolynomialCoeffs<F> {
         &self,
         shift: F,
         zero_factor: Option<usize>,
-        root_table: Option<FftRootTable<F>>,
+        root_table: Option<&FftRootTable<F>>,
     ) -> PolynomialValues<F> {
         let modified_poly: Self = shift
             .powers()


### PR DESCRIPTION
This unfortunately results in the root table being passed around a bit as part of `ProverOnlyCircuitData`, but it does speed up PolynomialBatchCommitment::lde_values by 10%