### PR TITLE
Optimize combination of gate constraints in recursive circuit

### DIFF
--- a/src/plonk/vanishing_poly.rs
+++ b/src/plonk/vanishing_poly.rs
@@ -288,24 +288,20 @@ pub fn evaluate_gate_constraints_recursively<F: RichField + Extendable<D>, const
     num_gate_constraints: usize,
     vars: EvaluationTargets<D>,
 ) -> Vec<ExtensionTarget<D>> {
-    let mut all_gate_constraints = vec![vec![]; num_gate_constraints];
+    let mut all_gate_constraints = vec![builder.zero_extension(); num_gate_constraints];
     for gate in gates {
-        let gate_constraints = with_context!(
+        with_context!(
             builder,
             &format!("evaluate {} constraints", gate.gate.0.id()),
-            gate.gate
-                .0
-                .eval_filtered_recursively(builder, vars, &gate.prefix)
+            gate.gate.0.eval_filtered_recursively(
+                builder,
+                vars,
+                &gate.prefix,
+                &mut all_gate_constraints
+            )
         );
-        for (i, c) in gate_constraints.into_iter().enumerate() {
-            all_gate_constraints[i].push(c);
-        }
     }
-    let mut constraints = vec![builder.zero_extension(); num_gate_constraints];
-    for (i, v) in all_gate_constraints.into_iter().enumerate() {
-        constraints[i] = builder.add_many_extension(&v);
-    }
-    constraints
+    all_gate_constraints
 }
 
 /// Evaluate the vanishing polynomial at `x`. In this context, the vanishing polynomial is a random


### PR DESCRIPTION
Just passing the "combined constraints" buffer into `eval_filtered_recursively`, so that we can combine a mul by the filter with an add into the buffer. Saves 56 wires.