### PR TITLE
Improve twiddle access for FFT

### DIFF
--- a/field/src/fft.rs
+++ b/field/src/fft.rs
@@ -12,7 +12,7 @@ pub type FftRootTable<F> = Vec<Vec<F>>;
 pub fn fft_root_table<F: Field>(n: usize) -> FftRootTable<F> {
     let lg_n = log2_strict(n);
     let mut root_table = Vec::with_capacity(1);
- 
+
     if lg_n <= 1 {
         let root_row = vec![F::ONE; 1];
         root_table.push(root_row);
@@ -28,7 +28,7 @@ pub fn fft_root_table<F: Field>(n: usize) -> FftRootTable<F> {
         }
         root_table.push(root_row);
     }
- 
+
     root_table
 }
 

--- a/field/src/fft.rs
+++ b/field/src/fft.rs
@@ -11,19 +11,24 @@ pub type FftRootTable<F> = Vec<Vec<F>>;
 
 pub fn fft_root_table<F: Field>(n: usize) -> FftRootTable<F> {
     let lg_n = log2_strict(n);
-    let base = F::primitive_root_of_unity(lg_n);
-
     let mut root_table = Vec::with_capacity(1);
-    let half_n = 1 << (lg_n - 1);
-    let mut root_row = vec![F::ZERO; half_n];
-    // store roots of unity in "reverse bits" order
-    // faster than calling: reverse_index_bits_in_place(&mut root_row[..])
-    for (i, b) in base.powers().take(half_n).enumerate() {
-        let j = i.reverse_bits() >> (64 - lg_n + 1);
-        root_row[j] = b;
+ 
+    if lg_n <= 1 {
+        let root_row = vec![F::ONE; 1];
+        root_table.push(root_row);
+    } else {
+        let base = F::primitive_root_of_unity(lg_n);
+        let half_n = 1 << (lg_n - 1);
+        let mut root_row = vec![F::ZERO; half_n];
+        // store roots of unity in "reverse bits" order
+        // faster than calling: reverse_index_bits_in_place(&mut root_row[..])
+        for (i, b) in base.powers().take(half_n).enumerate() {
+            let j = i.reverse_bits() >> (64 - lg_n + 1);
+            root_row[j] = b;
+        }
+        root_table.push(root_row);
     }
-    root_table.push(root_row);
-
+ 
     root_table
 }
 


### PR DESCRIPTION
We implemented Bowers et al. "Improved Twiddle Access for Fast Fourier Transforms"
https://doi.org/10.1109/TSP.2009.2035984

In our experiments this is 10%+ faster than the existing DIT.
The algorithm turns out to be surprisingly simple because it's just like DIT, but with a DIF butterfly! 🤯 

The key is that, by rearranging the computation, the twiddle is now constant within the inner-most loop, so you have less memory accesses. Because it was simple enough, I've also manually unrolled the case wˆ0 to save 1 mul.

Two things we didn't do (it's prob safer if you look at them later):
1. The roots_table is no longer a table, we just need 1 row. So you could slightly simplify the API.
2. I'm not sure I fully understood the trick with $r>0$ and sparse matrix... I clearly left the test so this new implementation is correct. However I removed that code, IMO with this new algo you no longer get that improvement, but I might be incorrect.
 
In summary:
- less memory for root_table (only 1 row)
- less memory access with const twiddle
- pretty much same algorithm & code complexity (just a diff butterfly)
- removed the special case for $r>0$, but unrolled the case $wˆ0$ (trying to maintain simplicity vs extreme perf)
- in our experiments this is 10%+ faster in pretty much all cases we tested