### PR TITLE
Use 7 bytes to represent a field element to avoid collisions in hash conversion

### DIFF
--- a/src/hash/hash_types.rs
+++ b/src/hash/hash_types.rs
@@ -161,6 +161,7 @@ impl<const N: usize> From<BytesHash<N>> for u64 {
 impl<F: RichField, const N: usize> From<BytesHash<N>> for Vec<F> {
     fn from(hash: BytesHash<N>) -> Self {
         hash.0
+            // Chunks of 7 bytes since 8 bytes would allow collisions.
             .chunks(7)
             .map(|bytes| {
                 let mut arr = [0; 8];


### PR DESCRIPTION
As discussed in the comments of #341, this changes `impl From<BytesHash<N>> for Vec<F>` to use a 7-bytes representation (instead of 8) for field elements to avoid collisions. 