### PR TITLE
256 bit salts

### DIFF
--- a/src/fri/commitment.rs
+++ b/src/fri/commitment.rs
@@ -16,8 +16,8 @@ use crate::util::reducing::ReducingFactor;
 use crate::util::timing::TimingTree;
 use crate::util::{log2_strict, reverse_bits, reverse_index_bits_in_place, transpose};
 
-/// Two (~64 bit) field elements gives ~128 bit security.
-pub const SALT_SIZE: usize = 2;
+/// Four (~64 bit) field elements gives ~128 bit security.
+pub const SALT_SIZE: usize = 4;
 
 /// Represents a batch FRI based commitment to a list of polynomials.
 pub struct PolynomialBatchCommitment<F: RichField> {


### PR DESCRIPTION
I believe I was mistaken earlier, and hash-based commitments actually call for `r = 2*security_bits` bits of randomness.

I.e. I believe breaking a particular commitment requires `O(2^r)` work (more if the committed value adds entropy, but assume it doesn't), but breaking one of `n` commitments requires less work.

It seems like this should be a well-known thing, but I can't find much in the literature. The IOP paper does mention using `2*security_bits` of randomness though.