### PR TITLE
Simple witness generation fix

### DIFF
--- a/src/iop/generator.rs
+++ b/src/iop/generator.rs
@@ -51,7 +51,9 @@ pub(crate) fn generate_partial_witness<F: RichField + Extendable<D>, const D: us
 
             // Enqueue unfinished generators that were watching one of the newly populated targets.
             for &(watch, _) in &buffer.target_values {
-                let opt_watchers = generator_indices_by_watches.get(&witness.target_index(watch));
+                let watch_index = witness.target_index(watch);
+                let watch_rep_index = witness.forest[watch_index].parent;
+                let opt_watchers = generator_indices_by_watches.get(&watch_rep_index);
                 if let Some(watchers) = opt_watchers {
                     for &watching_generator_idx in watchers {
                         if !generator_is_expired[watching_generator_idx] {


### PR DESCRIPTION
When we went through newly-populated values, as in

    for &(watch, _) in &buffer.target_values

`watch` was not necessarily a representative, because it came from a `GeneratedValues`, whose `set_target` doesn't know about representatives.