### PR TITLE
Minor: fix build on 32-bit x86

### DIFF
--- a/src/field/packable.rs
+++ b/src/field/packable.rs
@@ -12,7 +12,7 @@ impl<F: Field> Packable for F {
     default type Packing = Self;
 }
 
-#[cfg(target_feature = "avx2")]
+#[cfg(all(target_arch = "x86_64", target_feature = "avx2"))]
 impl Packable for crate::field::goldilocks_field::GoldilocksField {
     type Packing = crate::field::arch::x86_64::avx2_goldilocks_field::Avx2GoldilocksField;
 }


### PR DESCRIPTION
Not that this was ever going to come up, but still, we should compile successfully on all platforms supported by Rust.

Add a conditional compilation check so that 32-bit x86 (with AVX2) doesn't try to access a module compiled only on x86_64.