### PR TITLE
Minor optimizations to addition

### DIFF
--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -198,10 +198,27 @@ pub(crate) fn reverse_bits(n: usize, num_bits: usize) -> usize {
 }
 
 #[inline(always)]
-pub(crate) unsafe fn assume(p: bool) {
+pub(crate) fn assume(p: bool) {
     debug_assert!(p);
     if !p {
-        unreachable_unchecked();
+        unsafe {
+            unreachable_unchecked();
+        }
+    }
+}
+
+/// Try to force Rust to emit a branch. Example:
+///     if x > 2 {
+///         y = foo();
+///         branch_hint();
+///     } else {
+///         y = bar();
+///     }
+/// This function has no semantics. It is a hint only.
+#[inline(always)]
+pub(crate) fn branch_hint() {
+    unsafe {
+        asm!("", options(nomem, nostack, preserves_flags));
     }
 }
 


### PR DESCRIPTION
1. Replace wrapping add/sub with standard add/sub where possible, letting the compiler assume it can’t happen.
2. Rewrite add/sub accounting for double-overflow. Use @dlubarov’s idea of two `overflowing_add`s. Also, force branch.

Appears to shave ~3% off prover times on my Skylake.