### PR TITLE
Use Jemalloc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,9 @@ serde = { version = "1.0", features = ["derive"] }
 serde_cbor = "0.11.1"
 static_assertions = "1.1.0"
 
+[target.'cfg(not(target_env = "msvc"))'.dependencies]
+jemallocator = "0.3.2"
+
 [dev-dependencies]
 criterion = "0.3.5"
 tynm = "0.1.6"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,3 +13,11 @@ pub mod iop;
 pub mod plonk;
 pub mod polynomial;
 pub mod util;
+
+// Set up Jemalloc
+#[cfg(not(target_env = "msvc"))]
+use jemallocator::Jemalloc;
+
+#[cfg(not(target_env = "msvc"))]
+#[global_allocator]
+static GLOBAL: Jemalloc = Jemalloc;


### PR DESCRIPTION
Decreases proof times by 12% (🤯) on my M1 Pro (.380s -> .336s).

My only concern is that `global_allocator` sets the allocator globally. We probably don't want the allocator to change as a silent side-effect of importing our library. The [`allocator_api` feature](https://github.com/rust-lang/rust/issues/32838) will, once stable, let us use a different allocator without a global override.