### PR TITLE
Fix `keccak256_word` ASM function

### DIFF
--- a/evm/src/cpu/kernel/asm/util/keccak.asm
+++ b/evm/src/cpu/kernel/asm/util/keccak.asm
@@ -8,7 +8,7 @@
     %stack (word) -> (0, @SEGMENT_KERNEL_GENERAL, 0, word, $num_bytes, %%after_mstore)
     %jump(mstore_unpacking)
 %%after_mstore:
-    // stack: (empty)
-    %stack () -> (0, @SEGMENT_KERNEL_GENERAL, 0, $num_bytes) // context, segment, offset, len
+    // stack: offset
+    %stack (offset) -> (0, @SEGMENT_KERNEL_GENERAL, 0, $num_bytes) // context, segment, offset, len
     KECCAK_GENERAL
 %endmacro


### PR DESCRIPTION
`mstore_unpacking` leaves the offset on the stack.