### PR TITLE
Require a `PrimeField` to be its own `PrimeField`

### DIFF
--- a/src/field/field_types.rs
+++ b/src/field/field_types.rs
@@ -404,7 +404,7 @@ pub trait Field:
 }
 
 /// A finite field of prime order less than 2^64.
-pub trait PrimeField: Field {
+pub trait PrimeField: Field<PrimeField = Self> {
     const ORDER: u64;
 
     /// The number of bits required to encode any field element.


### PR DESCRIPTION
My recent PackedField code closely mirrors the field trait hierarchy. It refused to compile without this guarantee, instead yielding a cryptic error message