### PR TITLE
Recursion in 2^12 gates

### DIFF
--- a/src/plonk/circuit_data.rs
+++ b/src/plonk/circuit_data.rs
@@ -60,18 +60,18 @@ impl CircuitConfig {
     pub(crate) fn standard_recursion_config() -> Self {
         Self {
             num_wires: 135,
-            num_routed_wires: 25,
-            constant_gate_size: 6,
+            num_routed_wires: 80,
+            constant_gate_size: 8,
             use_base_arithmetic_gate: true,
-            security_bits: 100,
+            security_bits: 93,
             rate_bits: 3,
             num_challenges: 2,
             zero_knowledge: false,
             cap_height: 3,
             fri_config: FriConfig {
-                proof_of_work_bits: 16,
+                proof_of_work_bits: 15,
                 reduction_strategy: FriReductionStrategy::ConstantArityBits(3, 5),
-                num_query_rounds: 28,
+                num_query_rounds: 26,
             },
         }
     }


### PR DESCRIPTION
For now, we can do shrinking recursion with 93 bits of security. It's not quite as high as we want, but it's close, and I think it makes sense to merge this and treat the 2^12 circuit as our main benchmark, as we continue working to improve security.