### PR TITLE
Add .DS_Store to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,10 @@
+# Cargo build
 /target
 Cargo.lock
+
+# Profile-guided optimization
 /tmp
 pgo-data.profdata
+
+# MacOS nuisances
+.DS_Store


### PR DESCRIPTION
`.DS_Store` files are used by macOS to store folder-specific user settings.