### PR TITLE
[WIP] Minor refactor of partial product code

### DIFF
--- a/src/plonk/vanishing_poly.rs
+++ b/src/plonk/vanishing_poly.rs
@@ -75,13 +75,10 @@ pub(crate) fn eval_vanishing_poly<F: RichField + Extendable<D>, const D: usize>(
         );
         vanishing_partial_products_terms.extend(partial_product_checks);
 
-        let v_shift_term = *current_partial_products.last().unwrap()
-            * numerator_values[final_num_prod..].iter().copied().product()
-            - z_gz
-                * denominator_values[final_num_prod..]
-                    .iter()
-                    .copied()
-                    .product();
+        let final_nume_product = numerator_values[final_num_prod..].iter().copied().product();
+        let final_deno_product = denominator_values[final_num_prod..].iter().copied().product();
+        let last_partial = *current_partial_products.last().unwrap();
+        let v_shift_term = last_partial * final_nume_product - z_gz * final_deno_product;
         vanishing_v_shift_terms.push(v_shift_term);
     }
 
@@ -185,21 +182,17 @@ pub(crate) fn eval_vanishing_poly_base_batch<F: RichField + Extendable<D>, const
             );
             vanishing_partial_products_terms.extend(partial_product_checks);
 
-            let v_shift_term = *current_partial_products.last().unwrap()
-                * numerator_values[final_num_prod..].iter().copied().product()
-                - z_gz
-                    * denominator_values[final_num_prod..]
-                        .iter()
-                        .copied()
-                        .product();
+            let final_nume_product = numerator_values[final_num_prod..].iter().copied().product();
+            let final_deno_product = denominator_values[final_num_prod..].iter().copied().product();
+            let last_partial = *current_partial_products.last().unwrap();
+            let v_shift_term = last_partial * final_nume_product - z_gz * final_deno_product;
             vanishing_v_shift_terms.push(v_shift_term);
 
             numerator_values.clear();
             denominator_values.clear();
         }
 
-        let vanishing_terms = vanishing_z_1_terms
-            .iter()
+        let vanishing_terms = vanishing_z_1_terms.iter()
             .chain(vanishing_partial_products_terms.iter())
             .chain(vanishing_v_shift_terms.iter())
             .chain(constraint_terms);
@@ -381,17 +374,11 @@ pub(crate) fn eval_vanishing_poly_recursively<F: RichField + Extendable<D>, cons
         );
         vanishing_partial_products_terms.extend(partial_product_checks);
 
-        let nume_acc = builder.mul_many_extension(&{
-            let mut v = numerator_values[final_num_prod..].to_vec();
-            v.push(*current_partial_products.last().unwrap());
-            v
-        });
-        let z_gz_denominators = builder.mul_many_extension(&{
-            let mut v = denominator_values[final_num_prod..].to_vec();
-            v.push(z_gz);
-            v
-        });
-        let v_shift_term = builder.sub_extension(nume_acc, z_gz_denominators);
+        let final_nume_product = builder.mul_many_extension(&numerator_values[final_num_prod..]);
+        let final_deno_product = builder.mul_many_extension(&denominator_values[final_num_prod..]);
+        let z_gz_denominators = builder.mul_extension(z_gz, final_deno_product);
+        let last_partial = *current_partial_products.last().unwrap();
+        let v_shift_term = builder.mul_sub_extension(last_partial, final_nume_product, z_gz_denominators);
         vanishing_v_shift_terms.push(v_shift_term);
     }
 

--- a/src/util/partial_products.rs
+++ b/src/util/partial_products.rs
@@ -2,19 +2,30 @@ use crate::field::extension_field::target::ExtensionTarget;
 use crate::field::extension_field::Extendable;
 use crate::field::field_types::{Field, RichField};
 use crate::plonk::circuit_builder::CircuitBuilder;
+use itertools::Itertools;
+
+pub(crate) fn quotient_chunk_products<F: Field>(
+    quotient_values: &[F],
+    max_degree: usize,
+) -> Vec<F> {
+    debug_assert!(max_degree > 1);
+    assert!(quotient_values.len() > 0);
+    let chunk_size = max_degree;
+    quotient_values.chunks(chunk_size)
+        .map(|chunk| chunk.iter().copied().product())
+        .collect()
+}
 
 /// Compute partial products of the original vector `v` such that all products consist of `max_degree`
 /// or less elements. This is done until we've computed the product `P` of all elements in the vector.
