### PR TITLE
Verify that non-canonical splits are OK

### DIFF
--- a/src/field/field_types.rs
+++ b/src/field/field_types.rs
@@ -345,6 +345,11 @@ pub trait Field:
 pub trait PrimeField: Field {
     const ORDER: u64;
 
+    /// The number of bits required to encode any field element.
+    fn bits() -> usize {
+        bits_u64(Self::NEG_ONE.to_canonical_u64())
+    }
+
     fn to_canonical_u64(&self) -> u64;
 
     fn to_noncanonical_u64(&self) -> u64;

--- a/src/plonk/circuit_data.rs
+++ b/src/plonk/circuit_data.rs
@@ -48,6 +48,10 @@ impl Default for CircuitConfig {
 }
 
 impl CircuitConfig {
+    pub fn rate(&self) -> f64 {
+        1.0 / ((1 << self.rate_bits) as f64)
+    }
+
     pub fn num_advice_wires(&self) -> usize {
         self.num_wires - self.num_routed_wires
     }


### PR DESCRIPTION
The effect on soundness error is negligible for our current field, but this introduces an assertion that could fail if we changed to a field with more elements in the "ambiguous" range.