### PR TITLE
Fix & cleanup partial products

### DIFF
--- a/src/util/partial_products.rs
+++ b/src/util/partial_products.rs
@@ -1,9 +1,12 @@
+use std::iter;
+
 use itertools::Itertools;
 
 use crate::field::extension_field::target::ExtensionTarget;
 use crate::field::extension_field::Extendable;
 use crate::field::field_types::{Field, RichField};
 use crate::plonk::circuit_builder::CircuitBuilder;
+use crate::util::ceil_div_usize;
 
 pub(crate) fn quotient_chunk_products<F: Field>(
     quotient_values: &[F],
@@ -33,70 +36,74 @@ pub(crate) fn partial_products_and_z_gx<F: Field>(z_x: F, quotient_chunk_product
 
 /// Returns a tuple `(a,b)`, where `a` is the length of the output of `partial_products()` on a
 /// vector of length `n`, and `b` is the number of original elements consumed in `partial_products()`.
-pub fn num_partial_products(n: usize, max_degree: usize) -> (usize, usize) {
+pub(crate) fn num_partial_products(n: usize, max_degree: usize) -> (usize, usize) {
     debug_assert!(max_degree > 1);
     let chunk_size = max_degree;
-    let num_chunks = n / chunk_size;
-
+    // We'll split the product into `ceil_div_usize(n, chunk_size)` chunks, but the last chunk will
+    // be associated with Z(gx) itself. Thus we subtract one to get the chunks associated with
+    // partial products.
+    let num_chunks = ceil_div_usize(n, chunk_size) - 1;
     (num_chunks, num_chunks * chunk_size)
 }
 
-/// Checks that the partial products of `numerators/denominators` are coherent with those in `partials` by only computing
-/// products of size `max_degree` or less.
+/// Checks the relationship between each pair of partial product accumulators. In particular, this
+/// sequence of accumulators starts with `Z(x)`, then contains each partial product polynomials
+/// `p_i(x)`, and finally `Z(g x)`. See the partial products section of the Plonky2 paper.
 pub(crate) fn check_partial_products<F: Field>(
     numerators: &[F],
     denominators: &[F],
     partials: &[F],
     z_x: F,
+    z_gx: F,
     max_degree: usize,
 ) -> Vec<F> {
     debug_assert!(max_degree > 1);
-    let mut acc = z_x;
-    let mut partials = partials.iter();
-    let mut res = Vec::new();
+    let product_accs = iter::once(&z_x)
+        .chain(partials.iter())
+        .chain(iter::once(&z_gx));
     let chunk_size = max_degree;
-    for (nume_chunk, deno_chunk) in numerators
-        .chunks_exact(chunk_size)
-        .zip_eq(denominators.chunks_exact(chunk_size))
-    {
-        let num_chunk_product = nume_chunk.iter().copied().product();
-        let den_chunk_product = deno_chunk.iter().copied().product();
-        let new_acc = *partials.next().unwrap();
-        res.push(acc * num_chunk_product - new_acc * den_chunk_product);
-        acc = new_acc;
-    }
-    debug_assert!(partials.next().is_none());
-
-    res
+    numerators
+        .chunks(chunk_size)
+        .zip_eq(denominators.chunks(chunk_size))
+        .zip_eq(product_accs.tuple_windows())
+        .map(|((nume_chunk, deno_chunk), (&prev_acc, &next_acc))| {
+            let num_chunk_product = nume_chunk.iter().copied().product();
+            let den_chunk_product = deno_chunk.iter().copied().product();
+            // Assert that next_acc * deno_product = prev_acc * nume_product.
+            prev_acc * num_chunk_product - next_acc * den_chunk_product
+        })
+        .collect()
 }
 
+/// Checks the relationship between each pair of partial product accumulators. In particular, this
+/// sequence of accumulators starts with `Z(x)`, then contains each partial product polynomials
+/// `p_i(x)`, and finally `Z(g x)`. See the partial products section of the Plonky2 paper.
 pub(crate) fn check_partial_products_recursively<F: RichField + Extendable<D>, const D: usize>(
     builder: &mut CircuitBuilder<F, D>,
     numerators: &[ExtensionTarget<D>],
     denominators: &[ExtensionTarget<D>],
     partials: &[ExtensionTarget<D>],
-    mut acc: ExtensionTarget<D>,
+    z_x: ExtensionTarget<D>,
+    z_gx: ExtensionTarget<D>,
     max_degree: usize,
 ) -> Vec<ExtensionTarget<D>> {
     debug_assert!(max_degree > 1);
-    let mut partials = partials.iter();
-    let mut res = Vec::new();
+    let product_accs = iter::once(&z_x)
+        .chain(partials.iter())
+        .chain(iter::once(&z_gx));
     let chunk_size = max_degree;
-    for (nume_chunk, deno_chunk) in numerators
-        .chunks_exact(chunk_size)
-        .zip(denominators.chunks_exact(chunk_size))
-    {
-        let nume_product = builder.mul_many_extension(nume_chunk);
-        let deno_product = builder.mul_many_extension(deno_chunk);
-        let new_acc = *partials.next().unwrap();
-        let new_acc_deno = builder.mul_extension(new_acc, deno_product);
-        // Assert that new_acc*deno_product = acc * nume_product.
-        res.push(builder.mul_sub_extension(acc, nume_product, new_acc_deno));
-        acc = new_acc;
-    }
-    debug_assert!(partials.next().is_none());
-
-    res
+    numerators
+        .chunks(chunk_size)
+        .zip_eq(denominators.chunks(chunk_size))
+        .zip_eq(product_accs.tuple_windows())
+        .map(|((nume_chunk, deno_chunk), (&prev_acc, &next_acc))| {
+            let nume_product = builder.mul_many_extension(nume_chunk);
+            let deno_product = builder.mul_many_extension(deno_chunk);
+            let next_acc_deno = builder.mul_extension(next_acc, deno_product);
+            // Assert that next_acc * deno_product = prev_acc * nume_product.
+            builder.mul_sub_extension(prev_acc, nume_product, next_acc_deno)
+        })
+        .collect()
 }
 
 #[cfg(test)]
@@ -108,36 +115,31 @@ mod tests {
     fn test_partial_products() {
         type F = GoldilocksField;
         let denominators = vec![F::ONE; 6];
+        let z_x = F::ONE;
         let v = field_vec(&[1, 2, 3, 4, 5, 6]);
+        let z_gx = F::from_canonical_u64(720);
         let quotient_chunks_prods = quotient_chunk_products(&v, 2);
         assert_eq!(quotient_chunks_prods, field_vec(&[2, 12, 30]));
-        let p = partial_products_and_z_gx(F::ONE, &quotient_chunks_prods);
-        assert_eq!(p, field_vec(&[2, 24, 720]));
+        let pps_and_z_gx = partial_products_and_z_gx(z_x, &quotient_chunks_prods);
+        let pps = &pps_and_z_gx[..pps_and_z_gx.len() - 1];
+        assert_eq!(pps_and_z_gx, field_vec(&[2, 24, 720]));
 
         let nums = num_partial_products(v.len(), 2);
-        assert_eq!(p.len(), nums.0);
-        assert!(check_partial_products(&v, &denominators, &p, F::ONE, 2)
+        assert_eq!(pps.len(), nums.0);
+        assert!(check_partial_products(&v, &denominators, pps, z_x, z_gx, 2)
             .iter()
             .all(|x| x.is_zero()));
-        assert_eq!(
-            *p.last().unwrap() * v[nums.1..].iter().copied().product::<F>(),
-            v.into_iter().product::<F>(),
-        );
 
-        let v = field_vec(&[1, 2, 3, 4, 5, 6]);
         let quotient_chunks_prods = quotient_chunk_products(&v, 3);
         assert_eq!(quotient_chunks_prods, field_vec(&[6, 120]));
-        let p = partial_products_and_z_gx(F::ONE, &quotient_chunks_prods);
-        assert_eq!(p, field_vec(&[6, 720]));
+        let pps_and_z_gx = partial_products_and_z_gx(z_x, &quotient_chunks_prods);
+        let pps = &pps_and_z_gx[..pps_and_z_gx.len() - 1];
+        assert_eq!(pps_and_z_gx, field_vec(&[6, 720]));
         let nums = num_partial_products(v.len(), 3);
-        assert_eq!(p.len(), nums.0);
-        assert!(check_partial_products(&v, &denominators, &p, F::ONE, 3)
+        assert_eq!(pps.len(), nums.0);
+        assert!(check_partial_products(&v, &denominators, pps, z_x, z_gx, 3)
             .iter()
             .all(|x| x.is_zero()));
-        assert_eq!(
-            *p.last().unwrap() * v[nums.1..].iter().copied().product::<F>(),
-            v.into_iter().product::<F>(),
-        );
     }
 
     fn field_vec<F: Field>(xs: &[usize]) -> Vec<F> {


### PR DESCRIPTION
My previous change introduced a bug -- when `num_routed_wires` was a multiple of 8, the partial products "consumed" all `num_routed_wires` terms, whereas we actually want to leave 8 terms for the final product.

This PR also changes `check_partial_products` to include the final product constraint, and merges `vanishing_v_shift_terms` into `vanishing_partial_products_terms`. I think this is natural since `Z(x)`, partial products, and `Z(g x)` are all part of the same product accumulator chain.