### PR TITLE
Change gate evaluation memory layout

### DIFF
--- a/src/field/batch_util.rs
+++ b/src/field/batch_util.rs
@@ -1,0 +1,65 @@
+use crate::field::field_types::Field;
+use crate::field::packable::Packable;
+use crate::field::packed_field::PackedField;
+
+fn pack_with_leftovers_split_point<P: PackedField>(slice: &[P::Scalar]) -> usize {
+    let n = slice.len();
+    let n_leftover = n % P::WIDTH;
+    n - n_leftover
+}
+
+fn pack_slice_with_leftovers<P: PackedField>(slice: &[P::Scalar]) -> (&[P], &[P::Scalar]) {
+    let split_point = pack_with_leftovers_split_point::<P>(slice);
+    let (slice_packable, slice_leftovers) = slice.split_at(split_point);
+    let slice_packed = P::pack_slice(slice_packable);
+    (slice_packed, slice_leftovers)
+}
+
+fn pack_slice_with_leftovers_mut<P: PackedField>(
+    slice: &mut [P::Scalar],
+) -> (&mut [P], &mut [P::Scalar]) {
+    let split_point = pack_with_leftovers_split_point::<P>(slice);
+    let (slice_packable, slice_leftovers) = slice.split_at_mut(split_point);
+    let slice_packed = P::pack_slice_mut(slice_packable);
+    (slice_packed, slice_leftovers)
+}
+
+/// Elementwise inplace multiplication of two slices of field elements.
+/// Implementation be faster than the trivial for loop.
+pub fn batch_multiply_inplace<F: Field>(out: &mut [F], a: &[F]) {
+    let n = out.len();
+    assert_eq!(n, a.len(), "both arrays must have the same length");
+
+    // Split out slice of vectors, leaving leftovers as scalars
+    let (out_packed, out_leftovers) =
+        pack_slice_with_leftovers_mut::<<F as Packable>::Packing>(out);
+    let (a_packed, a_leftovers) = pack_slice_with_leftovers::<<F as Packable>::Packing>(a);
+
+    // Multiply packed and the leftovers
+    for (x_out, x_a) in out_packed.iter_mut().zip(a_packed) {
+        *x_out *= *x_a;
+    }
+    for (x_out, x_a) in out_leftovers.iter_mut().zip(a_leftovers) {
+        *x_out *= *x_a;
+    }
+}
+
+/// Elementwise inplace addition of two slices of field elements.
+/// Implementation be faster than the trivial for loop.
+pub fn batch_add_inplace<F: Field>(out: &mut [F], a: &[F]) {
+    let n = out.len();
+    assert_eq!(n, a.len(), "both arrays must have the same length");
+
+    // Split out slice of vectors, leaving leftovers as scalars
+    let (out_packed, out_leftovers) =
+        pack_slice_with_leftovers_mut::<<F as Packable>::Packing>(out);
+    let (a_packed, a_leftovers) = pack_slice_with_leftovers::<<F as Packable>::Packing>(a);
+
+    // Add packed and the leftovers
+    for (x_out, x_a) in out_packed.iter_mut().zip(a_packed) {
+        *x_out += *x_a;
+    }
+    for (x_out, x_a) in out_leftovers.iter_mut().zip(a_leftovers) {
+        *x_out += *x_a;
+    }
+}

--- a/src/field/mod.rs
+++ b/src/field/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod batch_util;
 pub(crate) mod cosets;
 pub mod extension_field;
 pub mod fft;

--- a/src/gates/arithmetic_u32.rs
+++ b/src/gates/arithmetic_u32.rs
@@ -6,6 +6,7 @@ use crate::field::extension_field::target::ExtensionTarget;
 use crate::field::extension_field::Extendable;
 use crate::field::field_types::{Field, RichField};
 use crate::gates::gate::Gate;
+use crate::gates::util::StridedConstraintConsumer;
 use crate::iop::generator::{GeneratedValues, SimpleGenerator, WitnessGenerator};
 use crate::iop::target::Target;
 use crate::iop::wire::Wire;
@@ -118,8 +119,11 @@ impl<F: RichField + Extendable<D>, const D: usize> Gate<F, D> for U32ArithmeticG
         constraints
     }
 
-    fn eval_unfiltered_base(&self, vars: EvaluationVarsBase<F>) -> Vec<F> {
-        let mut constraints = Vec::with_capacity(self.num_constraints());
+    fn eval_unfiltered_base_one(
+        &self,
+        vars: EvaluationVarsBase<F>,
+        mut yield_constr: StridedConstraintConsumer<F>,
+    ) {
         for i in 0..self.num_ops {
             let multiplicand_0 = vars.local_wires[self.wire_ith_multiplicand_0(i)];
             let multiplicand_1 = vars.local_wires[self.wire_ith_multiplicand_1(i)];
@@ -133,7 +137,7 @@ impl<F: RichField + Extendable<D>, const D: usize> Gate<F, D> for U32ArithmeticG
             let base = F::from_canonical_u64(1 << 32u64);
             let combined_output = output_high * base + output_low;
 
-            constraints.push(combined_output - computed_output);
+            yield_constr.one(combined_output - computed_output);
 
             let mut combined_low_limbs = F::ZERO;
             let mut combined_high_limbs = F::ZERO;
@@ -145,7 +149,7 @@ impl<F: RichField + Extendable<D>, const D: usize> Gate<F, D> for U32ArithmeticG
                 let product = (0..max_limb)
                     .map(|x| this_limb - F::from_canonical_usize(x))
                     .product();
-                constraints.push(product);
+                yield_constr.one(product);
 
                 if j < midpoint {
                     combined_low_limbs = base * combined_low_limbs + this_limb;
@@ -153,11 +157,9 @@ impl<F: RichField + Extendable<D>, const D: usize> Gate<F, D> for U32ArithmeticG
                     combined_high_limbs = base * combined_high_limbs + this_limb;
                 }
             }
-            constraints.push(combined_low_limbs - output_low);
-            constraints.push(combined_high_limbs - output_high);
+            yield_constr.one(combined_low_limbs - output_low);
+            yield_constr.one(combined_high_limbs - output_high);
         }
-
-        constraints
     }
 
     fn eval_unfiltered_recursively(

--- a/src/gates/base_sum.rs
+++ b/src/gates/base_sum.rs
@@ -4,6 +4,7 @@ use crate::field::extension_field::target::ExtensionTarget;
 use crate::field::extension_field::Extendable;
 use crate::field::field_types::{Field, PrimeField, RichField};
 use crate::gates::gate::Gate;
+use crate::gates::util::StridedConstraintConsumer;
 use crate::iop::generator::{GeneratedValues, SimpleGenerator, WitnessGenerator};
 use crate::iop::target::Target;
 use crate::iop::witness::{PartitionWitness, Witness};
@@ -57,22 +58,23 @@ impl<F: RichField + Extendable<D>, const D: usize, const B: usize> Gate<F, D> fo
         constraints
     }
 
