### PR TITLE
Witness generation fix

### DIFF
--- a/src/iop/generator.rs
+++ b/src/iop/generator.rs
@@ -49,9 +49,11 @@ pub(crate) fn generate_partial_witness<F: RichField + Extendable<D>, const D: us
                 remaining_generators -= 1;
             }
 
+            let new_target_reps = witness.extend_returning_parents(buffer.target_values.drain(..));
+
             // Enqueue unfinished generators that were watching one of the newly populated targets.
-            for &(watch, _) in &buffer.target_values {
-                let opt_watchers = generator_indices_by_watches.get(&witness.target_index(watch));
+            for watch in new_target_reps {
+                let opt_watchers = generator_indices_by_watches.get(&watch);
                 if let Some(watchers) = opt_watchers {
                     for &watching_generator_idx in watchers {
                         if !generator_is_expired[watching_generator_idx] {
@@ -60,8 +62,6 @@ pub(crate) fn generate_partial_witness<F: RichField + Extendable<D>, const D: us
                     }
                 }
             }
-
-            witness.extend(buffer.target_values.drain(..));
         }
 
         pending_generator_indices = next_pending_generator_indices;


### PR DESCRIPTION
When we went through newly-populated values, as in

    for &(watch, _) in &buffer.target_values

`watch` was not necessarily a representative, because it came from a `GeneratedValues`, whose `set_target` doesn't know about representatives.

To avoid adding extra lookups, we can modify `extend` to return representative indices (which it already has to look up), and iterate through those instead of the original `GeneratedValues`.