### PR TITLE
Minor: Take `CircuitConfig` by reference to avoid a few clones

### DIFF
--- a/src/gadgets/arithmetic.rs
+++ b/src/gadgets/arithmetic.rs
@@ -108,7 +108,7 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
         exponent_bits: impl IntoIterator<Item = impl Borrow<BoolTarget>>,
     ) -> Target {
         let _false = self._false();
-        let gate = ExponentiationGate::new_from_config(self.config.clone());
+        let gate = ExponentiationGate::new_from_config(&self.config);
         let num_power_bits = gate.num_power_bits;
         let mut exp_bits_vec: Vec<BoolTarget> =
             exponent_bits.into_iter().map(|b| *b.borrow()).collect();

--- a/src/gadgets/permutation.rs
+++ b/src/gadgets/permutation.rs
@@ -81,7 +81,7 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
         let (gate, gate_index, mut next_copy) =
             match self.current_switch_gates[chunk_size - 1].clone() {
                 None => {
-                    let gate = SwitchGate::<F, D>::new_from_config(self.config.clone(), chunk_size);
+                    let gate = SwitchGate::<F, D>::new_from_config(&self.config, chunk_size);
                     let gate_index = self.add_gate(gate.clone(), vec![]);
                     (gate, gate_index, 0)
                 }

--- a/src/gates/exponentiation.rs
+++ b/src/gates/exponentiation.rs
@@ -27,7 +27,7 @@ impl<F: RichField + Extendable<D>, const D: usize> ExponentiationGate<F, D> {
         }
     }
 
-    pub fn new_from_config(config: CircuitConfig) -> Self {
+    pub fn new_from_config(config: &CircuitConfig) -> Self {
         let num_power_bits = Self::max_power_bits(config.num_wires, config.num_routed_wires);
         Self::new(num_power_bits)
     }
@@ -302,13 +302,13 @@ mod tests {
             ..CircuitConfig::large_config()
         };
 
-        test_low_degree::<CrandallField, _, 4>(ExponentiationGate::new_from_config(config));
+        test_low_degree::<CrandallField, _, 4>(ExponentiationGate::new_from_config(&config));
     }
 
     #[test]
     fn eval_fns() -> Result<()> {
         test_eval_fns::<CrandallField, _, 4>(ExponentiationGate::new_from_config(
-            CircuitConfig::large_config(),
+            &CircuitConfig::large_config(),
         ))
     }
 

--- a/src/gates/switch.rs
+++ b/src/gates/switch.rs
@@ -31,7 +31,7 @@ impl<F: RichField + Extendable<D>, const D: usize> SwitchGate<F, D> {
         }
     }
 
-    pub fn new_from_config(config: CircuitConfig, chunk_size: usize) -> Self {
+    pub fn new_from_config(config: &CircuitConfig, chunk_size: usize) -> Self {
         let num_copies = Self::max_num_copies(config.num_routed_wires, chunk_size);
         Self::new(num_copies, chunk_size)
     }
@@ -352,7 +352,7 @@ mod tests {
     #[test]
     fn low_degree() {
         test_low_degree::<CrandallField, _, 4>(SwitchGate::<_, 4>::new_from_config(
-            CircuitConfig::large_config(),
+            &CircuitConfig::large_config(),
             3,
         ));
     }
@@ -360,7 +360,7 @@ mod tests {
     #[test]
     fn eval_fns() -> Result<()> {
         test_eval_fns::<CrandallField, _, 4>(SwitchGate::<_, 4>::new_from_config(
-            CircuitConfig::large_config(),
+            &CircuitConfig::large_config(),
             3,
         ))
     }


### PR DESCRIPTION
Change the signature of `new_from_config` from `fn new_from_config(config: CircuitConfig)` to `fn new_from_config(config: &CircuitConfig)` in the exponentiation and switch gates to avoid cloning the config.