### PR TITLE
Separate some circuit logic from FRI code

### DIFF
--- a/plonky2/src/bin/bench_recursion.rs
+++ b/plonky2/src/bin/bench_recursion.rs
@@ -26,11 +26,11 @@ fn bench_prove<C: GenericConfig<D>, const D: usize>() -> Result<()> {
         constant_gate_size: 6,
         use_base_arithmetic_gate: false,
         security_bits: 128,
-        rate_bits: 3,
         num_challenges: 3,
         zero_knowledge: false,
-        cap_height: 1,
         fri_config: FriConfig {
+            rate_bits: 3,
+            cap_height: 1,
             proof_of_work_bits: 15,
             reduction_strategy: FriReductionStrategy::ConstantArityBits(3, 5),
             num_query_rounds: 35,

--- a/plonky2/src/fri/commitment.rs
+++ b/plonky2/src/fri/commitment.rs
@@ -208,14 +208,14 @@ impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
         alpha.shift_poly(&mut final_poly);
         final_poly += zs_quotient;
 
-        let lde_final_poly = final_poly.lde(config.rate_bits);
+        let lde_final_poly = final_poly.lde(config.fri_config.rate_bits);
         let lde_final_values = timed!(
             timing,
             &format!("perform final FFT {}", lde_final_poly.len()),
             lde_final_poly.coset_fft(F::coset_shift().into())
         );
 
-        let fri_proof = fri_proof(
+        let fri_proof = fri_proof::<F, C, D>(
             &commitments
                 .par_iter()
                 .map(|c| &c.merkle_tree)
@@ -223,7 +223,7 @@ impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
             lde_final_poly,
             lde_final_values,
             challenger,
-            common_data,
+            &common_data.fri_params,
             timing,
         );
 

--- a/plonky2/src/fri/mod.rs
+++ b/plonky2/src/fri/mod.rs
@@ -9,6 +9,12 @@ pub mod verifier;
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct FriConfig {
+    /// `rate = 2^{-rate_bits}`.
+    pub rate_bits: usize,
+
+    /// Height of Merkle tree caps.
+    pub cap_height: usize,
+
     pub proof_of_work_bits: u32,
 
     pub reduction_strategy: FriReductionStrategy,
@@ -17,10 +23,16 @@ pub struct FriConfig {
     pub num_query_rounds: usize,
 }
 
-/// Parameters which are generated during preprocessing, in contrast to `FriConfig` which is
-/// user-specified.
+/// FRI parameters, including generated parameters which are specific to an instance size, in
+/// contrast to `FriConfig` which is user-specified and independent of instance size.
 #[derive(Debug)]
-pub(crate) struct FriParams {
+pub struct FriParams {
+    /// User-specified FRI configuration.
+    pub config: FriConfig,
+
+    /// The degree of the purported codeword, measured in bits.
+    pub degree_bits: usize,
+
     /// The arity of each FRI reduction step, expressed as the log2 of the actual arity.
     /// For example, `[3, 2, 1]` would describe a FRI reduction tree with 8-to-1 reduction, then
     /// a 4-to-1 reduction, then a 2-to-1 reduction. After these reductions, the reduced polynomial
@@ -35,5 +47,21 @@ impl FriParams {
 
     pub(crate) fn max_arity_bits(&self) -> Option<usize> {
         self.reduction_arity_bits.iter().copied().max()
+    }
+
+    pub fn lde_bits(&self) -> usize {
+        self.degree_bits + self.config.rate_bits
+    }
+
+    pub fn lde_size(&self) -> usize {
+        1 << self.lde_bits()
+    }
+
+    pub fn final_poly_bits(&self) -> usize {
+        self.degree_bits - self.total_arities()
+    }
+
+    pub fn final_poly_len(&self) -> usize {
+        1 << self.final_poly_bits()
     }
 }

--- a/plonky2/src/fri/proof.rs
+++ b/plonky2/src/fri/proof.rs
@@ -140,7 +140,7 @@ impl<F: RichField + Extendable<D>, H: Hasher<F>, const D: usize> FriProof<F, H, 
             pow_witness,
             ..
         } = self;
-        let cap_height = common_data.config.cap_height;
+        let cap_height = common_data.config.fri_config.cap_height;
         let reduction_arity_bits = &common_data.fri_params.reduction_arity_bits;
         let num_reductions = reduction_arity_bits.len();
         let num_initial_trees = query_round_proofs[0].initial_trees_proof.evals_proofs.len();
@@ -252,7 +252,7 @@ impl<F: RichField + Extendable<D>, H: Hasher<F>, const D: usize> CompressedFriPr
             ..
         } = challenges;
         let mut fri_inferred_elements = fri_inferred_elements.0.into_iter();
-        let cap_height = common_data.config.cap_height;
+        let cap_height = common_data.config.fri_config.cap_height;
         let reduction_arity_bits = &common_data.fri_params.reduction_arity_bits;
         let num_reductions = reduction_arity_bits.len();
         let num_initial_trees = query_round_proofs
@@ -270,7 +270,7 @@ impl<F: RichField + Extendable<D>, H: Hasher<F>, const D: usize> CompressedFriPr
         let mut steps_indices = vec![vec![]; num_reductions];
         let mut steps_evals = vec![vec![]; num_reductions];
         let mut steps_proofs = vec![vec![]; num_reductions];
-        let height = common_data.degree_bits + common_data.config.rate_bits;
+        let height = common_data.degree_bits + common_data.config.fri_config.rate_bits;
         let heights = reduction_arity_bits
             .iter()
             .scan(height, |acc, &bits| {

--- a/plonky2/src/fri/recursive_verifier.rs
+++ b/plonky2/src/fri/recursive_verifier.rs
@@ -78,7 +78,7 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
     ) {
         let random_access = RandomAccessGate::<F, D>::new_from_config(
             &self.config,
-            max_fri_arity_bits.max(self.config.cap_height),
+            max_fri_arity_bits.max(self.config.fri_config.cap_height),
         );
         let (interpolation_wires, interpolation_routed_wires) =
             if 1 << max_fri_arity_bits > common_data.quotient_degree_factor {
@@ -143,7 +143,7 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
         }
 
         debug_assert_eq!(
-            common_data.final_poly_len(),
+            common_data.fri_params.final_poly_len(),
             proof.final_poly.len(),
             "Final polynomial has wrong degree."
         );
@@ -267,8 +267,8 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
         let degree_log = common_data.degree_bits;
         debug_assert_eq!(
             degree_log,
-            common_data.config.cap_height + proof.evals_proofs[0].1.siblings.len()
-                - config.rate_bits
+            common_data.config.fri_config.cap_height + proof.evals_proofs[0].1.siblings.len()
+                - config.fri_config.rate_bits
         );
         let subgroup_x = self.convert_to_ext(subgroup_x);
         let mut alpha = ReducingFactorTarget::new(alpha);
@@ -343,8 +343,9 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
         let x_index = challenger.get_challenge(self);
         let mut x_index_bits = self.low_bits(x_index, n_log, F::BITS);
 
-        let cap_index =
-            self.le_sum(x_index_bits[x_index_bits.len() - common_data.config.cap_height..].iter());
+        let cap_index = self.le_sum(
+            x_index_bits[x_index_bits.len() - common_data.config.fri_config.cap_height..].iter(),
+        );
         with_context!(
             self,
             "check FRI initial proof",

--- a/plonky2/src/fri/verifier.rs
+++ b/plonky2/src/fri/verifier.rs
@@ -72,7 +72,7 @@ pub(crate) fn verify_fri_proof<
 ) -> Result<()> {
     let config = &common_data.config;
     ensure!(
-        common_data.final_poly_len() == proof.final_poly.len(),
+        common_data.fri_params.final_poly_len() == proof.final_poly.len(),
         "Final polynomial has wrong degree."
     );
 

--- a/plonky2/src/plonk/circuit_data.rs
+++ b/plonky2/src/plonk/circuit_data.rs
@@ -30,14 +30,11 @@ pub struct CircuitConfig {
     /// for both base field and extension field arithmetic.
     pub use_base_arithmetic_gate: bool,
     pub security_bits: usize,
-    pub rate_bits: usize,
     /// The number of challenge points to generate, for IOPs that have soundness errors of (roughly)
     /// `degree / |F|`.
     pub num_challenges: usize,
     pub zero_knowledge: bool,
-    pub cap_height: usize,
 
-    // TODO: Find a better place for this.
     pub fri_config: FriConfig,
 }
 
@@ -49,7 +46,7 @@ impl Default for CircuitConfig {
 
 impl CircuitConfig {
     pub fn rate(&self) -> f64 {
-        1.0 / ((1 << self.rate_bits) as f64)
+        1.0 / ((1 << self.fri_config.rate_bits) as f64)
     }
 
     pub fn num_advice_wires(&self) -> usize {
@@ -64,11 +61,11 @@ impl CircuitConfig {
             constant_gate_size: 5,
             use_base_arithmetic_gate: true,
             security_bits: 100,
-            rate_bits: 3,
             num_challenges: 2,
             zero_knowledge: false,
-            cap_height: 4,
             fri_config: FriConfig {
+                rate_bits: 3,
+                cap_height: 4,
                 proof_of_work_bits: 16,
                 reduction_strategy: FriReductionStrategy::ConstantArityBits(4, 5),
                 num_query_rounds: 28,
@@ -251,11 +248,11 @@ impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
     }
 
     pub fn lde_size(&self) -> usize {
-        1 << (self.degree_bits + self.config.rate_bits)
+        1 << (self.degree_bits + self.config.fri_config.rate_bits)
     }
 
     pub fn lde_generator(&self) -> F {
-        F::primitive_root_of_unity(self.degree_bits + self.config.rate_bits)
+        F::primitive_root_of_unity(self.degree_bits + self.config.fri_config.rate_bits)
     }
 
     pub fn constraint_degree(&self) -> usize {
@@ -288,10 +285,6 @@ impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
     /// Range of the partial products polynomials in the `zs_partial_products_commitment`.
     pub fn partial_products_range(&self) -> RangeFrom<usize> {
         self.config.num_challenges..
-    }
-
-    pub fn final_poly_len(&self) -> usize {
-        1 << (self.degree_bits - self.fri_params.total_arities())
     }
 }
 

--- a/plonky2/src/plonk/get_challenges.rs
+++ b/plonky2/src/plonk/get_challenges.rs
@@ -189,7 +189,7 @@ impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
             vec![HashSet::new(); common_data.fri_params.reduction_arity_bits.len()];
         let precomputed_reduced_evals =
             PrecomputedReducedEvals::from_os_and_alpha(&self.proof.openings, *fri_alpha);
-        let log_n = common_data.degree_bits + common_data.config.rate_bits;
+        let log_n = common_data.degree_bits + common_data.config.fri_config.rate_bits;
         // Simulate the proof verification and collect the inferred elements.
         // The content of the loop is basically the same as the `fri_verifier_query_round` function.
         for &(mut x_index) in fri_query_indices {

--- a/plonky2/src/plonk/prover.rs
+++ b/plonky2/src/plonk/prover.rs
@@ -71,9 +71,9 @@ pub(crate) fn prove<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, co
         "compute wires commitment",
         PolynomialBatchCommitment::from_values(
             wires_values,
-            config.rate_bits,
+            config.fri_config.rate_bits,
             config.zero_knowledge & PlonkPolynomials::WIRES.blinding,
-            config.cap_height,
+            config.fri_config.cap_height,
             timing,
             prover_data.fft_root_table.as_ref(),
         )
@@ -111,9 +111,9 @@ pub(crate) fn prove<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, co
         "commit to partial products and Z's",
         PolynomialBatchCommitment::from_values(
             zs_partial_products,
-            config.rate_bits,
+            config.fri_config.rate_bits,
             config.zero_knowledge & PlonkPolynomials::ZS_PARTIAL_PRODUCTS.blinding,
-            config.cap_height,
+            config.fri_config.cap_height,
             timing,
             prover_data.fft_root_table.as_ref(),
         )
@@ -160,9 +160,9 @@ pub(crate) fn prove<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, co
         "commit to quotient polys",
         PolynomialBatchCommitment::from_coeffs(
             all_quotient_poly_chunks,
-            config.rate_bits,
+            config.fri_config.rate_bits,
             config.zero_knowledge & PlonkPolynomials::QUOTIENT.blinding,
-            config.cap_height,
+            config.fri_config.cap_height,
             timing,
             prover_data.fft_root_table.as_ref(),
         )
@@ -309,14 +309,14 @@ fn compute_quotient_polys<
     let num_challenges = common_data.config.num_challenges;
     let max_degree_bits = log2_ceil(common_data.quotient_degree_factor);
     assert!(
-        max_degree_bits <= common_data.config.rate_bits,
+        max_degree_bits <= common_data.config.fri_config.rate_bits,
         "Having constraints of degree higher than the rate is not supported yet. \
         If we need this in the future, we can precompute the larger LDE before computing the `ListPolynomialCommitment`s."
     );
 
     // We reuse the LDE computed in `ListPolynomialCommitment` and extract every `step` points to get
     // an LDE matching `max_filtered_constraint_degree`.
-    let step = 1 << (common_data.config.rate_bits - max_degree_bits);
+    let step = 1 << (common_data.config.fri_config.rate_bits - max_degree_bits);
     // When opening the `Z`s polys at the "next" point in Plonk, need to look at the point `next_step`
     // steps away since we work on an LDE of degree `max_filtered_constraint_degree`.
     let next_step = 1 << max_degree_bits;

--- a/plonky2/src/plonk/recursive_verifier.rs
+++ b/plonky2/src/plonk/recursive_verifier.rs
@@ -454,8 +454,8 @@ mod tests {
 
         // A high-rate recursive proof, designed to be verifiable with fewer routed wires.
         let high_rate_config = CircuitConfig {
-            rate_bits: 7,
             fri_config: FriConfig {
+                rate_bits: 7,
                 proof_of_work_bits: 16,
                 num_query_rounds: 12,
                 ..standard_config.fri_config.clone()
@@ -476,10 +476,10 @@ mod tests {
 
         // A final proof, optimized for size.
         let final_config = CircuitConfig {
-            cap_height: 0,
-            rate_bits: 8,
             num_routed_wires: 37,
             fri_config: FriConfig {
+                rate_bits: 8,
+                cap_height: 0,
                 proof_of_work_bits: 20,
                 reduction_strategy: FriReductionStrategy::MinSize(None),
                 num_query_rounds: 10,
@@ -582,7 +582,7 @@ mod tests {
         set_proof_target(&inner_proof, &pt, &mut pw);
 
         let inner_data = VerifierCircuitTarget {
-            constants_sigmas_cap: builder.add_virtual_cap(inner_config.cap_height),
+            constants_sigmas_cap: builder.add_virtual_cap(inner_config.fri_config.cap_height),
         };
         pw.set_cap_target(
             &inner_data.constants_sigmas_cap,

--- a/plonky2/src/util/serialization.rs
+++ b/plonky2/src/util/serialization.rs
@@ -347,11 +347,12 @@ impl Buffer {
     ) -> Result<FriProof<F, C::Hasher, D>> {
         let config = &common_data.config;
         let commit_phase_merkle_caps = (0..common_data.fri_params.reduction_arity_bits.len())
-            .map(|_| self.read_merkle_cap(config.cap_height))
+            .map(|_| self.read_merkle_cap(config.fri_config.cap_height))
             .collect::<Result<Vec<_>>>()?;
         let query_round_proofs = self.read_fri_query_rounds(common_data)?;
-        let final_poly =
-            PolynomialCoeffs::new(self.read_field_ext_vec::<F, D>(common_data.final_poly_len())?);
+        let final_poly = PolynomialCoeffs::new(
+            self.read_field_ext_vec::<F, D>(common_data.fri_params.final_poly_len())?,
+        );
         let pow_witness = self.read_field()?;
         Ok(FriProof {
             commit_phase_merkle_caps,
@@ -376,9 +377,9 @@ impl Buffer {
         common_data: &CommonCircuitData<F, C, D>,
     ) -> Result<Proof<F, C, D>> {
         let config = &common_data.config;
-        let wires_cap = self.read_merkle_cap(config.cap_height)?;
-        let plonk_zs_partial_products_cap = self.read_merkle_cap(config.cap_height)?;
-        let quotient_polys_cap = self.read_merkle_cap(config.cap_height)?;
+        let wires_cap = self.read_merkle_cap(config.fri_config.cap_height)?;
+        let plonk_zs_partial_products_cap = self.read_merkle_cap(config.fri_config.cap_height)?;
+        let quotient_polys_cap = self.read_merkle_cap(config.fri_config.cap_height)?;
         let openings = self.read_opening_set(common_data)?;
         let opening_proof = self.read_fri_proof(common_data)?;
 
@@ -522,11 +523,12 @@ impl Buffer {
     ) -> Result<CompressedFriProof<F, C::Hasher, D>> {
         let config = &common_data.config;
         let commit_phase_merkle_caps = (0..common_data.fri_params.reduction_arity_bits.len())
-            .map(|_| self.read_merkle_cap(config.cap_height))
+            .map(|_| self.read_merkle_cap(config.fri_config.cap_height))
             .collect::<Result<Vec<_>>>()?;
         let query_round_proofs = self.read_compressed_fri_query_rounds(common_data)?;
-        let final_poly =
-            PolynomialCoeffs::new(self.read_field_ext_vec::<F, D>(common_data.final_poly_len())?);
+        let final_poly = PolynomialCoeffs::new(
+            self.read_field_ext_vec::<F, D>(common_data.fri_params.final_poly_len())?,
+        );
         let pow_witness = self.read_field()?;
         Ok(CompressedFriProof {
             commit_phase_merkle_caps,
@@ -559,9 +561,9 @@ impl Buffer {
         common_data: &CommonCircuitData<F, C, D>,
     ) -> Result<CompressedProof<F, C, D>> {
         let config = &common_data.config;
-        let wires_cap = self.read_merkle_cap(config.cap_height)?;
-        let plonk_zs_partial_products_cap = self.read_merkle_cap(config.cap_height)?;
-        let quotient_polys_cap = self.read_merkle_cap(config.cap_height)?;
+        let wires_cap = self.read_merkle_cap(config.fri_config.cap_height)?;
+        let plonk_zs_partial_products_cap = self.read_merkle_cap(config.fri_config.cap_height)?;
+        let quotient_polys_cap = self.read_merkle_cap(config.fri_config.cap_height)?;
         let openings = self.read_opening_set(common_data)?;
         let opening_proof = self.read_compressed_fri_proof(common_data)?;
 


### PR DESCRIPTION
My goal is to make the FRI code independent of circuit objects like `CommonCircuitData`, so that it can be reused by STARK code which won't involve those objects.

A few changes here:

- Move `rate_bits` and `cap_height` into `FriConfig`.
- Move `degree_bits` into `FriParameters` (since it's instance size specific).
- Make `FriParams` contain `FriConfig`, so FRI methods can take just the former and access fields in both.
- Replace `CommonCircuitConfig` with `FriParams` in FRI prover methods.

The FRI verifier methods still involve circuit objects, as they have PLONK logic in `fri_combine_initial`. Will think about how to deal with that after this.