-    fn eval_unfiltered_base(&self, vars: EvaluationVarsBase<F>) -> Vec<F> {
+    fn eval_unfiltered_base_one(
+        &self,
+        vars: EvaluationVarsBase<F>,
+        mut yield_constr: StridedConstraintConsumer<F>,
+    ) {
         let sum = vars.local_wires[Self::WIRE_SUM];
-        let limbs = &vars.local_wires[self.limbs()];
+        let limbs = vars.local_wires.view(self.limbs());
         let computed_sum = reduce_with_powers(limbs, F::from_canonical_usize(B));
 
-        let mut constraints = Vec::with_capacity(limbs.len() + 1);
-        constraints.push(computed_sum - sum);
+        yield_constr.one(computed_sum - sum);
 
         let constraints_iter = limbs.iter().map(|&limb| {
             (0..B)
                 .map(|i| unsafe { limb.sub_canonical_u64(i as u64) })
                 .product::<F>()
         });
-        constraints.extend(constraints_iter);
-
-        constraints
+        yield_constr.many(constraints_iter);
     }
 
     fn eval_unfiltered_recursively(

--- a/src/gates/constant.rs
+++ b/src/gates/constant.rs
@@ -4,6 +4,7 @@ use crate::field::extension_field::target::ExtensionTarget;
 use crate::field::extension_field::Extendable;
 use crate::field::field_types::{Field, RichField};
 use crate::gates::gate::Gate;
+use crate::gates::util::StridedConstraintConsumer;
 use crate::iop::generator::{GeneratedValues, SimpleGenerator, WitnessGenerator};
 use crate::iop::target::Target;
 use crate::iop::wire::Wire;
@@ -39,11 +40,16 @@ impl<F: RichField + Extendable<D>, const D: usize> Gate<F, D> for ConstantGate {
             .collect()
     }
 
-    fn eval_unfiltered_base(&self, vars: EvaluationVarsBase<F>) -> Vec<F> {
-        self.consts_inputs()
-            .zip(self.wires_outputs())
-            .map(|(con, out)| vars.local_constants[con] - vars.local_wires[out])
-            .collect()
+    fn eval_unfiltered_base_one(
+        &self,
+        vars: EvaluationVarsBase<F>,
+        mut yield_constr: StridedConstraintConsumer<F>,
+    ) {
+        yield_constr.many(
+            self.consts_inputs()
+                .zip(self.wires_outputs())
+                .map(|(con, out)| vars.local_constants[con] - vars.local_wires[out]),
+        );
     }
 
     fn eval_unfiltered_recursively(

--- a/src/gates/exponentiation.rs
+++ b/src/gates/exponentiation.rs
@@ -4,6 +4,7 @@ use crate::field::extension_field::target::ExtensionTarget;
 use crate::field::extension_field::Extendable;
 use crate::field::field_types::{Field, RichField};
 use crate::gates::gate::Gate;
+use crate::gates::util::StridedConstraintConsumer;
 use crate::iop::generator::{GeneratedValues, SimpleGenerator, WitnessGenerator};
 use crate::iop::target::Target;
 use crate::iop::wire::Wire;
@@ -99,7 +100,11 @@ impl<F: RichField + Extendable<D>, const D: usize> Gate<F, D> for Exponentiation
         constraints
     }
 
-    fn eval_unfiltered_base(&self, vars: EvaluationVarsBase<F>) -> Vec<F> {
+    fn eval_unfiltered_base_one(
+        &self,
+        vars: EvaluationVarsBase<F>,
+        mut yield_constr: StridedConstraintConsumer<F>,
+    ) {
         let base = vars.local_wires[self.wire_base()];
 
         let power_bits: Vec<_> = (0..self.num_power_bits)
@@ -110,8 +115,6 @@ impl<F: RichField + Extendable<D>, const D: usize> Gate<F, D> for Exponentiation
             .collect();
 
         let output = vars.local_wires[self.wire_output()];
-
-        let mut constraints = Vec::with_capacity(self.num_constraints());
 
         for i in 0..self.num_power_bits {
             let prev_intermediate_value = if i == 0 {
@@ -126,12 +129,10 @@ impl<F: RichField + Extendable<D>, const D: usize> Gate<F, D> for Exponentiation
             let not_cur_bit = F::ONE - cur_bit;
             let computed_intermediate_value =
                 prev_intermediate_value * (cur_bit * base + not_cur_bit);
-            constraints.push(computed_intermediate_value - intermediate_values[i]);
+            yield_constr.one(computed_intermediate_value - intermediate_values[i]);
         }
 
-        constraints.push(output - intermediate_values[self.num_power_bits - 1]);
-
-        constraints
+        yield_constr.one(output - intermediate_values[self.num_power_bits - 1]);
     }
 
     fn eval_unfiltered_recursively(

--- a/src/gates/gate.rs
+++ b/src/gates/gate.rs
@@ -2,13 +2,17 @@ use std::fmt::{Debug, Error, Formatter};
 use std::hash::{Hash, Hasher};
 use std::sync::Arc;
 
+use crate::field::batch_util::batch_multiply_inplace;
 use crate::field::extension_field::target::ExtensionTarget;
 use crate::field::extension_field::{Extendable, FieldExtension};
 use crate::field::field_types::{Field, RichField};
 use crate::gates::gate_tree::Tree;
+use crate::gates::util::StridedConstraintConsumer;
 use crate::iop::generator::WitnessGenerator;
 use crate::plonk::circuit_builder::CircuitBuilder;
-use crate::plonk::vars::{EvaluationTargets, EvaluationVars, EvaluationVarsBase};
+use crate::plonk::vars::{
+    EvaluationTargets, EvaluationVars, EvaluationVarsBase, EvaluationVarsBaseBatch,
+};
 
 /// A custom gate.
 pub trait Gate<F: RichField + Extendable<D>, const D: usize>: 'static + Send + Sync {
@@ -18,9 +22,19 @@ pub trait Gate<F: RichField + Extendable<D>, const D: usize>: 'static + Send + S
 
     /// Like `eval_unfiltered`, but specialized for points in the base field.
     ///
+    ///
+    /// `eval_unfiltered_base_batch` calls this method by default. If `eval_unfiltered_base_batch`
+    /// is overridden, then `eval_unfiltered_base_one` is not necessary.
+    ///
     /// By default, this just calls `eval_unfiltered`, which treats the point as an extension field
     /// element. This isn't very efficient.
-    fn eval_unfiltered_base(&self, vars_base: EvaluationVarsBase<F>) -> Vec<F> {
+    fn eval_unfiltered_base_one(
+        &self,
+        vars_base: EvaluationVarsBase<F>,
+        mut yield_constr: StridedConstraintConsumer<F>,
+    ) {
+        // Note that this method uses `yield_constr` instead of returning its constraints.
+        // `yield_constr` abstracts out the underlying memory layout.
         let local_constants = &vars_base
             .local_constants
             .iter()
@@ -40,13 +54,21 @@ pub trait Gate<F: RichField + Extendable<D>, const D: usize>: 'static + Send + S
         let values = self.eval_unfiltered(vars);
 
         // Each value should be in the base field, i.e. only the degree-zero part should be nonzero.
-        values
-            .into_iter()
-            .map(|value| {
-                debug_assert!(F::Extension::is_in_basefield(&value));
-                value.to_basefield_array()[0]
-            })
-            .collect()
+        values.into_iter().for_each(|value| {
+            debug_assert!(F::Extension::is_in_basefield(&value));
+            yield_constr.one(value.to_basefield_array()[0])
+        })
+    }
+
+    fn eval_unfiltered_base_batch(&self, vars_base: EvaluationVarsBaseBatch<F>) -> Vec<F> {
+        let mut res = vec![F::ZERO; vars_base.len() * self.num_constraints()];
+        for (i, vars_base_one) in vars_base.iter().enumerate() {
+            self.eval_unfiltered_base_one(
+                vars_base_one,
+                StridedConstraintConsumer::new(&mut res, vars_base.len(), i),
+            );
+        }
+        res
     }
 
     fn eval_unfiltered_recursively(
@@ -64,26 +86,23 @@ pub trait Gate<F: RichField + Extendable<D>, const D: usize>: 'static + Send + S
             .collect()
     }
 
-    /// Like `eval_filtered`, but specialized for points in the base field.
-    fn eval_filtered_base(&self, mut vars: EvaluationVarsBase<F>, prefix: &[bool]) -> Vec<F> {
-        let filter = compute_filter(prefix, vars.local_constants);
-        vars.remove_prefix(prefix);
-        let mut res = self.eval_unfiltered_base(vars);
-        res.iter_mut().for_each(|c| {
-            *c *= filter;
-        });
-        res
-    }
-
+    /// The result is an array of length `vars_batch.len() * self.num_constraints()`. Constraint `j`
+    /// for point `i` is at index `j * batch_size + i`.
     fn eval_filtered_base_batch(
         &self,
-        vars_batch: &[EvaluationVarsBase<F>],
+        mut vars_batch: EvaluationVarsBaseBatch<F>,
         prefix: &[bool],
-    ) -> Vec<Vec<F>> {
-        vars_batch
+    ) -> Vec<F> {
+        let filters: Vec<_> = vars_batch
             .iter()
-            .map(|&vars| self.eval_filtered_base(vars, prefix))
-            .collect()
+            .map(|vars| compute_filter(prefix, vars.local_constants))
+            .collect();
+        vars_batch.remove_prefix(prefix);
+        let mut res_batch = self.eval_unfiltered_base_batch(vars_batch);
+        for res_chunk in res_batch.chunks_exact_mut(filters.len()) {
+            batch_multiply_inplace(res_chunk, &filters);
+        }
+        res_batch
     }
 
     /// Adds this gate's filtered constraints into the `combined_gate_constraints` buffer.
@@ -174,17 +193,11 @@ impl<F: RichField + Extendable<D>, const D: usize> PrefixedGate<F, D> {
 
 /// A gate's filter is computed as `prod b_i*c_i + (1-b_i)*(1-c_i)`, with `(b_i)` the prefix and
 /// `(c_i)` the local constants, which is one if the prefix of `constants` matches `prefix`.
-fn compute_filter<K: Field>(prefix: &[bool], constants: &[K]) -> K {
+fn compute_filter<'a, K: Field, T: IntoIterator<Item = &'a K>>(prefix: &[bool], constants: T) -> K {
     prefix
         .iter()
-        .enumerate()
-        .map(|(i, &b)| {
-            if b {
-                constants[i]
-            } else {
-                K::ONE - constants[i]
-            }
-        })
+        .zip(constants)
+        .map(|(&b, &c)| if b { c } else { K::ONE - c })
         .product()
 }
 

--- a/src/gates/gate_testing.rs
+++ b/src/gates/gate_testing.rs
@@ -7,7 +7,7 @@ use crate::hash::hash_types::HashOut;
 use crate::iop::witness::{PartialWitness, Witness};
 use crate::plonk::circuit_builder::CircuitBuilder;
 use crate::plonk::circuit_data::CircuitConfig;
-use crate::plonk::vars::{EvaluationTargets, EvaluationVars, EvaluationVarsBase};
+use crate::plonk::vars::{EvaluationTargets, EvaluationVars, EvaluationVarsBaseBatch};
 use crate::plonk::verifier::verify;
 use crate::polynomial::{PolynomialCoeffs, PolynomialValues};
 use crate::util::{log2_ceil, transpose};
@@ -100,19 +100,18 @@ pub(crate) fn test_eval_fns<F: RichField + Extendable<D>, G: Gate<F, D>, const D
         .collect::<Vec<_>>();
     let public_inputs_hash = HashOut::rand();
 
-    let vars_base = EvaluationVarsBase {
-        local_constants: &constants_base,
-        local_wires: &wires_base,
-        public_inputs_hash: &public_inputs_hash,
-    };
+    // Batch of 1.
+    let vars_base_batch =
+        EvaluationVarsBaseBatch::new(1, &constants_base, &wires_base, &public_inputs_hash);
     let vars = EvaluationVars {
         local_constants: &constants,
         local_wires: &wires,
         public_inputs_hash: &public_inputs_hash,
     };
 
-    let evals_base = gate.eval_unfiltered_base(vars_base);
+    let evals_base = gate.eval_unfiltered_base_batch(vars_base_batch);
     let evals = gate.eval_unfiltered(vars);
+    // This works because we have a batch of 1.
     ensure!(
         evals
             == evals_base

--- a/src/gates/insertion.rs
+++ b/src/gates/insertion.rs
@@ -5,6 +5,7 @@ use crate::field::extension_field::target::ExtensionTarget;
 use crate::field::extension_field::{Extendable, FieldExtension};
 use crate::field::field_types::{Field, RichField};
 use crate::gates::gate::Gate;
+use crate::gates::util::StridedConstraintConsumer;
 use crate::iop::generator::{GeneratedValues, SimpleGenerator, WitnessGenerator};
 use crate::iop::target::Target;
 use crate::iop::wire::Wire;
@@ -112,7 +113,11 @@ impl<F: RichField + Extendable<D>, const D: usize> Gate<F, D> for InsertionGate<
         constraints
     }
 
-    fn eval_unfiltered_base(&self, vars: EvaluationVarsBase<F>) -> Vec<F> {
+    fn eval_unfiltered_base_one(
+        &self,
+        vars: EvaluationVarsBase<F>,
+        mut yield_constr: StridedConstraintConsumer<F>,
+    ) {
         let insertion_index = vars.local_wires[self.wires_insertion_index()];
         let list_items = (0..self.vec_size)
             .map(|i| vars.get_local_ext(self.wires_original_list_item(i)))
@@ -122,7 +127,6 @@ impl<F: RichField + Extendable<D>, const D: usize> Gate<F, D> for InsertionGate<
             .collect::<Vec<_>>();
         let element_to_insert = vars.get_local_ext(self.wires_element_to_insert());
 
-        let mut constraints = Vec::with_capacity(self.num_constraints());
         let mut already_inserted = F::ZERO;
         for r in 0..=self.vec_size {
             let cur_index = F::from_canonical_usize(r);
@@ -131,8 +135,8 @@ impl<F: RichField + Extendable<D>, const D: usize> Gate<F, D> for InsertionGate<
             let insert_here = vars.local_wires[self.wire_insert_here_for_round_r(r)];
 
             // The two equality constraints.
-            constraints.push(difference * equality_dummy - (F::ONE - insert_here));
-            constraints.push(insert_here * difference);
+            yield_constr.one(difference * equality_dummy - (F::ONE - insert_here));
+            yield_constr.one(insert_here * difference);
 
             let mut new_item = element_to_insert.scalar_mul(insert_here);
             if r > 0 {
@@ -144,10 +148,8 @@ impl<F: RichField + Extendable<D>, const D: usize> Gate<F, D> for InsertionGate<
             }
 
             // Output constraint.
-            constraints.extend((new_item - output_list_items[r]).to_basefield_array());
+            yield_constr.many((new_item - output_list_items[r]).to_basefield_array());
         }
-
-        constraints
     }
 
     fn eval_unfiltered_recursively(

--- a/src/gates/interpolation.rs
+++ b/src/gates/interpolation.rs
@@ -9,6 +9,7 @@ use crate::field::interpolation::interpolant;
 use crate::gadgets::interpolation::InterpolationGate;
 use crate::gadgets::polynomial::PolynomialCoeffsExtAlgebraTarget;
 use crate::gates::gate::Gate;
+use crate::gates::util::StridedConstraintConsumer;
 use crate::iop::generator::{GeneratedValues, SimpleGenerator, WitnessGenerator};
 use crate::iop::target::Target;
 use crate::iop::wire::Wire;
@@ -109,9 +110,11 @@ impl<F: RichField + Extendable<D>, const D: usize> Gate<F, D>
         constraints
     }
 
-    fn eval_unfiltered_base(&self, vars: EvaluationVarsBase<F>) -> Vec<F> {
-        let mut constraints = Vec::with_capacity(self.num_constraints());
-
+    fn eval_unfiltered_base_one(
+        &self,
+        vars: EvaluationVarsBase<F>,
+        mut yield_constr: StridedConstraintConsumer<F>,
+    ) {
         let coeffs = (0..self.num_points())
             .map(|i| vars.get_local_ext(self.wires_coeff(i)))
             .collect();
@@ -121,15 +124,13 @@ impl<F: RichField + Extendable<D>, const D: usize> Gate<F, D>
         for (i, point) in coset.into_iter().enumerate() {
             let value = vars.get_local_ext(self.wires_value(i));
             let computed_value = interpolant.eval_base(point);
-            constraints.extend(&(value - computed_value).to_basefield_array());
+            yield_constr.many((value - computed_value).to_basefield_array());
         }
 
         let evaluation_point = vars.get_local_ext(self.wires_evaluation_point());
         let evaluation_value = vars.get_local_ext(self.wires_evaluation_value());
         let computed_evaluation_value = interpolant.eval(evaluation_point);
-        constraints.extend(&(evaluation_value - computed_evaluation_value).to_basefield_array());
-
-        constraints
+        yield_constr.many((evaluation_value - computed_evaluation_value).to_basefield_array());
     }
 
     fn eval_unfiltered_recursively(

--- a/src/gates/mod.rs
+++ b/src/gates/mod.rs
@@ -25,6 +25,7 @@ pub mod reducing;
 pub mod reducing_extension;
 pub mod subtraction_u32;
 pub mod switch;
+mod util;
 
 #[cfg(test)]
 mod gate_testing;

--- a/src/gates/noop.rs
+++ b/src/gates/noop.rs
@@ -4,7 +4,7 @@ use crate::field::field_types::RichField;
 use crate::gates::gate::Gate;
 use crate::iop::generator::WitnessGenerator;
 use crate::plonk::circuit_builder::CircuitBuilder;
-use crate::plonk::vars::{EvaluationTargets, EvaluationVars, EvaluationVarsBase};
+use crate::plonk::vars::{EvaluationTargets, EvaluationVars, EvaluationVarsBaseBatch};
 
 /// A gate which does nothing.
 pub struct NoopGate;
@@ -18,7 +18,7 @@ impl<F: RichField + Extendable<D>, const D: usize> Gate<F, D> for NoopGate {
         Vec::new()
     }
 
-    fn eval_unfiltered_base(&self, _vars: EvaluationVarsBase<F>) -> Vec<F> {
+    fn eval_unfiltered_base_batch(&self, _vars: EvaluationVarsBaseBatch<F>) -> Vec<F> {
         Vec::new()
     }
 

--- a/src/gates/public_input.rs
+++ b/src/gates/public_input.rs
@@ -4,6 +4,7 @@ use crate::field::extension_field::target::ExtensionTarget;
 use crate::field::extension_field::Extendable;
 use crate::field::field_types::RichField;
 use crate::gates::gate::Gate;
+use crate::gates::util::StridedConstraintConsumer;
 use crate::iop::generator::WitnessGenerator;
 use crate::plonk::circuit_builder::CircuitBuilder;
 use crate::plonk::vars::{EvaluationTargets, EvaluationVars, EvaluationVarsBase};
@@ -29,11 +30,16 @@ impl<F: RichField + Extendable<D>, const D: usize> Gate<F, D> for PublicInputGat
             .collect()
     }
 
-    fn eval_unfiltered_base(&self, vars: EvaluationVarsBase<F>) -> Vec<F> {
-        Self::wires_public_inputs_hash()
-            .zip(vars.public_inputs_hash.elements)
-            .map(|(wire, hash_part)| vars.local_wires[wire] - hash_part)
-            .collect()
+    fn eval_unfiltered_base_one(
+        &self,
+        vars: EvaluationVarsBase<F>,
+        mut yield_constr: StridedConstraintConsumer<F>,
+    ) {
+        yield_constr.many(
+            Self::wires_public_inputs_hash()
+                .zip(vars.public_inputs_hash.elements)
+                .map(|(wire, hash_part)| vars.local_wires[wire] - hash_part),
+        )
     }
 
     fn eval_unfiltered_recursively(

--- a/src/gates/random_access.rs
+++ b/src/gates/random_access.rs
@@ -6,6 +6,7 @@ use crate::field::extension_field::target::ExtensionTarget;
 use crate::field::extension_field::Extendable;
 use crate::field::field_types::{Field, RichField};
 use crate::gates::gate::Gate;
+use crate::gates::util::StridedConstraintConsumer;
 use crate::iop::generator::{GeneratedValues, SimpleGenerator, WitnessGenerator};
 use crate::iop::target::Target;
 use crate::iop::wire::Wire;
@@ -125,9 +126,11 @@ impl<F: RichField + Extendable<D>, const D: usize> Gate<F, D> for RandomAccessGa
         constraints
     }
 
-    fn eval_unfiltered_base(&self, vars: EvaluationVarsBase<F>) -> Vec<F> {
-        let mut constraints = Vec::with_capacity(self.num_constraints());
-
+    fn eval_unfiltered_base_one(
+        &self,
+        vars: EvaluationVarsBase<F>,
+        mut yield_constr: StridedConstraintConsumer<F>,
+    ) {
         for copy in 0..self.num_copies {
             let access_index = vars.local_wires[self.wire_access_index(copy)];
             let mut list_items = (0..self.vec_size())
@@ -140,12 +143,12 @@ impl<F: RichField + Extendable<D>, const D: usize> Gate<F, D> for RandomAccessGa
 
             // Assert that each bit wire value is indeed boolean.
             for &b in &bits {
-                constraints.push(b * (b - F::ONE));
+                yield_constr.one(b * (b - F::ONE));
             }
 
             // Assert that the binary decomposition was correct.
             let reconstructed_index = bits.iter().rev().fold(F::ZERO, |acc, &b| acc.double() + b);
-            constraints.push(reconstructed_index - access_index);
+            yield_constr.one(reconstructed_index - access_index);
 
             // Repeatedly fold the list, selecting the left or right item from each pair based on
             // the corresponding bit.
@@ -158,10 +161,8 @@ impl<F: RichField + Extendable<D>, const D: usize> Gate<F, D> for RandomAccessGa
             }
 
             debug_assert_eq!(list_items.len(), 1);
-            constraints.push(list_items[0] - claimed_element);
+            yield_constr.one(list_items[0] - claimed_element);
         }
-
-        constraints
     }
 
     fn eval_unfiltered_recursively(

--- a/src/gates/reducing.rs
+++ b/src/gates/reducing.rs
@@ -5,6 +5,7 @@ use crate::field::extension_field::Extendable;
 use crate::field::extension_field::FieldExtension;
 use crate::field::field_types::RichField;
 use crate::gates::gate::Gate;
+use crate::gates::util::StridedConstraintConsumer;
 use crate::iop::generator::{GeneratedValues, SimpleGenerator, WitnessGenerator};
 use crate::iop::target::Target;
 use crate::iop::witness::{PartitionWitness, Witness};
@@ -80,7 +81,11 @@ impl<F: RichField + Extendable<D>, const D: usize> Gate<F, D> for ReducingGate<D
             .collect()
     }
 
-    fn eval_unfiltered_base(&self, vars: EvaluationVarsBase<F>) -> Vec<F> {
+    fn eval_unfiltered_base_one(
+        &self,
+        vars: EvaluationVarsBase<F>,
+        mut yield_constr: StridedConstraintConsumer<F>,
+    ) {
         let alpha = vars.get_local_ext(Self::wires_alpha());
         let old_acc = vars.get_local_ext(Self::wires_old_acc());
         let coeffs = self
@@ -91,14 +96,11 @@ impl<F: RichField + Extendable<D>, const D: usize> Gate<F, D> for ReducingGate<D
             .map(|i| vars.get_local_ext(self.wires_accs(i)))
             .collect::<Vec<_>>();
 
-        let mut constraints = Vec::with_capacity(<Self as Gate<F, D>>::num_constraints(self));
         let mut acc = old_acc;
         for i in 0..self.num_coeffs {
-            constraints.extend((acc * alpha + coeffs[i].into() - accs[i]).to_basefield_array());
+            yield_constr.many((acc * alpha + coeffs[i].into() - accs[i]).to_basefield_array());
             acc = accs[i];
         }
-
-        constraints
     }
 
     fn eval_unfiltered_recursively(

--- a/src/gates/switch.rs
+++ b/src/gates/switch.rs
@@ -6,6 +6,7 @@ use crate::field::extension_field::target::ExtensionTarget;
 use crate::field::extension_field::Extendable;
 use crate::field::field_types::{Field, RichField};
 use crate::gates::gate::Gate;
+use crate::gates::util::StridedConstraintConsumer;
 use crate::iop::generator::{GeneratedValues, WitnessGenerator};
 use crate::iop::target::Target;
 use crate::iop::wire::Wire;
@@ -94,9 +95,11 @@ impl<F: RichField + Extendable<D>, const D: usize> Gate<F, D> for SwitchGate<F, 
         constraints
     }
 
-    fn eval_unfiltered_base(&self, vars: EvaluationVarsBase<F>) -> Vec<F> {
-        let mut constraints = Vec::with_capacity(self.num_constraints());
-
+    fn eval_unfiltered_base_one(
+        &self,
+        vars: EvaluationVarsBase<F>,
+        mut yield_constr: StridedConstraintConsumer<F>,
+    ) {
         for c in 0..self.num_copies {
             let switch_bool = vars.local_wires[self.wire_switch_bool(c)];
             let not_switch = F::ONE - switch_bool;
@@ -107,14 +110,12 @@ impl<F: RichField + Extendable<D>, const D: usize> Gate<F, D> for SwitchGate<F, 
                 let first_output = vars.local_wires[self.wire_first_output(c, e)];
                 let second_output = vars.local_wires[self.wire_second_output(c, e)];
 
-                constraints.push(switch_bool * (first_input - second_output));
-                constraints.push(switch_bool * (second_input - first_output));
-                constraints.push(not_switch * (first_input - first_output));
-                constraints.push(not_switch * (second_input - second_output));
+                yield_constr.one(switch_bool * (first_input - second_output));
+                yield_constr.one(switch_bool * (second_input - first_output));
+                yield_constr.one(not_switch * (first_input - first_output));
+                yield_constr.one(not_switch * (second_input - second_output));
             }
         }
-
-        constraints
     }
 
     fn eval_unfiltered_recursively(

--- a/src/gates/util.rs
+++ b/src/gates/util.rs
@@ -1,0 +1,62 @@
+use std::marker::PhantomData;
+
+use crate::field::field_types::Field;
+
+/// Writes constraints yielded by a gate to a buffer, with a given stride.
+/// Permits us to abstract the underlying memory layout. In particular, we can make a matrix of
+/// constraints where every column is an evaluation point and every row is a constraint index, with
+/// the matrix stored in row-contiguous form.
+pub struct StridedConstraintConsumer<'a, F: Field> {
+    // This is a particularly neat way of doing this, more so than a slice. We increase start by
+    // stride at every step and terminate when it equals end.
+    start: *mut F,
+    end: *mut F,
+    stride: usize,
+    _phantom: PhantomData<&'a mut [F]>,
+}
+
+impl<'a, F: Field> StridedConstraintConsumer<'a, F> {
+    pub fn new(buffer: &'a mut [F], stride: usize, offset: usize) -> Self {
+        assert!(offset < stride);
+        assert_eq!(buffer.len() % stride, 0);
+        let ptr_range = buffer.as_mut_ptr_range();
+        // `wrapping_add` is needed to avoid undefined behavior. Plain `add` causes UB if 'the ...
+        // resulting pointer [is neither] in bounds or one byte past the end of the same allocated
+        // object'; the UB results even if the pointer is not dereferenced. `end` will be more than
+        // one byte past the buffer unless `offset` is 0. The same applies to `start` if the buffer
+        // has length 0 and the offset is not 0.
+        // We _could_ do pointer arithmetic without `wrapping_add`, but the logic would be
+        // unnecessarily complicated.
+        let start = ptr_range.start.wrapping_add(offset);
+        let end = ptr_range.end.wrapping_add(offset);
+        Self {
+            start,
+            end,
+            stride,
+            _phantom: PhantomData,
+        }
+    }
+
+    /// Emit one constraint.
+    pub fn one(&mut self, constraint: F) {
+        if self.start != self.end {
+            // # Safety
+            // The checks in `new` guarantee that this points to valid space.
+            unsafe {
+                *self.start = constraint;
+            }
+            // See the comment in `new`. `wrapping_add` is needed to avoid UB if we've just
+            // exhausted our buffer (and hence we're setting `self.start` to point past the end).
+            self.start = self.start.wrapping_add(self.stride);
+        } else {
+            panic!("gate produced too many constraints");
+        }
+    }
+
+    /// Convenience method that calls `.one()` multiple times.
+    pub fn many<I: IntoIterator<Item = F>>(&mut self, constraints: I) {
+        constraints
+            .into_iter()
+            .for_each(|constraint| self.one(constraint));
+    }
+}

--- a/src/plonk/plonk_common.rs
+++ b/src/plonk/plonk_common.rs
@@ -157,9 +157,15 @@ pub(crate) fn reduce_with_powers_multi<
     cumul
 }
 
-pub(crate) fn reduce_with_powers<F: Field>(terms: &[F], alpha: F) -> F {
+pub(crate) fn reduce_with_powers<'a, F: Field, T: IntoIterator<Item = &'a F>>(
+    terms: T,
+    alpha: F,
+) -> F
+where
+    T::IntoIter: DoubleEndedIterator,
+{
     let mut sum = F::ZERO;
-    for &term in terms.iter().rev() {
+    for &term in terms.into_iter().rev() {
         sum = sum * alpha + term;
     }
     sum

--- a/src/plonk/vars.rs
+++ b/src/plonk/vars.rs
@@ -5,6 +5,7 @@ use crate::field::extension_field::target::{ExtensionAlgebraTarget, ExtensionTar
 use crate::field::extension_field::{Extendable, FieldExtension};
 use crate::field::field_types::Field;
 use crate::hash::hash_types::{HashOut, HashOutTarget};
+use crate::util::strided_view::PackedStridedView;
 
 #[derive(Debug, Copy, Clone)]
 pub struct EvaluationVars<'a, F: Extendable<D>, const D: usize> {
@@ -13,10 +14,22 @@ pub struct EvaluationVars<'a, F: Extendable<D>, const D: usize> {
     pub(crate) public_inputs_hash: &'a HashOut<F>,
 }
 
+/// A batch of evaluation vars, in the base field.
+/// Wires and constants are stored in an evaluation point-major order (that is, wire 0 for all
+/// evaluation points, then wire 1 for all points, and so on).
 #[derive(Debug, Copy, Clone)]
-pub struct EvaluationVarsBase<'a, F: Field> {
+pub struct EvaluationVarsBaseBatch<'a, F: Field> {
+    batch_size: usize,
     pub(crate) local_constants: &'a [F],
     pub(crate) local_wires: &'a [F],
+    pub(crate) public_inputs_hash: &'a HashOut<F>,
+}
+
+/// A view into `EvaluationVarsBaseBatch` for a particular evaluation point. Does not copy the data.
+#[derive(Debug, Copy, Clone)]
+pub struct EvaluationVarsBase<'a, F: Field> {
+    pub(crate) local_constants: PackedStridedView<'a, F>,
+    pub(crate) local_wires: PackedStridedView<'a, F>,
     pub(crate) public_inputs_hash: &'a HashOut<F>,
 }
 
@@ -35,18 +48,81 @@ impl<'a, F: Extendable<D>, const D: usize> EvaluationVars<'a, F, D> {
     }
 }
 
+impl<'a, F: Field> EvaluationVarsBaseBatch<'a, F> {
+    pub fn new(
+        batch_size: usize,
+        local_constants: &'a [F],
+        local_wires: &'a [F],
+        public_inputs_hash: &'a HashOut<F>,
+    ) -> Self {
+        assert_eq!(local_constants.len() % batch_size, 0);
+        assert_eq!(local_wires.len() % batch_size, 0);
+        Self {
+            batch_size,
+            local_constants,
+            local_wires,
+            public_inputs_hash,
+        }
+    }
+
+    pub fn remove_prefix(&mut self, prefix: &[bool]) {
+        self.local_constants = &self.local_constants[prefix.len() * self.len()..];
+    }
+
+    pub fn len(&self) -> usize {
+        self.batch_size
+    }
+
+    pub fn view(&self, index: usize) -> EvaluationVarsBase<'a, F> {
+        // We cannot implement `Index` as `EvaluationVarsBase` is a struct, not a reference.
+        assert!(index < self.len());
+        let local_constants = PackedStridedView::new(self.local_constants, self.len(), index);
+        let local_wires = PackedStridedView::new(self.local_wires, self.len(), index);
+        EvaluationVarsBase {
+            local_constants,
+            local_wires,
+            public_inputs_hash: self.public_inputs_hash,
+        }
+    }
+
+    pub fn iter(&self) -> EvaluationVarsBaseBatchIter<'a, F> {
+        EvaluationVarsBaseBatchIter::new(*self)
+    }
+}
+
 impl<'a, F: Field> EvaluationVarsBase<'a, F> {
     pub fn get_local_ext<const D: usize>(&self, wire_range: Range<usize>) -> F::Extension
     where
         F: Extendable<D>,
     {
         debug_assert_eq!(wire_range.len(), D);
-        let arr = self.local_wires[wire_range].try_into().unwrap();
+        let arr = self.local_wires.view(wire_range).try_into().unwrap();
         F::Extension::from_basefield_array(arr)
     }
+}
 
-    pub fn remove_prefix(&mut self, prefix: &[bool]) {
-        self.local_constants = &self.local_constants[prefix.len()..];
+/// Iterator of views (`EvaluationVarsBase`) into a `EvaluationVarsBaseBatch`.
+pub struct EvaluationVarsBaseBatchIter<'a, F: Field> {
+    i: usize,
+    vars_batch: EvaluationVarsBaseBatch<'a, F>,
+}
+
+impl<'a, F: Field> EvaluationVarsBaseBatchIter<'a, F> {
+    pub fn new(vars_batch: EvaluationVarsBaseBatch<'a, F>) -> Self {
+        EvaluationVarsBaseBatchIter { i: 0, vars_batch }
+    }
+}
+
+impl<'a, F: Field> Iterator for EvaluationVarsBaseBatchIter<'a, F> {
+    type Item = EvaluationVarsBase<'a, F>;
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.i < self.vars_batch.len() {
+            let res = self.vars_batch.view(self.i);
+            self.i += 1;
+            Some(res)
+        } else {
+            None
+        }
     }
 }
 

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -10,6 +10,7 @@ pub(crate) mod marking;
 pub(crate) mod partial_products;
 pub mod reducing;
 pub mod serialization;
+pub(crate) mod strided_view;
 pub(crate) mod timing;
 
 pub(crate) fn bits_u64(n: u64) -> usize {

--- a/src/util/strided_view.rs
+++ b/src/util/strided_view.rs
@@ -1,0 +1,317 @@
+use std::marker::PhantomData;
+use std::mem::size_of;
+use std::ops::{Index, Range, RangeFrom, RangeFull, RangeInclusive, RangeTo, RangeToInclusive};
+
+use crate::field::packed_field::PackedField;
+
+/// Imagine a slice, but with a stride (a la a NumPy array).
+///
+/// For example, if the stride is 3,
+///     `packed_strided_view[0]` is `data[0]`,
+///     `packed_strided_view[1]` is `data[3]`,
+///     `packed_strided_view[2]` is `data[6]`,
+/// and so on. An offset may be specified. With an offset of 1, we get
+///     `packed_strided_view[0]` is `data[1]`,
+///     `packed_strided_view[1]` is `data[4]`,
+///     `packed_strided_view[2]` is `data[7]`,
+/// and so on.
+///
+/// Additionally, this view is *packed*, which means that it may yield a packing of the underlying
+/// field slice. With a packing of width 4 and a stride of 5, the accesses are
+///     `packed_strided_view[0]` is `data[0..4]`, transmuted to the packing,
+///     `packed_strided_view[1]` is `data[5..9]`, transmuted to the packing,
+///     `packed_strided_view[2]` is `data[10..14]`, transmuted to the packing,
+/// and so on.
+#[derive(Debug, Copy, Clone)]
+pub struct PackedStridedView<'a, P: PackedField> {
+    // This type has to be a struct, which means that it is not itself a reference (in the sense
+    // that a slice is a reference so we can return it from e.g. `Index::index`).
+
+    // Raw pointers rarely appear in good Rust code, but I think this is the most elegant way to
+    // implement this. The alternative would be to replace `start_ptr` and `length` with one slice
+    // (`&[P::Scalar]`). Unfortunately, with a slice, an empty view becomes an edge case that
+    // necessitates separate handling. It _could_ be done but it would also be uglier.
+    start_ptr: *const P::Scalar,
+    /// This is the total length of elements accessible through the view. In other words, valid
+    /// indices are in `0..length`.
+    length: usize,
+    /// This stride is in units of `P::Scalar` (NOT in bytes and NOT in `P`).
+    stride: usize,
+    _phantom: PhantomData<&'a [P::Scalar]>,
+}
+
+impl<'a, P: PackedField> PackedStridedView<'a, P> {
+    // `wrapping_add` is needed throughout to avoid undefined behavior. Plain `add` causes UB if
+    // '[either] the starting [or] resulting pointer [is neither] in bounds or one byte past the
+    // end of the same allocated object'; the UB results even if the pointer is not dereferenced.
+
+    #[inline]
+    pub fn new(data: &'a [P::Scalar], stride: usize, offset: usize) -> Self {
+        assert!(
+            stride >= P::WIDTH,
+            "stride (got {}) must be at least P::WIDTH ({})",
+            stride,
+            P::WIDTH
+        );
+        assert_eq!(
+            data.len() % stride,
+            0,
+            "data.len() ({}) must be a multiple of stride (got {})",
+            data.len(),
+            stride
+        );
+
+        // This requirement means that stride divides data into slices of `data.len() / stride`
+        // elements. Every access must fit entirely within one of those slices.
+        assert!(
+            offset + P::WIDTH <= stride,
+            "offset (got {}) + P::WIDTH ({}) cannot be greater than stride (got {})",
+            offset,
+            P::WIDTH,
+            stride
+        );
+
+        // See comment above. `start_ptr` will be more than one byte past the buffer if `data` has
+        // length 0 and `offset` is not 0.
+        let start_ptr = data.as_ptr().wrapping_add(offset);
+
+        Self {
+            start_ptr,
+            length: data.len() / stride,
+            stride,
+            _phantom: PhantomData,
+        }
+    }
+
+    #[inline]
+    pub fn get(&self, index: usize) -> Option<&'a P> {
+        if index < self.length {
+            // Cast scalar pointer to vector pointer.
+            let res_ptr = unsafe { self.start_ptr.add(index * self.stride) }.cast();
+            // This transmutation is safe by the spec in `PackedField`.
+            Some(unsafe { &*res_ptr })
+        } else {
+            None
+        }
+    }
+
+    /// Take a range of `PackedStridedView` indices, as `PackedStridedView`.
+    #[inline]
+    pub fn view<I>(&self, index: I) -> Self
+    where
+        Self: Viewable<I, View = Self>,
+    {
+        // We cannot implement `Index` as `PackedStridedView` is a struct, not a reference.
+
+        // The `Viewable` trait is needed for overloading.
+        // Re-export `Viewable::view` so users don't have to import `Viewable`.
+        <Self as Viewable<I>>::view(self, index)
+    }
+
+    #[inline]
+    pub fn iter(&self) -> PackedStridedViewIter<'a, P> {
+        PackedStridedViewIter::new(
+            self.start_ptr,
+            // See comment at the top of the `impl`. Below will point more than one byte past the
+            // end of the buffer (unless `offset` is 0) so `wrapping_add` is needed.
+            self.start_ptr.wrapping_add(self.length * self.stride),
+            self.stride,
+        )
+    }
+
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.length
+    }
+}
+
+impl<'a, P: PackedField> Index<usize> for PackedStridedView<'a, P> {
+    type Output = P;
+    #[inline]
+    fn index(&self, index: usize) -> &Self::Output {
+        self.get(index)
+            .expect("invalid memory access in PackedStridedView")
+    }
+}
+
+impl<'a, P: PackedField> IntoIterator for PackedStridedView<'a, P> {
+    type Item = &'a P;
+    type IntoIter = PackedStridedViewIter<'a, P>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct TryFromPackedStridedViewError;
+
+impl<P: PackedField, const N: usize> TryInto<[P; N]> for PackedStridedView<'_, P> {
+    type Error = TryFromPackedStridedViewError;
+    fn try_into(self) -> Result<[P; N], Self::Error> {
+        if N == self.len() {
+            let mut res = [P::ZERO; N];
+            for i in 0..N {
+                res[i] = *self.get(i).unwrap();
+            }
+            Ok(res)
+        } else {
+            Err(TryFromPackedStridedViewError)
+        }
+    }
+}
+
+// Not deriving `Copy`. An implicit copy of an iterator is likely a bug.
+#[derive(Clone, Debug)]
+pub struct PackedStridedViewIter<'a, P: PackedField> {
+    // Again, a pair of pointers is a neater solution than a slice. `start` and `end` are always
+    // separated by a multiple of stride elements. To advance the iterator from the front, we
+    // advance `start` by `stride` elements. To advance it from the end, we subtract `stride`
+    // elements. Iteration is done when they meet.
+    // A slice cannot recreate the same pattern. The end pointer may point past the underlying
+    // buffer (this is okay as we do not dereference it in that case); it becomes valid as soon as
+    // it is decreased by `stride`. On the other hand, a slice that ends on invalid memory is
+    // instant undefined behavior.
+    start: *const P::Scalar,
+    end: *const P::Scalar,
+    stride: usize,
+    _phantom: PhantomData<&'a [P::Scalar]>,
+}
+
+impl<'a, P: PackedField> PackedStridedViewIter<'a, P> {
+    pub(self) fn new(start: *const P::Scalar, end: *const P::Scalar, stride: usize) -> Self {
+        Self {
+            start,
+            end,
+            stride,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<'a, P: PackedField> Iterator for PackedStridedViewIter<'a, P> {
+    type Item = &'a P;
+    fn next(&mut self) -> Option<Self::Item> {
+        debug_assert_eq!(
+            (self.end as usize).wrapping_sub(self.start as usize)
+                % (self.stride * size_of::<P::Scalar>()),
+            0,
+            "start and end pointers should be separated by a multiple of stride"
+        );
+
+        if self.start != self.end {
+            let res = unsafe { &*self.start.cast() };
+            // See comment in `PackedStridedView`. Below will point more than one byte past the end
+            // of the buffer if the offset is not 0 and we've reached the end.
+            self.start = self.start.wrapping_add(self.stride);
+            Some(res)
+        } else {
+            None
+        }
+    }
+}
+
+impl<'a, P: PackedField> DoubleEndedIterator for PackedStridedViewIter<'a, P> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        debug_assert_eq!(
+            (self.end as usize).wrapping_sub(self.start as usize)
+                % (self.stride * size_of::<P::Scalar>()),
+            0,
+            "start and end pointers should be separated by a multiple of stride"
+        );
+
+        if self.start != self.end {
+            // See comment in `PackedStridedView`. `self.end` starts off pointing more than one byte
+            // past the end of the buffer unless `offset` is 0.
+            self.end = self.end.wrapping_sub(self.stride);
+            Some(unsafe { &*self.end.cast() })
+        } else {
+            None
+        }
+    }
+}
+
+pub trait Viewable<F> {
+    // We cannot implement `Index` as `PackedStridedView` is a struct, not a reference.
+    type View;
+    fn view(&self, index: F) -> Self::View;
+}
+
+impl<'a, P: PackedField> Viewable<Range<usize>> for PackedStridedView<'a, P> {
+    type View = Self;
+    fn view(&self, range: Range<usize>) -> Self::View {
+        assert!(range.start <= self.len(), "Invalid access");
+        assert!(range.end <= self.len(), "Invalid access");
+        Self {
+            // See comment in `PackedStridedView`. `self.start_ptr` will point more than one byte
+            // past the end of the buffer if the offset is not 0 and the buffer has length 0.
+            start_ptr: self.start_ptr.wrapping_add(self.stride * range.start),
+            length: range.end - range.start,
+            stride: self.stride,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<'a, P: PackedField> Viewable<RangeFrom<usize>> for PackedStridedView<'a, P> {
+    type View = Self;
+    fn view(&self, range: RangeFrom<usize>) -> Self::View {
+        assert!(range.start <= self.len(), "Invalid access");
+        Self {
+            // See comment in `PackedStridedView`. `self.start_ptr` will point more than one byte
+            // past the end of the buffer if the offset is not 0 and the buffer has length 0.
+            start_ptr: self.start_ptr.wrapping_add(self.stride * range.start),
+            length: self.len() - range.start,
+            stride: self.stride,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<'a, P: PackedField> Viewable<RangeFull> for PackedStridedView<'a, P> {
+    type View = Self;
+    fn view(&self, _range: RangeFull) -> Self::View {
+        *self
+    }
+}
+
+impl<'a, P: PackedField> Viewable<RangeInclusive<usize>> for PackedStridedView<'a, P> {
+    type View = Self;
+    fn view(&self, range: RangeInclusive<usize>) -> Self::View {
+        assert!(*range.start() <= self.len(), "Invalid access");
+        assert!(*range.end() < self.len(), "Invalid access");
+        Self {
+            // See comment in `PackedStridedView`. `self.start_ptr` will point more than one byte
+            // past the end of the buffer if the offset is not 0 and the buffer has length 0.
+            start_ptr: self.start_ptr.wrapping_add(self.stride * range.start()),
+            length: range.end() - range.start() + 1,
+            stride: self.stride,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<'a, P: PackedField> Viewable<RangeTo<usize>> for PackedStridedView<'a, P> {
+    type View = Self;
+    fn view(&self, range: RangeTo<usize>) -> Self::View {
+        assert!(range.end <= self.len(), "Invalid access");
+        Self {
+            start_ptr: self.start_ptr,
+            length: range.end,
+            stride: self.stride,
+            _phantom: PhantomData,
+        }
+    }
+}
+
+impl<'a, P: PackedField> Viewable<RangeToInclusive<usize>> for PackedStridedView<'a, P> {
+    type View = Self;
+    fn view(&self, range: RangeToInclusive<usize>) -> Self::View {
+        assert!(range.end < self.len(), "Invalid access");
+        Self {
+            start_ptr: self.start_ptr,
+            length: range.end + 1,
+            stride: self.stride,
+            _phantom: PhantomData,
+        }
+    }
+}


### PR DESCRIPTION
This is the meat of the SIMD gate evaluation change. It changes the memory layouts associated with gate evaluation (inputs and outputs) to be matrices of field elements of shape `[[F; num_points]; some_length]`.

It does not, by itself, enable SIMD evaluation. That PR will be easier and just a bunch of moving code around (without actually changing it much). I do not want these changes, which are more likely to be controversial, to be lost in that.