### PR TITLE
Less use of ZK configs in tests

### DIFF
--- a/src/gadgets/permutation.rs
+++ b/src/gadgets/permutation.rs
@@ -397,7 +397,7 @@ mod tests {
         type F = CrandallField;
         const D: usize = 4;
 
-        let config = CircuitConfig::large_zk_config();
+        let config = CircuitConfig::large_config();
 
         let pw = PartialWitness::new();
         let mut builder = CircuitBuilder::<F, D>::new(config);
@@ -422,7 +422,7 @@ mod tests {
         type F = CrandallField;
         const D: usize = 4;
 
-        let config = CircuitConfig::large_zk_config();
+        let config = CircuitConfig::large_config();
 
         let pw = PartialWitness::new();
         let mut builder = CircuitBuilder::<F, D>::new(config);
@@ -451,7 +451,7 @@ mod tests {
         type F = CrandallField;
         const D: usize = 4;
 
-        let config = CircuitConfig::large_zk_config();
+        let config = CircuitConfig::large_config();
 
         let pw = PartialWitness::new();
         let mut builder = CircuitBuilder::<F, D>::new(config);

--- a/src/gadgets/sorting.rs
+++ b/src/gadgets/sorting.rs
@@ -186,7 +186,7 @@ mod tests {
         type F = CrandallField;
         const D: usize = 4;
 
-        let config = CircuitConfig::large_zk_config();
+        let config = CircuitConfig::large_config();
 
         let mut pw = PartialWitness::new();
         let mut builder = CircuitBuilder::<F, D>::new(config);


### PR DESCRIPTION
ZK circuit tests are quite slow, so I think we should use them very sparingly, and not in any tests with loops