### PR TITLE
Goldilocks: better constant propagation through add_with_wraparound

### DIFF
--- a/src/field/goldilocks_field.rs
+++ b/src/field/goldilocks_field.rs
@@ -13,6 +13,7 @@ use crate::field::extension_field::quartic::QuarticExtension;
 use crate::field::extension_field::Extendable;
 use crate::field::field_types::{Field, PrimeField, RichField};
 use crate::field::inversion::try_inverse_u64;
+use crate::util::assume;
 
 const EPSILON: u64 = (1 << 32) - 1;
 
@@ -280,6 +281,8 @@ unsafe fn add_with_wraparound(x: u64, y: u64) -> u64 {
         inlateout(reg) y => adjustment,
         options(pure, nomem, nostack),
     );
+    assume(x != 0 || (res_wrapped == y && adjustment == 0));
+    assume(y != 0 || (res_wrapped == x && adjustment == 0));
     res_wrapped.wrapping_add(adjustment) // Add EPSILON == subtract ORDER.
 }
 
@@ -307,6 +310,7 @@ unsafe fn sub_with_wraparound(x: u64, y: u64) -> u64 {
         inlateout(reg) y => adjustment,
         options(pure, nomem, nostack),
     );
+    assume(y != 0 || (res_wrapped == x && adjustment == 0));
     res_wrapped.wrapping_sub(adjustment) // Subtract EPSILON == add ORDER.
 }
 

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,3 +1,5 @@
+use core::hint::unreachable_unchecked;
+
 use crate::field::field_types::Field;
 use crate::polynomial::polynomial::PolynomialValues;
 
@@ -193,6 +195,14 @@ pub(crate) fn reverse_bits(n: usize, num_bits: usize) -> usize {
     n.reverse_bits()
         .overflowing_shr(usize::BITS - num_bits as u32)
         .0
+}
+
+#[inline(always)]
+pub(crate) unsafe fn assume(p: bool) {
+    debug_assert!(p);
+    if !p {
+        unreachable_unchecked();
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
[`std::hint::unreachable_unchecked`](https://doc.rust-lang.org/std/hint/fn.unreachable_unchecked.html) is a function that generates UB when it is reached. This UB can be used for optimization: we can tell the compiler that a condition will never be true. `unreachable_unchecked` is in stable, unlike [`core::intrinsics::assume`](https://doc.rust-lang.org/core/intrinsics/fn.assume.html)

In this particular case, we inform the compiler about some of the semantics of the inline ASM used in multiplication. It allows some constraint propagation. In particular, the compiler can skip the first step of the reduction when it knows that the full product is only 96 bits (e.g. multiplication by `W` in #318).