### PR TITLE
Decrease CI scratch disk space

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -29,7 +29,8 @@ jobs:
           command: test
           args: --all
         env:
-          RUSTFLAGS: -Copt-level=3 -Cdebug-assertions -Coverflow-checks=y -Cincremental=false -Cdebuginfo=0 -Cprefer-dynamic=y
+          RUSTFLAGS: -Copt-level=3 -Cdebug-assertions -Coverflow-checks=y -Cdebuginfo=0 -Cprefer-dynamic=y
+          CARGO_INCREMENTAL: 0
 
   lints:
     name: Formatting and Clippy


### PR DESCRIPTION
This change reduces the `/target` directory size by over 5✕ (on my computer). The CI has no need for incremental builds (everything is discarded on exit), debug symbols (nobody's running a debugger, plus it's optimized anyway), or static linking (the binary is not distributed).

I'm not sure how much this will do by itself, but this change will make the CI `/target` directory small enough that we can [cache it between builds](https://docs.github.com/en/actions/advanced-guides/caching-dependencies-to-speed-up-workflows) if we so desire. This way we will not have to compile all the dependencies every time.