### PR TITLE
Address some more arithmetic gates that have unique constants

### DIFF
--- a/src/gates/poseidon.rs
+++ b/src/gates/poseidon.rs
@@ -351,10 +351,10 @@ where
                 let sbox_in = vars.local_wires[Self::wire_partial_sbox(r)];
                 constraints.push(builder.sub_extension(state[0], sbox_in));
                 state[0] = <F as Poseidon<WIDTH>>::sbox_monomial_recursive(builder, sbox_in);
-                state[0] = builder.add_const_extension(
-                    state[0],
-                    F::from_canonical_u64(<F as Poseidon<WIDTH>>::FAST_PARTIAL_ROUND_CONSTANTS[r]),
-                );
+                let c = <F as Poseidon<WIDTH>>::FAST_PARTIAL_ROUND_CONSTANTS[r];
+                let c = F::Extension::from_canonical_u64(c);
+                let c = builder.constant_extension(c);
+                state[0] = builder.add_extension(state[0], c);
                 state =
                     <F as Poseidon<WIDTH>>::mds_partial_layer_fast_recursive(builder, &state, r);
             }

--- a/src/hash/poseidon.rs
+++ b/src/hash/poseidon.rs
@@ -455,8 +455,9 @@ where
         );
         for i in 1..WIDTH {
             let t = <Self as Poseidon<WIDTH>>::FAST_PARTIAL_ROUND_W_HATS[r][i - 1];
-            let t = Self::from_canonical_u64(t);
-            d = builder.mul_const_add_extension(t, state[i], d);
+            let t = Self::Extension::from_canonical_u64(t);
+            let t = builder.constant_extension(t);
+            d = builder.mul_add_extension(t, state[i], d);
         }
 
         let mut result = [builder.zero_extension(); WIDTH];


### PR DESCRIPTION
Saves 131 gates, though only when not using `PoseidonMdsGate`, so not relevant for the 2^12 branch.