### PR TITLE
Better errors for insufficient (routed) wires for FRI

### DIFF
--- a/src/fri/mod.rs
+++ b/src/fri/mod.rs
@@ -32,4 +32,12 @@ impl FriParams {
     pub(crate) fn total_arities(&self) -> usize {
         self.reduction_arity_bits.iter().sum()
     }
+
+    pub(crate) fn max_arity_bits(&self) -> Option<usize> {
+        self.reduction_arity_bits.iter().copied().max()
+    }
+
+    pub(crate) fn max_arity(&self) -> Option<usize> {
+        self.max_arity_bits().map(|bits| 1 << bits)
+    }
 }

--- a/src/gates/interpolation.rs
+++ b/src/gates/interpolation.rs
@@ -81,6 +81,12 @@ impl<F: RichField + Extendable<D>, const D: usize> InterpolationGate<F, D> {
         self.start_evaluation_value() + D
     }
 
+    /// The number of routed wires required in the typical usage of this gate, where the points to
+    /// interpolate, the evaluation point, and the corresponding value are all routed.
+    pub(crate) fn num_routed_wires(&self) -> usize {
+        self.start_coeffs()
+    }
+
     /// Wire indices of the interpolant's `i`th coefficient.
     pub fn wires_coeff(&self, i: usize) -> Range<usize> {
         debug_assert!(i < self.num_points);

--- a/src/gates/random_access.rs
+++ b/src/gates/random_access.rs
@@ -45,6 +45,10 @@ impl<F: RichField + Extendable<D>, const D: usize> RandomAccessGate<F, D> {
         (self.vec_size + 1) * D + 1
     }
 
+    pub(crate) fn num_routed_wires(&self) -> usize {
+        self.start_of_intermediate_wires()
+    }
+
     /// An intermediate wire for a dummy variable used to show equality.
     /// The prover sets this to 1/(x-y) if x != y, or to an arbitrary value if
     /// x == y.


### PR DESCRIPTION
For examlpe, if I change a test to use `ConstantArityBits(4, 5)`, I get

    To efficiently perform FRI checks with an arity of 16, at least 152 wires are needed. Consider reducing arity.