### PR TITLE
Reduce constant_gate_size to 5

### DIFF
--- a/src/hash/merkle_proofs.rs
+++ b/src/hash/merkle_proofs.rs
@@ -93,7 +93,7 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
         proof: &MerkleProofTarget,
     ) {
         let zero = self.zero();
-        let mut state: HashOutTarget = self.hash_or_noop(leaf_data);
+        let mut state = self.hash_or_noop(leaf_data);
 
         for (&bit, &sibling) in leaf_index_bits.iter().zip(&proof.siblings) {
             let mut perm_inputs = [zero; SPONGE_WIDTH];

--- a/src/plonk/circuit_data.rs
+++ b/src/plonk/circuit_data.rs
@@ -61,7 +61,7 @@ impl CircuitConfig {
         Self {
             num_wires: 135,
             num_routed_wires: 80,
-            constant_gate_size: 8,
+            constant_gate_size: 5,
             use_base_arithmetic_gate: true,
             security_bits: 93,
             rate_bits: 3,


### PR DESCRIPTION
This results in 8 constant polynomials, which means our Merkle tree containing preprocessed polynomials has leaves of size 80 + 8 = 88. A multiple of 8 is efficient in terms of how many gates it takes to hash a leaf. Saves 17 gates.