### PR TITLE
Rename `PackedField` constants `ZERO` -> `ZEROS`, `ONE` -> `ONES`

### DIFF
--- a/field/src/arch/x86_64/avx2_goldilocks_field.rs
+++ b/field/src/arch/x86_64/avx2_goldilocks_field.rs
@@ -73,7 +73,7 @@ impl Debug for Avx2GoldilocksField {
 impl Default for Avx2GoldilocksField {
     #[inline]
     fn default() -> Self {
-        Self::ZERO
+        Self::ZEROS
     }
 }
 
@@ -142,7 +142,7 @@ impl Neg for Avx2GoldilocksField {
 impl Product for Avx2GoldilocksField {
     #[inline]
     fn product<I: Iterator<Item = Self>>(iter: I) -> Self {
-        iter.reduce(|x, y| x * y).unwrap_or(Self::ONE)
+        iter.reduce(|x, y| x * y).unwrap_or(Self::ONES)
     }
 }
 
@@ -151,8 +151,8 @@ unsafe impl PackedField for Avx2GoldilocksField {
 
     type Scalar = GoldilocksField;
 
-    const ZERO: Self = Self([<GoldilocksField as Field>::ZERO; 4]);
-    const ONE: Self = Self([<GoldilocksField as Field>::ONE; 4]);
+    const ZEROS: Self = Self([GoldilocksField::ZERO; 4]);
+    const ONES: Self = Self([GoldilocksField::ONE; 4]);
 
     #[inline]
     fn from_arr(arr: [Self::Scalar; Self::WIDTH]) -> Self {
@@ -238,7 +238,7 @@ impl SubAssign<GoldilocksField> for Avx2GoldilocksField {
 impl Sum for Avx2GoldilocksField {
     #[inline]
     fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
-        iter.reduce(|x, y| x + y).unwrap_or(Self::ZERO)
+        iter.reduce(|x, y| x + y).unwrap_or(Self::ZEROS)
     }
 }
 

--- a/field/src/fft.rs
+++ b/field/src/fft.rs
@@ -121,7 +121,7 @@ fn fft_classic_simd<P: PackedField>(
             let half_m = 1 << lg_half_m;
 
             // Set omega to root_table[lg_half_m][0..half_m] but repeated.
-            let mut omega = P::ZERO;
+            let mut omega = P::default();
             for (j, omega_j) in omega.as_slice_mut().iter_mut().enumerate() {
                 *omega_j = root_table[lg_half_m][j % half_m];
             }

--- a/field/src/packed_field.rs
+++ b/field/src/packed_field.rs
@@ -41,8 +41,8 @@ where
     type Scalar: Field;
 
     const WIDTH: usize;
-    const ZERO: Self;
-    const ONE: Self;
+    const ZEROS: Self;
+    const ONES: Self;
 
     fn square(&self) -> Self {
         *self * *self
@@ -103,8 +103,8 @@ unsafe impl<F: Field> PackedField for F {
     type Scalar = Self;
 
     const WIDTH: usize = 1;
-    const ZERO: Self = <F as Field>::ZERO;
-    const ONE: Self = <F as Field>::ONE;
+    const ZEROS: Self = F::ZERO;
+    const ONES: Self = F::ONE;
 
     fn square(&self) -> Self {
         <Self as Field>::square(self)

--- a/plonky2/src/gates/arithmetic_u32.rs
+++ b/plonky2/src/gates/arithmetic_u32.rs
@@ -100,8 +100,8 @@ impl<F: RichField + Extendable<D>, const D: usize> Gate<F, D> for U32ArithmeticG
 
             constraints.push(combined_output - computed_output);
 
-            let mut combined_low_limbs = <F::Extension as Field>::ZERO;
-            let mut combined_high_limbs = <F::Extension as Field>::ZERO;
+            let mut combined_low_limbs = F::Extension::ZERO;
+            let mut combined_high_limbs = F::Extension::ZERO;
             let midpoint = Self::num_limbs() / 2;
             let base = F::Extension::from_canonical_u64(1u64 << Self::limb_bits());
             for j in (0..Self::num_limbs()).rev() {
@@ -255,8 +255,8 @@ impl<F: RichField + Extendable<D>, const D: usize> PackedEvaluableBase<F, D>
 
             yield_constr.one(combined_output - computed_output);
 
-            let mut combined_low_limbs = P::ZERO;
-            let mut combined_high_limbs = P::ZERO;
+            let mut combined_low_limbs = P::ZEROS;
+            let mut combined_high_limbs = P::ZEROS;
             let midpoint = Self::num_limbs() / 2;
             let base = F::from_canonical_u64(1u64 << Self::limb_bits());
             for j in (0..Self::num_limbs()).rev() {

--- a/plonky2/src/gates/assert_le.rs
+++ b/plonky2/src/gates/assert_le.rs
@@ -116,7 +116,7 @@ impl<F: RichField + Extendable<D>, const D: usize> Gate<F, D> for AssertLessThan
 
         let chunk_size = 1 << self.chunk_bits();
 
-        let mut most_significant_diff_so_far = <F::Extension as Field>::ZERO;
+        let mut most_significant_diff_so_far = F::Extension::ZERO;
 
         for i in 0..self.num_chunks {
             // Range-check the chunks to be less than `chunk_size`.
@@ -134,15 +134,14 @@ impl<F: RichField + Extendable<D>, const D: usize> Gate<F, D> for AssertLessThan
             let chunks_equal = vars.local_wires[self.wire_chunks_equal(i)];
 
             // Two constraints to assert that `chunks_equal` is valid.
-            constraints
-                .push(difference * equality_dummy - (<F::Extension as Field>::ONE - chunks_equal));
+            constraints.push(difference * equality_dummy - (F::Extension::ONE - chunks_equal));
             constraints.push(chunks_equal * difference);
 
             // Update `most_significant_diff_so_far`.
             let intermediate_value = vars.local_wires[self.wire_intermediate_value(i)];
             constraints.push(intermediate_value - chunks_equal * most_significant_diff_so_far);
             most_significant_diff_so_far =
-                intermediate_value + (<F::Extension as Field>::ONE - chunks_equal) * difference;
+                intermediate_value + (F::Extension::ONE - chunks_equal) * difference;
         }
 
         let most_significant_diff = vars.local_wires[self.wire_most_significant_diff()];
@@ -314,7 +313,7 @@ impl<F: RichField + Extendable<D>, const D: usize> PackedEvaluableBase<F, D>
 
         let chunk_size = 1 << self.chunk_bits();
 
-        let mut most_significant_diff_so_far = P::ZERO;
+        let mut most_significant_diff_so_far = P::ZEROS;
 
         for i in 0..self.num_chunks {
             // Range-check the chunks to be less than `chunk_size`.
@@ -332,14 +331,14 @@ impl<F: RichField + Extendable<D>, const D: usize> PackedEvaluableBase<F, D>
             let chunks_equal = vars.local_wires[self.wire_chunks_equal(i)];
 
             // Two constraints to assert that `chunks_equal` is valid.
-            yield_constr.one(difference * equality_dummy - (P::ONE - chunks_equal));
+            yield_constr.one(difference * equality_dummy - (P::ONES - chunks_equal));
             yield_constr.one(chunks_equal * difference);
 
             // Update `most_significant_diff_so_far`.
             let intermediate_value = vars.local_wires[self.wire_intermediate_value(i)];
             yield_constr.one(intermediate_value - chunks_equal * most_significant_diff_so_far);
             most_significant_diff_so_far =
-                intermediate_value + (P::ONE - chunks_equal) * difference;
+                intermediate_value + (P::ONES - chunks_equal) * difference;
         }
 
         let most_significant_diff = vars.local_wires[self.wire_most_significant_diff()];

--- a/plonky2/src/gates/comparison.rs
+++ b/plonky2/src/gates/comparison.rs
@@ -123,7 +123,7 @@ impl<F: RichField + Extendable<D>, const D: usize> Gate<F, D> for ComparisonGate
 
         let chunk_size = 1 << self.chunk_bits();
 
-        let mut most_significant_diff_so_far = <F::Extension as Field>::ZERO;
+        let mut most_significant_diff_so_far = F::Extension::ZERO;
 
         for i in 0..self.num_chunks {
             // Range-check the chunks to be less than `chunk_size`.
@@ -141,15 +141,14 @@ impl<F: RichField + Extendable<D>, const D: usize> Gate<F, D> for ComparisonGate
             let chunks_equal = vars.local_wires[self.wire_chunks_equal(i)];
 
             // Two constraints to assert that `chunks_equal` is valid.
-            constraints
-                .push(difference * equality_dummy - (<F::Extension as Field>::ONE - chunks_equal));
+            constraints.push(difference * equality_dummy - (F::Extension::ONE - chunks_equal));
             constraints.push(chunks_equal * difference);
 
             // Update `most_significant_diff_so_far`.
             let intermediate_value = vars.local_wires[self.wire_intermediate_value(i)];
             constraints.push(intermediate_value - chunks_equal * most_significant_diff_so_far);
             most_significant_diff_so_far =
-                intermediate_value + (<F::Extension as Field>::ONE - chunks_equal) * difference;
+                intermediate_value + (F::Extension::ONE - chunks_equal) * difference;
         }
 
         let most_significant_diff = vars.local_wires[self.wire_most_significant_diff()];
@@ -161,7 +160,7 @@ impl<F: RichField + Extendable<D>, const D: usize> Gate<F, D> for ComparisonGate
 
         // Range-check the bits.
         for &bit in &most_significant_diff_bits {
-            constraints.push(bit * (<F::Extension as Field>::ONE - bit));
+            constraints.push(bit * (F::Extension::ONE - bit));
         }
 
         let bits_combined = reduce_with_powers(&most_significant_diff_bits, F::Extension::TWO);
@@ -347,7 +346,7 @@ impl<F: RichField + Extendable<D>, const D: usize> PackedEvaluableBase<F, D>
 
         let chunk_size = 1 << self.chunk_bits();
 
-        let mut most_significant_diff_so_far = P::ZERO;
+        let mut most_significant_diff_so_far = P::ZEROS;
 
         for i in 0..self.num_chunks {
             // Range-check the chunks to be less than `chunk_size`.
@@ -365,14 +364,14 @@ impl<F: RichField + Extendable<D>, const D: usize> PackedEvaluableBase<F, D>
             let chunks_equal = vars.local_wires[self.wire_chunks_equal(i)];
 
             // Two constraints to assert that `chunks_equal` is valid.
-            yield_constr.one(difference * equality_dummy - (P::ONE - chunks_equal));
+            yield_constr.one(difference * equality_dummy - (P::ONES - chunks_equal));
             yield_constr.one(chunks_equal * difference);
 
             // Update `most_significant_diff_so_far`.
             let intermediate_value = vars.local_wires[self.wire_intermediate_value(i)];
             yield_constr.one(intermediate_value - chunks_equal * most_significant_diff_so_far);
             most_significant_diff_so_far =
-                intermediate_value + (P::ONE - chunks_equal) * difference;
+                intermediate_value + (P::ONES - chunks_equal) * difference;
         }
 
         let most_significant_diff = vars.local_wires[self.wire_most_significant_diff()];
@@ -384,7 +383,7 @@ impl<F: RichField + Extendable<D>, const D: usize> PackedEvaluableBase<F, D>
 
         // Range-check the bits.
         for &bit in &most_significant_diff_bits {
-            yield_constr.one(bit * (P::ONE - bit));
+            yield_constr.one(bit * (P::ONES - bit));
         }
 
         let bits_combined = reduce_with_powers(&most_significant_diff_bits, F::TWO);

--- a/plonky2/src/gates/exponentiation.rs
+++ b/plonky2/src/gates/exponentiation.rs
@@ -88,7 +88,7 @@ impl<F: RichField + Extendable<D>, const D: usize> Gate<F, D> for Exponentiation
 
         for i in 0..self.num_power_bits {
             let prev_intermediate_value = if i == 0 {
-                <F::Extension as Field>::ONE
+                F::Extension::ONE
             } else {
                 <F::Extension as Field>::square(&intermediate_values[i - 1])
             };
@@ -96,7 +96,7 @@ impl<F: RichField + Extendable<D>, const D: usize> Gate<F, D> for Exponentiation
             // power_bits is in LE order, but we accumulate in BE order.
             let cur_bit = power_bits[self.num_power_bits - i - 1];
 
-            let not_cur_bit = <F::Extension as Field>::ONE - cur_bit;
+            let not_cur_bit = F::Extension::ONE - cur_bit;
             let computed_intermediate_value =
                 prev_intermediate_value * (cur_bit * base + not_cur_bit);
             constraints.push(computed_intermediate_value - intermediate_values[i]);
@@ -210,7 +210,7 @@ impl<F: RichField + Extendable<D>, const D: usize> PackedEvaluableBase<F, D>
 
         for i in 0..self.num_power_bits {
             let prev_intermediate_value = if i == 0 {
-                P::ONE
+                P::ONES
             } else {
                 intermediate_values[i - 1].square()
             };
@@ -218,7 +218,7 @@ impl<F: RichField + Extendable<D>, const D: usize> PackedEvaluableBase<F, D>
             // power_bits is in LE order, but we accumulate in BE order.
             let cur_bit = power_bits[self.num_power_bits - i - 1];
 
-            let not_cur_bit = P::ONE - cur_bit;
+            let not_cur_bit = P::ONES - cur_bit;
             let computed_intermediate_value =
                 prev_intermediate_value * (cur_bit * base + not_cur_bit);
             yield_constr.one(computed_intermediate_value - intermediate_values[i]);

--- a/plonky2/src/gates/gmimc.rs
+++ b/plonky2/src/gates/gmimc.rs
@@ -81,7 +81,7 @@ impl<F: RichField + Extendable<D> + GMiMC<WIDTH>, const D: usize, const WIDTH: u
 
         // Assert that `swap` is binary.
         let swap = vars.local_wires[Self::WIRE_SWAP];
-        constraints.push(swap * (swap - <F::Extension as Field>::ONE));
+        constraints.push(swap * (swap - F::Extension::ONE));
 
         let mut state = Vec::with_capacity(12);
         for i in 0..4 {
@@ -100,7 +100,7 @@ impl<F: RichField + Extendable<D> + GMiMC<WIDTH>, const D: usize, const WIDTH: u
 
         // Value that is implicitly added to each element.
         // See https://affine.group/2020/02/starkware-challenge
-        let mut addition_buffer = <F::Extension as Field>::ZERO;
+        let mut addition_buffer = F::Extension::ZERO;
 
         for r in 0..gmimc::NUM_ROUNDS {
             let active = r % WIDTH;
@@ -245,7 +245,7 @@ impl<F: RichField + Extendable<D> + GMiMC<WIDTH>, const D: usize, const WIDTH: u
 
         // Value that is implicitly added to each element.
         // See https://affine.group/2020/02/starkware-challenge
-        let mut addition_buffer = P::ZERO;
+        let mut addition_buffer = P::ZEROS;
 
         for r in 0..gmimc::NUM_ROUNDS {
             let active = r % WIDTH;

--- a/plonky2/src/gates/random_access.rs
+++ b/plonky2/src/gates/random_access.rs
@@ -105,14 +105,14 @@ impl<F: RichField + Extendable<D>, const D: usize> Gate<F, D> for RandomAccessGa
 
             // Assert that each bit wire value is indeed boolean.
             for &b in &bits {
-                constraints.push(b * (b - <F::Extension as Field>::ONE));
+                constraints.push(b * (b - F::Extension::ONE));
             }
 
             // Assert that the binary decomposition was correct.
             let reconstructed_index = bits
                 .iter()
                 .rev()
-                .fold(<F::Extension as Field>::ZERO, |acc, &b| acc.double() + b);
+                .fold(F::Extension::ZERO, |acc, &b| acc.double() + b);
             constraints.push(reconstructed_index - access_index);
 
             // Repeatedly fold the list, selecting the left or right item from each pair based on
@@ -254,7 +254,7 @@ impl<F: RichField + Extendable<D>, const D: usize> PackedEvaluableBase<F, D>
             }
 
             // Assert that the binary decomposition was correct.
-            let reconstructed_index = bits.iter().rev().fold(P::ZERO, |acc, &b| acc + acc + b);
+            let reconstructed_index = bits.iter().rev().fold(P::ZEROS, |acc, &b| acc + acc + b);
             yield_constr.one(reconstructed_index - access_index);
 
             // Repeatedly fold the list, selecting the left or right item from each pair based on

--- a/plonky2/src/gates/subtraction_u32.rs
+++ b/plonky2/src/gates/subtraction_u32.rs
@@ -100,7 +100,7 @@ impl<F: RichField + Extendable<D>, const D: usize> Gate<F, D> for U32Subtraction
             constraints.push(output_result - (result_initial + base * output_borrow));
 
             // Range-check output_result to be at most 32 bits.
-            let mut combined_limbs = <F::Extension as Field>::ZERO;
+            let mut combined_limbs = F::Extension::ZERO;
             let limb_base = F::Extension::from_canonical_u64(1u64 << Self::limb_bits());
             for j in (0..Self::num_limbs()).rev() {
                 let this_limb = vars.local_wires[self.wire_ith_output_jth_limb(i, j)];
@@ -115,7 +115,7 @@ impl<F: RichField + Extendable<D>, const D: usize> Gate<F, D> for U32Subtraction
             constraints.push(combined_limbs - output_result);
 
             // Range-check output_borrow to be one bit.
-            constraints.push(output_borrow * (<F::Extension as Field>::ONE - output_borrow));
+            constraints.push(output_borrow * (F::Extension::ONE - output_borrow));
         }
 
         constraints
@@ -243,7 +243,7 @@ impl<F: RichField + Extendable<D>, const D: usize> PackedEvaluableBase<F, D>
             yield_constr.one(output_result - (result_initial + output_borrow * base));
 
             // Range-check output_result to be at most 32 bits.
-            let mut combined_limbs = P::ZERO;
+            let mut combined_limbs = P::ZEROS;
             let limb_base = F::from_canonical_u64(1u64 << Self::limb_bits());
             for j in (0..Self::num_limbs()).rev() {
                 let this_limb = vars.local_wires[self.wire_ith_output_jth_limb(i, j)];
@@ -258,7 +258,7 @@ impl<F: RichField + Extendable<D>, const D: usize> PackedEvaluableBase<F, D>
             yield_constr.one(combined_limbs - output_result);
 
             // Range-check output_borrow to be one bit.
-            yield_constr.one(output_borrow * (P::ONE - output_borrow));
+            yield_constr.one(output_borrow * (P::ONES - output_borrow));
         }
     }
 }

--- a/plonky2/src/gates/switch.rs
+++ b/plonky2/src/gates/switch.rs
@@ -83,7 +83,7 @@ impl<F: RichField + Extendable<D>, const D: usize> Gate<F, D> for SwitchGate<F, 
 
         for c in 0..self.num_copies {
             let switch_bool = vars.local_wires[self.wire_switch_bool(c)];
-            let not_switch = <F::Extension as Field>::ONE - switch_bool;
+            let not_switch = F::Extension::ONE - switch_bool;
 
             for e in 0..self.chunk_size {
                 let first_input = vars.local_wires[self.wire_first_input(c, e)];
@@ -197,7 +197,7 @@ impl<F: RichField + Extendable<D>, const D: usize> PackedEvaluableBase<F, D> for
     ) {
         for c in 0..self.num_copies {
             let switch_bool = vars.local_wires[self.wire_switch_bool(c)];
-            let not_switch = P::ONE - switch_bool;
+            let not_switch = P::ONES - switch_bool;
 
             for e in 0..self.chunk_size {
                 let first_input = vars.local_wires[self.wire_first_input(c, e)];

--- a/plonky2/src/plonk/plonk_common.rs
+++ b/plonky2/src/plonk/plonk_common.rs
@@ -167,7 +167,7 @@ pub(crate) fn reduce_with_powers<'a, P: PackedField, T: IntoIterator<Item = &'a 
 where
     T::IntoIter: DoubleEndedIterator,
 {
-    let mut sum = P::ZERO;
+    let mut sum = P::ZEROS;
     for &term in terms.into_iter().rev() {
         sum = sum * alpha + term;
     }

--- a/plonky2/src/util/strided_view.rs
+++ b/plonky2/src/util/strided_view.rs
@@ -149,7 +149,7 @@ impl<P: PackedField, const N: usize> TryInto<[P; N]> for PackedStridedView<'_, P
     type Error = TryFromPackedStridedViewError;
     fn try_into(self) -> Result<[P; N], Self::Error> {
         if N == self.len() {
-            let mut res = [P::ZERO; N];
+            let mut res = [P::default(); N];
             for i in 0..N {
                 res[i] = *self.get(i).unwrap();
             }


### PR DESCRIPTION
Cleanup promised in #395. Disambiguate between constants in `Field` and `PackedField` to avoid having to write things like `<Foo as Field>::ZERO`. (Recall that every `Field` implements `PackedField`.)

This is done by renaming `ZERO` to `ZEROS` and `ONE` to `ONES` in `PrimeField`. I usually would not rename things to avoid such conflicts (that's what namespaces are for) but I actually think the plurals are more descriptive.