-pub fn partial_products<F: Field>(v: &[F], max_degree: usize) -> Vec<F> {
-    debug_assert!(max_degree > 1);
+pub(crate) fn partial_products_and_z_gx<F: Field>(z_x: F, quotient_chunk_products: &[F]) -> Vec<F> {
+    assert!(quotient_chunk_products.len() > 0);
     let mut res = Vec::new();
-    let mut acc = F::ONE;
-    let chunk_size = max_degree;
-    for chunk in v.chunks_exact(chunk_size) {
-        acc *= chunk.iter().copied().product();
+    let mut acc = z_x;
+    for &quotient_chunk_product in quotient_chunk_products {
+        acc *= quotient_chunk_product;
         res.push(acc);
     }
-
     res
 }
 
@@ -30,24 +41,26 @@ pub fn num_partial_products(n: usize, max_degree: usize) -> (usize, usize) {
 
 /// Checks that the partial products of `numerators/denominators` are coherent with those in `partials` by only computing
 /// products of size `max_degree` or less.
-pub fn check_partial_products<F: Field>(
+pub(crate) fn check_partial_products<F: Field>(
     numerators: &[F],
     denominators: &[F],
     partials: &[F],
-    mut acc: F,
+    z_x: F,
     max_degree: usize,
 ) -> Vec<F> {
     debug_assert!(max_degree > 1);
+    let mut acc = z_x;
     let mut partials = partials.iter();
     let mut res = Vec::new();
     let chunk_size = max_degree;
     for (nume_chunk, deno_chunk) in numerators
         .chunks_exact(chunk_size)
-        .zip(denominators.chunks_exact(chunk_size))
+        .zip_eq(denominators.chunks_exact(chunk_size))
     {
-        acc *= nume_chunk.iter().copied().product();
-        let mut new_acc = *partials.next().unwrap();
-        res.push(acc - new_acc * deno_chunk.iter().copied().product());
+        let num_chunk_product = nume_chunk.iter().copied().product();
+        let den_chunk_product = deno_chunk.iter().copied().product();
+        let new_acc = *partials.next().unwrap();
+        res.push(acc * num_chunk_product - new_acc * den_chunk_product);
         acc = new_acc;
     }
     debug_assert!(partials.next().is_none());
@@ -55,7 +68,7 @@ pub fn check_partial_products<F: Field>(
     res
 }
 
-pub fn check_partial_products_recursively<F: RichField + Extendable<D>, const D: usize>(
+pub(crate) fn check_partial_products_recursively<F: RichField + Extendable<D>, const D: usize>(
     builder: &mut CircuitBuilder<F, D>,
     numerators: &[ExtensionTarget<D>],
     denominators: &[ExtensionTarget<D>],
@@ -93,18 +106,11 @@ mod tests {
     fn test_partial_products() {
         type F = GoldilocksField;
         let denominators = vec![F::ONE; 6];
-        let v = [1, 2, 3, 4, 5, 6]
-            .into_iter()
-            .map(|&i| F::from_canonical_u64(i))
-            .collect::<Vec<_>>();
-        let p = partial_products(&v, 2);
-        assert_eq!(
-            p,
-            [2, 24, 720]
-                .into_iter()
-                .map(|&i| F::from_canonical_u64(i))
-                .collect::<Vec<_>>()
-        );
+        let v = field_vec(&[1, 2, 3, 4, 5, 6]);
+        let quotient_chunks_prods = quotient_chunk_products(&v, 2);
+        assert_eq!(quotient_chunks_prods, field_vec(&[2, 12, 30]));
+        let p = partial_products_and_z_gx(F::ONE, &quotient_chunks_prods);
+        assert_eq!(p, field_vec(&[2, 24, 720]));
 
         let nums = num_partial_products(v.len(), 2);
         assert_eq!(p.len(), nums.0);
@@ -116,17 +122,12 @@ mod tests {
             v.into_iter().product::<F>(),
         );
 
-        let v = [1, 2, 3, 4, 5, 6]
-            .into_iter()
-            .map(|&i| F::from_canonical_u64(i))
-            .collect::<Vec<_>>();
-        let p = partial_products(&v, 3);
+        let v = field_vec(&[1, 2, 3, 4, 5, 6]);
+        let quotient_chunks_prods = quotient_chunk_products(&v, 3);
+        let p = partial_products_and_z_gx(F::ONE, &quotient_chunks_prods);
         assert_eq!(
             p,
-            [6, 720]
-                .into_iter()
-                .map(|&i| F::from_canonical_u64(i))
-                .collect::<Vec<_>>()
+            field_vec(&[6, 720])
         );
         let nums = num_partial_products(v.len(), 3);
         assert_eq!(p.len(), nums.0);
@@ -137,5 +138,9 @@ mod tests {
             *p.last().unwrap() * v[nums.1..].iter().copied().product::<F>(),
             v.into_iter().product::<F>(),
         );
+    }
+
+    fn field_vec<F: Field>(xs: &[usize]) -> Vec<F> {
+        xs.iter().map(|&x| F::from_canonical_usize(x)).collect()
     }
 }


### PR DESCRIPTION
- I changed `partial_products` to take `Z(x)` as its initial accumulator, and also to include the final product, representing `Z(g x)`. This requires that `partial_products_and_z_gx` calls be chained sequentially. To keep most of our parallelism, I moved the quotient products into a new `quotient_chunk_products` function. The main goal was to avoid needing to "correct" products (multiplying by `Z(x)`) later; that could be confusing.
- In the prover, `wires_permutation_partial_products` was prepending values which, IIUC, correspond to `Z(g x)` evaluations. Note the "shift", which was later removed in `compute_z`. I changed `wires_permutation_partial_products` to remove the shift itself, so it now returns a `Z(x)` polynomial, and `compute_z` isn't needed. I also moved the `Z(x)` polynomial to the end; this goes naturally with the `partial_products` change.

I think a bit more simplification might be possible if we change the order of committed partial and Z polynomials to match the prover's "natural" order, but I haven't tried that yet.

I was also thinking of trying changing `check_partial_products` to include the final check; I might try that later.