### PR TITLE
Ensure only one `BaseSumGate` is instantiated

### DIFF
--- a/src/gadgets/range_check.rs
+++ b/src/gadgets/range_check.rs
@@ -1,6 +1,5 @@
 use crate::field::extension_field::Extendable;
 use crate::field::field_types::RichField;
-use crate::gates::base_sum::BaseSumGate;
 use crate::iop::generator::{GeneratedValues, SimpleGenerator};
 use crate::iop::target::{BoolTarget, Target};
 use crate::iop::witness::{PartitionWitness, Witness};

--- a/src/gadgets/split_base.rs
+++ b/src/gadgets/split_base.rs
@@ -13,7 +13,7 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
     /// base-B limb of the element, with little-endian ordering.
     pub fn split_le_base<const B: usize>(&mut self, x: Target, num_limbs: usize) -> Vec<Target> {
         let gate_type = BaseSumGate::<B>::new(num_limbs);
-        let gate = self.add_gate(gate_type.clone(), vec![]);
+        let gate = self.add_gate(gate_type, vec![]);
         let sum = Target::wire(gate, BaseSumGate::<B>::WIRE_SUM);
         self.connect(x, sum);
 

--- a/src/gadgets/split_join.rs
+++ b/src/gadgets/split_join.rs
@@ -5,7 +5,7 @@ use crate::iop::generator::{GeneratedValues, SimpleGenerator};
 use crate::iop::target::{BoolTarget, Target};
 use crate::iop::witness::{PartitionWitness, Witness};
 use crate::plonk::circuit_builder::CircuitBuilder;
-use crate::util::{bits_u64, ceil_div_usize};
+use crate::util::ceil_div_usize;
 
 impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
     /// Split the given integer into a list of wires, where each one represents a

--- a/src/gates/base_sum.rs
+++ b/src/gates/base_sum.rs
@@ -11,7 +11,6 @@ use crate::plonk::circuit_builder::CircuitBuilder;
 use crate::plonk::circuit_data::CircuitConfig;
 use crate::plonk::plonk_common::{reduce_with_powers, reduce_with_powers_ext_recursive};
 use crate::plonk::vars::{EvaluationTargets, EvaluationVars, EvaluationVarsBase};
-use crate::util::bits_u64;
 
 /// A gate which can decompose a number into base B little-endian limbs.
 #[derive(Copy, Clone, Debug)]


### PR DESCRIPTION
Use a constant `num_limbs` to use in `BaseSumGate<2>` throughout the code to ensure only one instance of `BaseSumGate` in the circuit.