### PR TITLE
`FromTargets` trait

### DIFF
--- a/evm/src/proof.rs
+++ b/evm/src/proof.rs
@@ -13,6 +13,7 @@ use plonky2::hash::merkle_tree::MerkleCap;
 use plonky2::iop::ext_target::ExtensionTarget;
 use plonky2::iop::target::Target;
 use plonky2::plonk::config::GenericConfig;
+use plonky2::util::from_targets::FromTargets;
 use serde::{Deserialize, Serialize};
 
 use crate::all_stark::NUM_TABLES;
@@ -83,10 +84,43 @@ pub struct PublicValuesTarget {
     pub block_metadata: BlockMetadataTarget,
 }
 
+impl<'a, F, const D: usize> FromTargets<'a, F, D> for PublicValuesTarget {
+    type Config = ();
+
+    fn len(_config: Self::Config) -> usize {
+        2 * <TrieRootsTarget as FromTargets<F, D>>::len(())
+            + <BlockMetadataTarget as FromTargets<F, D>>::len(())
+    }
+
+    fn from_targets<I: Iterator<Item = Target>>(targets: &mut I, _config: Self::Config) -> Self {
+        Self {
+            trie_roots_before: <_ as FromTargets<F, D>>::from_targets(targets, ()),
+            trie_roots_after: <_ as FromTargets<F, D>>::from_targets(targets, ()),
+            block_metadata: <_ as FromTargets<F, D>>::from_targets(targets, ()),
+        }
+    }
+}
+
 pub struct TrieRootsTarget {
     pub state_root: [Target; 8],
     pub transactions_root: [Target; 8],
     pub receipts_root: [Target; 8],
+}
+
+impl<'a, F, const D: usize> FromTargets<'a, F, D> for TrieRootsTarget {
+    type Config = ();
+
+    fn len(_config: Self::Config) -> usize {
+        24
+    }
+
+    fn from_targets<I: Iterator<Item = Target>>(targets: &mut I, _config: Self::Config) -> Self {
+        Self {
+            state_root: <_ as FromTargets<F, D>>::from_targets(targets, ()),
+            transactions_root: <_ as FromTargets<F, D>>::from_targets(targets, ()),
+            receipts_root: <_ as FromTargets<F, D>>::from_targets(targets, ()),
+        }
+    }
 }
 
 pub struct BlockMetadataTarget {
@@ -97,6 +131,26 @@ pub struct BlockMetadataTarget {
     pub block_gaslimit: Target,
     pub block_chain_id: Target,
     pub block_base_fee: Target,
+}
+
+impl<'a, F, const D: usize> FromTargets<'a, F, D> for BlockMetadataTarget {
+    type Config = ();
+
+    fn len(_config: Self::Config) -> usize {
+        11
+    }
+
+    fn from_targets<I: Iterator<Item = Target>>(targets: &mut I, _config: Self::Config) -> Self {
+        Self {
+            block_beneficiary: <_ as FromTargets<F, D>>::from_targets(targets, ()),
+            block_timestamp: <_ as FromTargets<F, D>>::from_targets(targets, ()),
+            block_number: <_ as FromTargets<F, D>>::from_targets(targets, ()),
+            block_difficulty: <_ as FromTargets<F, D>>::from_targets(targets, ()),
+            block_gaslimit: <_ as FromTargets<F, D>>::from_targets(targets, ()),
+            block_chain_id: <_ as FromTargets<F, D>>::from_targets(targets, ()),
+            block_base_fee: <_ as FromTargets<F, D>>::from_targets(targets, ()),
+        }
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/evm/src/recursive_verifier.rs
+++ b/evm/src/recursive_verifier.rs
@@ -579,7 +579,7 @@ where
 {
     let recursive_proofs = std::array::from_fn(|i| {
         let verifier_data = &verifier_data[i];
-        builder.add_virtual_proof_with_pis::<C>(&verifier_data.common)
+        builder.add_virtual(&verifier_data.common)
     });
     let verifier_data = std::array::from_fn(|i| {
         let verifier_data = &verifier_data[i];

--- a/evm/src/recursive_verifier.rs
+++ b/evm/src/recursive_verifier.rs
@@ -560,7 +560,7 @@ pub fn add_virtual_all_proof<F: RichField + Extendable<D>, const D: usize>(
         ),
     ];
 
-    let public_values = add_virtual_public_values(builder);
+    let public_values = builder.add_virtual(());
     AllProofTarget {
         stark_proofs,
         public_values,
@@ -583,6 +583,7 @@ where
     });
     let verifier_data = std::array::from_fn(|i| {
         let verifier_data = &verifier_data[i];
+
         VerifierCircuitTarget {
             constants_sigmas_cap: builder
                 .constant_merkle_cap(&verifier_data.verifier_only.constants_sigmas_cap),
@@ -592,53 +593,6 @@ where
     RecursiveAllProofTargetWithData {
         recursive_proofs,
         verifier_data,
-    }
-}
-
-pub fn add_virtual_public_values<F: RichField + Extendable<D>, const D: usize>(
-    builder: &mut CircuitBuilder<F, D>,
-) -> PublicValuesTarget {
-    let trie_roots_before = add_virtual_trie_roots(builder);
-    let trie_roots_after = add_virtual_trie_roots(builder);
-    let block_metadata = add_virtual_block_metadata(builder);
-    PublicValuesTarget {
-        trie_roots_before,
-        trie_roots_after,
-        block_metadata,
-    }
-}
-
-pub fn add_virtual_trie_roots<F: RichField + Extendable<D>, const D: usize>(
-    builder: &mut CircuitBuilder<F, D>,
-) -> TrieRootsTarget {
-    let state_root = builder.add_virtual(());
-    let transactions_root = builder.add_virtual(());
-    let receipts_root = builder.add_virtual(());
-    TrieRootsTarget {
-        state_root,
-        transactions_root,
-        receipts_root,
-    }
-}
-
-pub fn add_virtual_block_metadata<F: RichField + Extendable<D>, const D: usize>(
-    builder: &mut CircuitBuilder<F, D>,
-) -> BlockMetadataTarget {
-    let block_beneficiary = builder.add_virtual(());
-    let block_timestamp = builder.add_virtual(());
-    let block_number = builder.add_virtual(());
-    let block_difficulty = builder.add_virtual(());
-    let block_gaslimit = builder.add_virtual(());
-    let block_chain_id = builder.add_virtual(());
-    let block_base_fee = builder.add_virtual(());
-    BlockMetadataTarget {
-        block_beneficiary,
-        block_timestamp,
-        block_number,
-        block_difficulty,
-        block_gaslimit,
-        block_chain_id,
-        block_base_fee,
     }
 }
 

--- a/evm/src/stark_testing.rs
+++ b/evm/src/stark_testing.rs
@@ -118,17 +118,17 @@ where
     let mut builder = CircuitBuilder::<F, D>::new(circuit_config);
     let mut pw = PartialWitness::<F>::new();
 
-    let locals_t = builder.add_virtual_extension_targets(S::COLUMNS);
+    let locals_t: Vec<_> = builder.add_virtual(((), S::COLUMNS));
     pw.set_extension_targets(&locals_t, vars.local_values);
-    let nexts_t = builder.add_virtual_extension_targets(S::COLUMNS);
+    let nexts_t: Vec<_> = builder.add_virtual(((), S::COLUMNS));
     pw.set_extension_targets(&nexts_t, vars.next_values);
-    let alphas_t = builder.add_virtual_targets(1);
+    let alphas_t: Vec<_> = builder.add_virtual(((), 1));
     pw.set_target(alphas_t[0], alphas[0]);
-    let z_last_t = builder.add_virtual_extension_target();
+    let z_last_t = builder.add_virtual(());
     pw.set_extension_target(z_last_t, z_last);
-    let lagrange_first_t = builder.add_virtual_extension_target();
+    let lagrange_first_t = builder.add_virtual(());
     pw.set_extension_target(lagrange_first_t, lagrange_first);
-    let lagrange_last_t = builder.add_virtual_extension_target();
+    let lagrange_last_t = builder.add_virtual(());
     pw.set_extension_target(lagrange_last_t, lagrange_last);
 
     let vars = StarkEvaluationTargets::<D, { S::COLUMNS }> {

--- a/plonky2/examples/bench_recursion.rs
+++ b/plonky2/examples/bench_recursion.rs
@@ -15,9 +15,7 @@ use plonky2::{
     iop::witness::{PartialWitness, Witness},
     plonk::{
         circuit_builder::CircuitBuilder,
-        circuit_data::{
-            CircuitConfig, CommonCircuitData, VerifierCircuitTarget, VerifierOnlyCircuitData,
-        },
+        circuit_data::{CircuitConfig, CommonCircuitData, VerifierOnlyCircuitData},
         config::{AlgebraicHasher, GenericConfig, Hasher, PoseidonGoldilocksConfig},
         proof::{CompressedProofWithPublicInputs, ProofWithPublicInputs},
         prover::prove,
@@ -115,10 +113,7 @@ where
     let pt = builder.add_virtual(inner_cd);
     pw.set_proof_with_pis_target(&pt, inner_proof);
 
-    let inner_data = VerifierCircuitTarget {
-        constants_sigmas_cap: builder.add_virtual_cap(inner_cd.config.fri_config.cap_height),
-        circuit_digest: builder.add_virtual_hash(),
-    };
+    let inner_data = builder.add_virtual(inner_cd.config.fri_config.cap_height);
     pw.set_verifier_data_target(&inner_data, inner_vd);
 
     builder.verify_proof::<InnerC>(pt, &inner_data, inner_cd);

--- a/plonky2/examples/bench_recursion.rs
+++ b/plonky2/examples/bench_recursion.rs
@@ -112,7 +112,7 @@ where
     let (inner_proof, inner_vd, inner_cd) = inner;
     let mut builder = CircuitBuilder::<F, D>::new(config.clone());
     let mut pw = PartialWitness::new();
-    let pt = builder.add_virtual_proof_with_pis::<InnerC>(inner_cd);
+    let pt = builder.add_virtual(inner_cd);
     pw.set_proof_with_pis_target(&pt, inner_proof);
 
     let inner_data = VerifierCircuitTarget {

--- a/plonky2/src/fri/proof.rs
+++ b/plonky2/src/fri/proof.rs
@@ -237,7 +237,11 @@ impl<F: RichField + Extendable<D>, const D: usize> FromTargets<'_, F, D> for Fri
     type Config = CommonCircuitData<F, D>;
     fn len(config: &Self::Config) -> usize {
         (0..config.fri_params.reduction_arity_bits.len())
-            .map(|_| <MerkleCapTarget as FromTargets<'_, F, D>>::len(&config.config))
+            .map(|_| {
+                <MerkleCapTarget as FromTargets<'_, F, D>>::len(
+                    &config.config.fri_config.cap_height,
+                )
+            })
             .sum::<usize>()
             + (0..config.fri_params.config.num_query_rounds)
                 .map(|_| FriQueryRoundTarget::len(config))
@@ -254,7 +258,7 @@ impl<F: RichField + Extendable<D>, const D: usize> FromTargets<'_, F, D> for Fri
                 .map(|_| {
                     <MerkleCapTarget as FromTargets<'_, F, D>>::from_targets(
                         targets,
-                        &config.config,
+                        &config.config.fri_config.cap_height,
                     )
                 })
                 .collect(),

--- a/plonky2/src/fri/proof.rs
+++ b/plonky2/src/fri/proof.rs
@@ -40,22 +40,20 @@ impl<'a, F: RichField + Extendable<D>, const D: usize> FromTargets<'a, F, D>
     type Config = (&'a FriParams, usize); // (Params, query index)
 
     fn len(config: Self::Config) -> usize {
-        let num_siblings = config.0.degree_bits
+        let num_siblings = config.0.degree_bits + config.0.config.rate_bits
             - config.0.reduction_arity_bits[..=config.1]
                 .iter()
                 .sum::<usize>()
-            - config.0.config.cap_height
-            + config.0.config.rate_bits;
+            - config.0.config.cap_height;
         D * (1 << config.0.reduction_arity_bits[config.1]) + 4 * num_siblings
     }
 
     fn from_targets<I: Iterator<Item = Target>>(targets: &mut I, config: Self::Config) -> Self {
-        let num_siblings = config.0.degree_bits
+        let num_siblings = config.0.degree_bits + config.0.config.rate_bits
             - config.0.reduction_arity_bits[..=config.1]
                 .iter()
                 .sum::<usize>()
-            - config.0.config.cap_height
-            + config.0.config.rate_bits;
+            - config.0.config.cap_height;
         Self {
             evals: <_ as FromTargets<'_, F, D>>::from_targets(
                 targets,

--- a/plonky2/src/fri/recursive_verifier.rs
+++ b/plonky2/src/fri/recursive_verifier.rs
@@ -4,7 +4,6 @@ use plonky2_util::{log2_strict, reverse_index_bits_in_place};
 
 use crate::fri::proof::{
     FriChallengesTarget, FriInitialTreeProofTarget, FriProofTarget, FriQueryRoundTarget,
-    FriQueryStepTarget,
 };
 use crate::fri::structure::{FriBatchInfoTarget, FriInstanceInfoTarget, FriOpeningsTarget};
 use crate::fri::{FriConfig, FriParams};
@@ -397,81 +396,6 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
         let p_ambiguous = (num_ambiguous_elems as f64) / (F::ORDER as f64);
         assert!(p_ambiguous < query_error * 1e-5,
                 "A non-negligible portion of field elements are in the range that permits non-canonical encodings. Need to do more analysis or enforce canonical encodings.");
-    }
-
-    pub fn add_virtual_fri_proof(
-        &mut self,
-        num_leaves_per_oracle: &[usize],
-        params: &FriParams,
-    ) -> FriProofTarget<D> {
-        let cap_height = params.config.cap_height;
-        let num_queries = params.config.num_query_rounds;
-        let commit_phase_merkle_caps = (0..params.reduction_arity_bits.len())
-            .map(|_| self.add_virtual_cap(cap_height))
-            .collect();
-        let query_round_proofs = (0..num_queries)
-            .map(|_| self.add_virtual_fri_query(num_leaves_per_oracle, params))
-            .collect();
-        let final_poly = self.add_virtual_poly_coeff_ext(params.final_poly_len());
-        let pow_witness = self.add_virtual_target();
-        FriProofTarget {
-            commit_phase_merkle_caps,
-            query_round_proofs,
-            final_poly,
-            pow_witness,
-        }
-    }
-
-    fn add_virtual_fri_query(
-        &mut self,
-        num_leaves_per_oracle: &[usize],
-        params: &FriParams,
-    ) -> FriQueryRoundTarget<D> {
-        let cap_height = params.config.cap_height;
-        assert!(params.lde_bits() >= cap_height);
-        let mut merkle_proof_len = params.lde_bits() - cap_height;
-
-        let initial_trees_proof =
-            self.add_virtual_fri_initial_trees_proof(num_leaves_per_oracle, merkle_proof_len);
-
-        let mut steps = vec![];
-        for &arity_bits in &params.reduction_arity_bits {
-            assert!(merkle_proof_len >= arity_bits);
-            merkle_proof_len -= arity_bits;
-            steps.push(self.add_virtual_fri_query_step(arity_bits, merkle_proof_len));
-        }
-
-        FriQueryRoundTarget {
-            initial_trees_proof,
-            steps,
-        }
-    }
-
-    fn add_virtual_fri_initial_trees_proof(
-        &mut self,
-        num_leaves_per_oracle: &[usize],
-        initial_merkle_proof_len: usize,
-    ) -> FriInitialTreeProofTarget {
-        let evals_proofs = num_leaves_per_oracle
-            .iter()
-            .map(|&num_oracle_leaves| {
-                let leaves = self.add_virtual_targets(num_oracle_leaves);
-                let merkle_proof = self.add_virtual_merkle_proof(initial_merkle_proof_len);
-                (leaves, merkle_proof)
-            })
-            .collect();
-        FriInitialTreeProofTarget { evals_proofs }
-    }
-
-    fn add_virtual_fri_query_step(
-        &mut self,
-        arity_bits: usize,
-        merkle_proof_len: usize,
-    ) -> FriQueryStepTarget<D> {
-        FriQueryStepTarget {
-            evals: self.add_virtual_extension_targets(1 << arity_bits),
-            merkle_proof: self.add_virtual_merkle_proof(merkle_proof_len),
-        }
     }
 }
 

--- a/plonky2/src/gadgets/arithmetic_extension.rs
+++ b/plonky2/src/gadgets/arithmetic_extension.rs
@@ -471,7 +471,7 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
         y: ExtensionTarget<D>,
         z: ExtensionTarget<D>,
     ) -> ExtensionTarget<D> {
-        let inv = self.add_virtual_extension_target();
+        let inv = self.add_virtual(());
         let one = self.one_extension();
         self.add_simple_generator(QuotientGeneratorExtension {
             numerator: one,
@@ -592,7 +592,7 @@ mod tests {
         let mut builder = CircuitBuilder::<F, D>::new(config);
 
         let vs = FF::rand_vec(3);
-        let ts = builder.add_virtual_extension_targets(3);
+        let ts: Vec<_> = builder.add_virtual(((), 3));
         for (&v, &t) in vs.iter().zip(&ts) {
             pw.set_extension_target(t, v);
         }
@@ -654,12 +654,9 @@ mod tests {
         let mut pw = PartialWitness::new();
         let mut builder = CircuitBuilder::<F, D>::new(config);
 
-        let xt =
-            ExtensionAlgebraTarget(builder.add_virtual_extension_targets(D).try_into().unwrap());
-        let yt =
-            ExtensionAlgebraTarget(builder.add_virtual_extension_targets(D).try_into().unwrap());
-        let zt =
-            ExtensionAlgebraTarget(builder.add_virtual_extension_targets(D).try_into().unwrap());
+        let xt = builder.add_virtual(());
+        let yt = builder.add_virtual(());
+        let zt: ExtensionAlgebraTarget<D> = builder.add_virtual(());
         let comp_zt = builder.mul_ext_algebra(xt, yt);
         for i in 0..D {
             builder.connect_extension(zt.0[i], comp_zt.0[i]);

--- a/plonky2/src/gadgets/polynomial.rs
+++ b/plonky2/src/gadgets/polynomial.rs
@@ -19,11 +19,10 @@ impl<F: RichField + Extendable<D>, const D: usize> FromTargets<'_, F, D>
     }
 
     fn from_targets<I: Iterator<Item = Target>>(targets: &mut I, config: Self::Config) -> Self {
-        Self(
-            (0..config)
-                .map(|_| <ExtensionTarget<D> as FromTargets<'_, F, D>>::from_targets(targets, ()))
-                .collect(),
-        )
+        Self(<_ as FromTargets<F, D>>::from_targets(
+            targets,
+            ((), config),
+        ))
     }
 }
 

--- a/plonky2/src/gadgets/polynomial.rs
+++ b/plonky2/src/gadgets/polynomial.rs
@@ -14,14 +14,14 @@ impl<F: RichField + Extendable<D>, const D: usize> FromTargets<'_, F, D>
     for PolynomialCoeffsExtTarget<D>
 {
     type Config = usize;
-    fn len(config: &Self::Config) -> usize {
-        D * *config
+    fn len(config: Self::Config) -> usize {
+        D * config
     }
 
-    fn from_targets<I: Iterator<Item = Target>>(targets: &mut I, config: &Self::Config) -> Self {
+    fn from_targets<I: Iterator<Item = Target>>(targets: &mut I, config: Self::Config) -> Self {
         Self(
-            (0..*config)
-                .map(|_| <ExtensionTarget<D> as FromTargets<'_, F, D>>::from_targets(targets, &()))
+            (0..config)
+                .map(|_| <ExtensionTarget<D> as FromTargets<'_, F, D>>::from_targets(targets, ()))
                 .collect(),
         )
     }

--- a/plonky2/src/gadgets/polynomial.rs
+++ b/plonky2/src/gadgets/polynomial.rs
@@ -4,10 +4,28 @@ use crate::hash::hash_types::RichField;
 use crate::iop::ext_target::{ExtensionAlgebraTarget, ExtensionTarget};
 use crate::iop::target::Target;
 use crate::plonk::circuit_builder::CircuitBuilder;
+use crate::util::from_targets::FromTargets;
 use crate::util::reducing::ReducingFactorTarget;
 
 #[derive(Debug)]
 pub struct PolynomialCoeffsExtTarget<const D: usize>(pub Vec<ExtensionTarget<D>>);
+
+impl<F: RichField + Extendable<D>, const D: usize> FromTargets<'_, F, D>
+    for PolynomialCoeffsExtTarget<D>
+{
+    type Config = usize;
+    fn len(config: &Self::Config) -> usize {
+        D * *config
+    }
+
+    fn from_targets<I: Iterator<Item = Target>>(targets: &mut I, config: &Self::Config) -> Self {
+        Self(
+            (0..*config)
+                .map(|_| <ExtensionTarget<D> as FromTargets<'_, F, D>>::from_targets(targets, &()))
+                .collect(),
+        )
+    }
+}
 
 impl<const D: usize> PolynomialCoeffsExtTarget<D> {
     pub fn len(&self) -> usize {

--- a/plonky2/src/gadgets/select.rs
+++ b/plonky2/src/gadgets/select.rs
@@ -59,8 +59,8 @@ mod tests {
         let mut builder = CircuitBuilder::<F, D>::new(config);
 
         let (x, y) = (FF::rand(), FF::rand());
-        let xt = builder.add_virtual_extension_target();
-        let yt = builder.add_virtual_extension_target();
+        let xt = builder.add_virtual(());
+        let yt = builder.add_virtual(());
         let truet = builder._true();
         let falset = builder._false();
 

--- a/plonky2/src/gates/gate_testing.rs
+++ b/plonky2/src/gates/gate_testing.rs
@@ -137,11 +137,11 @@ where
     let mut pw = PartialWitness::new();
     let mut builder = CircuitBuilder::<F, D>::new(config);
 
-    let wires_t = builder.add_virtual_extension_targets(wires.len());
-    let constants_t = builder.add_virtual_extension_targets(constants.len());
+    let wires_t: Vec<_> = builder.add_virtual(((), wires.len()));
+    let constants_t: Vec<_> = builder.add_virtual(((), constants.len()));
     pw.set_extension_targets(&wires_t, &wires);
     pw.set_extension_targets(&constants_t, &constants);
-    let public_inputs_hash_t = builder.add_virtual_hash();
+    let public_inputs_hash_t = builder.add_virtual(());
     pw.set_hash_target(public_inputs_hash_t, public_inputs_hash);
 
     let vars = EvaluationVars {

--- a/plonky2/src/hash/hash_types.rs
+++ b/plonky2/src/hash/hash_types.rs
@@ -96,11 +96,11 @@ pub struct HashOutTarget {
 impl<F, const D: usize> FromTargets<'_, F, D> for HashOutTarget {
     type Config = ();
 
-    fn len(_config: &Self::Config) -> usize {
+    fn len(_config: Self::Config) -> usize {
         4
     }
 
-    fn from_targets<I: Iterator<Item = Target>>(targets: &mut I, _config: &Self::Config) -> Self {
+    fn from_targets<I: Iterator<Item = Target>>(targets: &mut I, _config: Self::Config) -> Self {
         Self {
             elements: [
                 targets.next().unwrap(),
@@ -133,14 +133,14 @@ pub struct MerkleCapTarget(pub Vec<HashOutTarget>);
 impl<F, const D: usize> FromTargets<'_, F, D> for MerkleCapTarget {
     type Config = usize; // Cap height
 
-    fn len(config: &Self::Config) -> usize {
-        4 << *config
+    fn len(config: Self::Config) -> usize {
+        4 << config
     }
 
-    fn from_targets<I: Iterator<Item = Target>>(targets: &mut I, config: &Self::Config) -> Self {
+    fn from_targets<I: Iterator<Item = Target>>(targets: &mut I, config: Self::Config) -> Self {
         let mut v = Vec::new();
-        for _ in 0..1 << *config {
-            let h = <HashOutTarget as FromTargets<F, D>>::from_targets(targets, &());
+        for _ in 0..1 << config {
+            let h = <HashOutTarget as FromTargets<F, D>>::from_targets(targets, ());
             v.push(h);
         }
         Self(v)

--- a/plonky2/src/hash/hash_types.rs
+++ b/plonky2/src/hash/hash_types.rs
@@ -4,7 +4,6 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::hash::poseidon::Poseidon;
 use crate::iop::target::Target;
-use crate::plonk::circuit_data::CircuitConfig;
 use crate::plonk::config::GenericHashOut;
 use crate::util::from_targets::FromTargets;
 
@@ -132,15 +131,15 @@ impl HashOutTarget {
 pub struct MerkleCapTarget(pub Vec<HashOutTarget>);
 
 impl<F, const D: usize> FromTargets<'_, F, D> for MerkleCapTarget {
-    type Config = CircuitConfig;
+    type Config = usize; // Cap height
 
     fn len(config: &Self::Config) -> usize {
-        config.fri_config.num_cap_elements() * 4
+        4 << *config
     }
 
     fn from_targets<I: Iterator<Item = Target>>(targets: &mut I, config: &Self::Config) -> Self {
         let mut v = Vec::new();
-        for _ in 0..config.fri_config.num_cap_elements() {
+        for _ in 0..1 << *config {
             let h = <HashOutTarget as FromTargets<F, D>>::from_targets(targets, &());
             v.push(h);
         }

--- a/plonky2/src/hash/hash_types.rs
+++ b/plonky2/src/hash/hash_types.rs
@@ -102,12 +102,7 @@ impl<F, const D: usize> FromTargets<'_, F, D> for HashOutTarget {
 
     fn from_targets<I: Iterator<Item = Target>>(targets: &mut I, _config: Self::Config) -> Self {
         Self {
-            elements: [
-                targets.next().unwrap(),
-                targets.next().unwrap(),
-                targets.next().unwrap(),
-                targets.next().unwrap(),
-            ],
+            elements: <_ as FromTargets<F, D>>::from_targets(targets, ()),
         }
     }
 }
@@ -138,12 +133,10 @@ impl<F, const D: usize> FromTargets<'_, F, D> for MerkleCapTarget {
     }
 
     fn from_targets<I: Iterator<Item = Target>>(targets: &mut I, config: Self::Config) -> Self {
-        let mut v = Vec::new();
-        for _ in 0..1 << config {
-            let h = <HashOutTarget as FromTargets<F, D>>::from_targets(targets, ());
-            v.push(h);
-        }
-        Self(v)
+        Self(<_ as FromTargets<F, D>>::from_targets(
+            targets,
+            ((), 1 << config),
+        ))
     }
 }
 

--- a/plonky2/src/hash/merkle_proofs.rs
+++ b/plonky2/src/hash/merkle_proofs.rs
@@ -33,14 +33,14 @@ pub struct MerkleProofTarget {
 impl<F: RichField + Extendable<D>, const D: usize> FromTargets<'_, F, D> for MerkleProofTarget {
     type Config = usize;
 
-    fn len(config: &Self::Config) -> usize {
-        *config * 4
+    fn len(config: Self::Config) -> usize {
+        config * 4
     }
 
-    fn from_targets<I: Iterator<Item = Target>>(targets: &mut I, config: &Self::Config) -> Self {
+    fn from_targets<I: Iterator<Item = Target>>(targets: &mut I, config: Self::Config) -> Self {
         Self {
-            siblings: (0..*config)
-                .map(|_| <HashOutTarget as FromTargets<F, D>>::from_targets(targets, &()))
+            siblings: (0..config)
+                .map(|_| <HashOutTarget as FromTargets<F, D>>::from_targets(targets, ()))
                 .collect(),
         }
     }

--- a/plonky2/src/hash/merkle_proofs.rs
+++ b/plonky2/src/hash/merkle_proofs.rs
@@ -39,9 +39,7 @@ impl<F: RichField + Extendable<D>, const D: usize> FromTargets<'_, F, D> for Mer
 
     fn from_targets<I: Iterator<Item = Target>>(targets: &mut I, config: Self::Config) -> Self {
         Self {
-            siblings: (0..config)
-                .map(|_| <HashOutTarget as FromTargets<F, D>>::from_targets(targets, ()))
-                .collect(),
+            siblings: <_ as FromTargets<F, D>>::from_targets(targets, ((), config)),
         }
     }
 }

--- a/plonky2/src/hash/merkle_proofs.rs
+++ b/plonky2/src/hash/merkle_proofs.rs
@@ -198,13 +198,13 @@ mod tests {
         let proof = tree.prove(i);
 
         let proof_t = MerkleProofTarget {
-            siblings: builder.add_virtual_hashes(proof.siblings.len()),
+            siblings: builder.add_virtual(((), proof.siblings.len())),
         };
         for i in 0..proof.siblings.len() {
             pw.set_hash_target(proof_t.siblings[i], proof.siblings[i]);
         }
 
-        let cap_t = builder.add_virtual_cap(cap_height);
+        let cap_t = builder.add_virtual(cap_height);
         pw.set_cap_target(&cap_t, &tree.cap);
 
         let i_c = builder.constant(F::from_canonical_usize(i));

--- a/plonky2/src/iop/ext_target.rs
+++ b/plonky2/src/iop/ext_target.rs
@@ -89,6 +89,18 @@ impl<const D: usize> ExtensionAlgebraTarget<D> {
     }
 }
 
+impl<F, const D: usize> FromTargets<'_, F, D> for ExtensionAlgebraTarget<D> {
+    type Config = ();
+
+    fn len(_config: Self::Config) -> usize {
+        D * D
+    }
+
+    fn from_targets<I: Iterator<Item = Target>>(targets: &mut I, _config: Self::Config) -> Self {
+        ExtensionAlgebraTarget(<_ as FromTargets<F, D>>::from_targets(targets, ()))
+    }
+}
+
 impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
     pub fn constant_extension(&mut self, c: F::Extension) -> ExtensionTarget<D> {
         let c_parts = c.to_basefield_array();

--- a/plonky2/src/iop/ext_target.rs
+++ b/plonky2/src/iop/ext_target.rs
@@ -75,7 +75,7 @@ impl<F, const D: usize> FromTargets<'_, F, D> for ExtensionTarget<D> {
     }
 
     fn from_targets<I: Iterator<Item = Target>>(targets: &mut I, _config: Self::Config) -> Self {
-        ExtensionTarget(std::array::from_fn(|_| targets.next().unwrap()))
+        ExtensionTarget(<_ as FromTargets<F, D>>::from_targets(targets, ()))
     }
 }
 

--- a/plonky2/src/iop/ext_target.rs
+++ b/plonky2/src/iop/ext_target.rs
@@ -7,6 +7,7 @@ use plonky2_field::types::Field;
 use crate::hash::hash_types::RichField;
 use crate::iop::target::Target;
 use crate::plonk::circuit_builder::CircuitBuilder;
+use crate::util::from_targets::FromTargets;
 
 /// `Target`s representing an element of an extension field.
 #[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
@@ -63,6 +64,18 @@ impl<const D: usize> TryFrom<Vec<Target>> for ExtensionTarget<D> {
 
     fn try_from(value: Vec<Target>) -> Result<Self, Self::Error> {
         Ok(Self(value.try_into()?))
+    }
+}
+
+impl<F, const D: usize> FromTargets<'_, F, D> for ExtensionTarget<D> {
+    type Config = ();
+
+    fn len(_config: &Self::Config) -> usize {
+        D
+    }
+
+    fn from_targets<I: Iterator<Item = Target>>(targets: &mut I, _config: &Self::Config) -> Self {
+        ExtensionTarget(std::array::from_fn(|_| targets.next().unwrap()))
     }
 }
 

--- a/plonky2/src/iop/ext_target.rs
+++ b/plonky2/src/iop/ext_target.rs
@@ -70,11 +70,11 @@ impl<const D: usize> TryFrom<Vec<Target>> for ExtensionTarget<D> {
 impl<F, const D: usize> FromTargets<'_, F, D> for ExtensionTarget<D> {
     type Config = ();
 
-    fn len(_config: &Self::Config) -> usize {
+    fn len(_config: Self::Config) -> usize {
         D
     }
 
-    fn from_targets<I: Iterator<Item = Target>>(targets: &mut I, _config: &Self::Config) -> Self {
+    fn from_targets<I: Iterator<Item = Target>>(targets: &mut I, _config: Self::Config) -> Self {
         ExtensionTarget(std::array::from_fn(|_| targets.next().unwrap()))
     }
 }

--- a/plonky2/src/plonk/circuit_builder.rs
+++ b/plonky2/src/plonk/circuit_builder.rs
@@ -174,10 +174,13 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
         (0..n).map(|_i| self.add_virtual_target()).collect()
     }
 
-    pub fn add_virtual<'a, A: FromTargets<'a, F, D, Config = CircuitConfig>>(&mut self) -> A {
-        let len = A::len(&self.config);
+    pub fn add_virtual<'a, Config, A: FromTargets<'a, F, D, Config = Config>>(
+        &mut self,
+        c: &Config,
+    ) -> A {
+        let len = A::len(c);
         let mut targets = self.add_virtual_targets(len).into_iter();
-        A::from_targets(&mut targets, &self.config)
+        A::from_targets(&mut targets, c)
     }
 
     pub fn add_virtual_target_arr<const N: usize>(&mut self) -> [Target; N] {

--- a/plonky2/src/plonk/circuit_builder.rs
+++ b/plonky2/src/plonk/circuit_builder.rs
@@ -42,6 +42,7 @@ use crate::plonk::permutation_argument::Forest;
 use crate::plonk::plonk_common::PlonkOracle;
 use crate::timed;
 use crate::util::context_tree::ContextTree;
+use crate::util::from_targets::FromTargets;
 use crate::util::partial_products::num_partial_products;
 use crate::util::timing::TimingTree;
 use crate::util::{transpose, transpose_poly_values};
@@ -171,6 +172,12 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
 
     pub fn add_virtual_targets(&mut self, n: usize) -> Vec<Target> {
         (0..n).map(|_i| self.add_virtual_target()).collect()
+    }
+
+    pub fn add_virtual<'a, A: FromTargets<'a, F, D, Config = CircuitConfig>>(&mut self) -> A {
+        let len = A::len(&self.config);
+        let mut targets = self.add_virtual_targets(len).into_iter();
+        A::from_targets(&mut targets, &self.config)
     }
 
     pub fn add_virtual_target_arr<const N: usize>(&mut self) -> [Target; N] {

--- a/plonky2/src/plonk/circuit_builder.rs
+++ b/plonky2/src/plonk/circuit_builder.rs
@@ -174,9 +174,9 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
         (0..n).map(|_i| self.add_virtual_target()).collect()
     }
 
-    pub fn add_virtual<'a, Config, A: FromTargets<'a, F, D, Config = Config>>(
+    pub fn add_virtual<'a, Config: Copy, A: FromTargets<'a, F, D, Config = Config>>(
         &mut self,
-        c: &Config,
+        c: Config,
     ) -> A {
         let len = A::len(c);
         let mut targets = self.add_virtual_targets(len).into_iter();

--- a/plonky2/src/plonk/circuit_data.rs
+++ b/plonky2/src/plonk/circuit_data.rs
@@ -501,17 +501,17 @@ pub struct VerifierCircuitTarget {
 impl<'a, F, const D: usize> FromTargets<'a, F, D> for VerifierCircuitTarget {
     type Config = usize; // Cap height
 
-    fn len(config: &Self::Config) -> usize {
+    fn len(config: Self::Config) -> usize {
         <MerkleCapTarget as FromTargets<F, D>>::len(config)
-            + <HashOutTarget as FromTargets<F, D>>::len(&())
+            + <HashOutTarget as FromTargets<F, D>>::len(())
     }
 
-    fn from_targets<I: Iterator<Item = Target>>(targets: &mut I, config: &Self::Config) -> Self {
+    fn from_targets<I: Iterator<Item = Target>>(targets: &mut I, config: Self::Config) -> Self {
         Self {
             constants_sigmas_cap: <MerkleCapTarget as FromTargets<F, D>>::from_targets(
                 targets, config,
             ),
-            circuit_digest: <HashOutTarget as FromTargets<F, D>>::from_targets(targets, &()),
+            circuit_digest: <HashOutTarget as FromTargets<F, D>>::from_targets(targets, ()),
         }
     }
 }

--- a/plonky2/src/plonk/proof.rs
+++ b/plonky2/src/plonk/proof.rs
@@ -45,27 +45,27 @@ pub struct ProofTarget<const D: usize> {
     pub opening_proof: FriProofTarget<D>,
 }
 
-impl<F: RichField + Extendable<D>, const D: usize> FromTargets<'_, F, D> for ProofTarget<D> {
-    type Config = CommonCircuitData<F, D>;
-    fn len(config: &Self::Config) -> usize {
-        3 * <MerkleCapTarget as FromTargets<F, D>>::len(&config.config.fri_config.cap_height)
+impl<'a, F: RichField + Extendable<D>, const D: usize> FromTargets<'a, F, D> for ProofTarget<D> {
+    type Config = &'a CommonCircuitData<F, D>;
+    fn len(config: Self::Config) -> usize {
+        3 * <MerkleCapTarget as FromTargets<F, D>>::len(config.config.fri_config.cap_height)
             + OpeningSetTarget::len(config)
             + FriProofTarget::len(config)
     }
 
-    fn from_targets<I: Iterator<Item = Target>>(targets: &mut I, config: &Self::Config) -> Self {
+    fn from_targets<I: Iterator<Item = Target>>(targets: &mut I, config: Self::Config) -> Self {
         Self {
             wires_cap: <MerkleCapTarget as FromTargets<F, D>>::from_targets(
                 targets,
-                &config.config.fri_config.cap_height,
+                config.config.fri_config.cap_height,
             ),
             plonk_zs_partial_products_cap: <MerkleCapTarget as FromTargets<F, D>>::from_targets(
                 targets,
-                &config.config.fri_config.cap_height,
+                config.config.fri_config.cap_height,
             ),
             quotient_polys_cap: <MerkleCapTarget as FromTargets<F, D>>::from_targets(
                 targets,
-                &config.config.fri_config.cap_height,
+                config.config.fri_config.cap_height,
             ),
             openings: OpeningSetTarget::from_targets(targets, config),
             opening_proof: FriProofTarget::from_targets(targets, config),
@@ -312,15 +312,16 @@ pub struct ProofWithPublicInputsTarget<const D: usize> {
     pub public_inputs: Vec<Target>,
 }
 
-impl<F: RichField + Extendable<D>, const D: usize> FromTargets<'_, F, D>
+impl<'a, F: RichField + Extendable<D>, const D: usize> FromTargets<'a, F, D>
     for ProofWithPublicInputsTarget<D>
 {
-    type Config = CommonCircuitData<F, D>;
-    fn len(config: &Self::Config) -> usize {
+    type Config = &'a CommonCircuitData<F, D>;
+
+    fn len(config: Self::Config) -> usize {
         ProofTarget::len(config) + config.num_public_inputs
     }
 
-    fn from_targets<I: Iterator<Item = Target>>(targets: &mut I, config: &Self::Config) -> Self {
+    fn from_targets<I: Iterator<Item = Target>>(targets: &mut I, config: Self::Config) -> Self {
         Self {
             proof: ProofTarget::from_targets(targets, config),
             public_inputs: targets.collect(),
@@ -427,9 +428,12 @@ impl<const D: usize> OpeningSetTarget<D> {
     }
 }
 
-impl<F: RichField + Extendable<D>, const D: usize> FromTargets<'_, F, D> for OpeningSetTarget<D> {
-    type Config = CommonCircuitData<F, D>;
-    fn len(config: &Self::Config) -> usize {
+impl<'a, F: RichField + Extendable<D>, const D: usize> FromTargets<'a, F, D>
+    for OpeningSetTarget<D>
+{
+    type Config = &'a CommonCircuitData<F, D>;
+
+    fn len(config: Self::Config) -> usize {
         let circonfig = &config.config;
         D * (config.num_constants // constants
             + circonfig.num_routed_wires // plonk_sigmas
@@ -439,29 +443,29 @@ impl<F: RichField + Extendable<D>, const D: usize> FromTargets<'_, F, D> for Ope
             + (config.quotient_degree_factor * circonfig.num_challenges)) // quotient_polys
     }
 
-    fn from_targets<I: Iterator<Item = Target>>(targets: &mut I, config: &Self::Config) -> Self {
+    fn from_targets<I: Iterator<Item = Target>>(targets: &mut I, config: Self::Config) -> Self {
         let circonfig = &config.config;
         Self {
             constants: (0..config.num_constants)
-                .map(|_| <ExtensionTarget<D> as FromTargets<F, D>>::from_targets(targets, &()))
+                .map(|_| <ExtensionTarget<D> as FromTargets<F, D>>::from_targets(targets, ()))
                 .collect(),
             plonk_sigmas: (0..circonfig.num_routed_wires)
-                .map(|_| <ExtensionTarget<D> as FromTargets<F, D>>::from_targets(targets, &()))
+                .map(|_| <ExtensionTarget<D> as FromTargets<F, D>>::from_targets(targets, ()))
                 .collect(),
             wires: (0..circonfig.num_wires)
-                .map(|_| <ExtensionTarget<D> as FromTargets<F, D>>::from_targets(targets, &()))
+                .map(|_| <ExtensionTarget<D> as FromTargets<F, D>>::from_targets(targets, ()))
                 .collect(),
             plonk_zs: (0..circonfig.num_challenges)
-                .map(|_| <ExtensionTarget<D> as FromTargets<F, D>>::from_targets(targets, &()))
+                .map(|_| <ExtensionTarget<D> as FromTargets<F, D>>::from_targets(targets, ()))
                 .collect(),
             plonk_zs_next: (0..circonfig.num_challenges)
-                .map(|_| <ExtensionTarget<D> as FromTargets<F, D>>::from_targets(targets, &()))
+                .map(|_| <ExtensionTarget<D> as FromTargets<F, D>>::from_targets(targets, ()))
                 .collect(),
             partial_products: (0..config.num_partial_products * circonfig.num_challenges)
-                .map(|_| <ExtensionTarget<D> as FromTargets<F, D>>::from_targets(targets, &()))
+                .map(|_| <ExtensionTarget<D> as FromTargets<F, D>>::from_targets(targets, ()))
                 .collect(),
             quotient_polys: (0..config.quotient_degree_factor * circonfig.num_challenges)
-                .map(|_| <ExtensionTarget<D> as FromTargets<F, D>>::from_targets(targets, &()))
+                .map(|_| <ExtensionTarget<D> as FromTargets<F, D>>::from_targets(targets, ()))
                 .collect(),
         }
     }

--- a/plonky2/src/plonk/proof.rs
+++ b/plonky2/src/plonk/proof.rs
@@ -446,27 +446,28 @@ impl<'a, F: RichField + Extendable<D>, const D: usize> FromTargets<'a, F, D>
     fn from_targets<I: Iterator<Item = Target>>(targets: &mut I, config: Self::Config) -> Self {
         let circonfig = &config.config;
         Self {
-            constants: (0..config.num_constants)
-                .map(|_| <ExtensionTarget<D> as FromTargets<F, D>>::from_targets(targets, ()))
-                .collect(),
-            plonk_sigmas: (0..circonfig.num_routed_wires)
-                .map(|_| <ExtensionTarget<D> as FromTargets<F, D>>::from_targets(targets, ()))
-                .collect(),
-            wires: (0..circonfig.num_wires)
-                .map(|_| <ExtensionTarget<D> as FromTargets<F, D>>::from_targets(targets, ()))
-                .collect(),
-            plonk_zs: (0..circonfig.num_challenges)
-                .map(|_| <ExtensionTarget<D> as FromTargets<F, D>>::from_targets(targets, ()))
-                .collect(),
-            plonk_zs_next: (0..circonfig.num_challenges)
-                .map(|_| <ExtensionTarget<D> as FromTargets<F, D>>::from_targets(targets, ()))
-                .collect(),
-            partial_products: (0..config.num_partial_products * circonfig.num_challenges)
-                .map(|_| <ExtensionTarget<D> as FromTargets<F, D>>::from_targets(targets, ()))
-                .collect(),
-            quotient_polys: (0..config.quotient_degree_factor * circonfig.num_challenges)
-                .map(|_| <ExtensionTarget<D> as FromTargets<F, D>>::from_targets(targets, ()))
-                .collect(),
+            constants: <_ as FromTargets<F, D>>::from_targets(targets, ((), config.num_constants)),
+            plonk_sigmas: <_ as FromTargets<F, D>>::from_targets(
+                targets,
+                ((), circonfig.num_routed_wires),
+            ),
+            wires: <_ as FromTargets<F, D>>::from_targets(targets, ((), circonfig.num_wires)),
+            plonk_zs: <_ as FromTargets<F, D>>::from_targets(
+                targets,
+                ((), circonfig.num_challenges),
+            ),
+            plonk_zs_next: <_ as FromTargets<F, D>>::from_targets(
+                targets,
+                ((), circonfig.num_challenges),
+            ),
+            partial_products: <_ as FromTargets<F, D>>::from_targets(
+                targets,
+                ((), config.num_partial_products * circonfig.num_challenges),
+            ),
+            quotient_polys: <_ as FromTargets<F, D>>::from_targets(
+                targets,
+                ((), config.quotient_degree_factor * circonfig.num_challenges),
+            ),
         }
     }
 }

--- a/plonky2/src/plonk/proof.rs
+++ b/plonky2/src/plonk/proof.rs
@@ -48,7 +48,7 @@ pub struct ProofTarget<const D: usize> {
 impl<F: RichField + Extendable<D>, const D: usize> FromTargets<'_, F, D> for ProofTarget<D> {
     type Config = CommonCircuitData<F, D>;
     fn len(config: &Self::Config) -> usize {
-        3 * <MerkleCapTarget as FromTargets<F, D>>::len(&config.config)
+        3 * <MerkleCapTarget as FromTargets<F, D>>::len(&config.config.fri_config.cap_height)
             + OpeningSetTarget::len(config)
             + FriProofTarget::len(config)
     }
@@ -57,15 +57,15 @@ impl<F: RichField + Extendable<D>, const D: usize> FromTargets<'_, F, D> for Pro
         Self {
             wires_cap: <MerkleCapTarget as FromTargets<F, D>>::from_targets(
                 targets,
-                &config.config,
+                &config.config.fri_config.cap_height,
             ),
             plonk_zs_partial_products_cap: <MerkleCapTarget as FromTargets<F, D>>::from_targets(
                 targets,
-                &config.config,
+                &config.config.fri_config.cap_height,
             ),
             quotient_polys_cap: <MerkleCapTarget as FromTargets<F, D>>::from_targets(
                 targets,
-                &config.config,
+                &config.config.fri_config.cap_height,
             ),
             openings: OpeningSetTarget::from_targets(targets, config),
             opening_proof: FriProofTarget::from_targets(targets, config),

--- a/plonky2/src/recursion/conditional_recursive_verifier.rs
+++ b/plonky2/src/recursion/conditional_recursive_verifier.rs
@@ -158,11 +158,7 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
         C::Hasher: AlgebraicHasher<F>,
     {
         let dummy_proof = self.add_virtual::<_, _>(inner_common_data);
-        let dummy_verifier_data = VerifierCircuitTarget {
-            constants_sigmas_cap: self
-                .add_virtual_cap(inner_common_data.config.fri_config.cap_height),
-            circuit_digest: self.add_virtual_hash(),
-        };
+        let dummy_verifier_data = self.add_virtual(inner_common_data.config.fri_config.cap_height);
         self.conditionally_verify_proof::<C>(
             condition,
             proof_with_pis,
@@ -409,15 +405,9 @@ mod tests {
         pw.set_proof_with_pis_target(&pt, &proof);
         let dummy_pt = builder.add_virtual::<_, _>(&data.common);
         pw.set_proof_with_pis_target::<C, D>(&dummy_pt, &dummy_proof);
-        let inner_data = VerifierCircuitTarget {
-            constants_sigmas_cap: builder.add_virtual_cap(data.common.config.fri_config.cap_height),
-            circuit_digest: builder.add_virtual_hash(),
-        };
+        let inner_data = builder.add_virtual(data.common.config.fri_config.cap_height);
         pw.set_verifier_data_target(&inner_data, &data.verifier_only);
-        let dummy_inner_data = VerifierCircuitTarget {
-            constants_sigmas_cap: builder.add_virtual_cap(data.common.config.fri_config.cap_height),
-            circuit_digest: builder.add_virtual_hash(),
-        };
+        let dummy_inner_data = builder.add_virtual(data.common.config.fri_config.cap_height);
         pw.set_verifier_data_target(&dummy_inner_data, &dummy_data);
         let b = builder.constant_bool(F::rand().0 % 2 == 0);
         builder.conditionally_verify_proof::<C>(

--- a/plonky2/src/recursion/conditional_recursive_verifier.rs
+++ b/plonky2/src/recursion/conditional_recursive_verifier.rs
@@ -157,7 +157,7 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
     where
         C::Hasher: AlgebraicHasher<F>,
     {
-        let dummy_proof = self.add_virtual::<_, _>(inner_common_data);
+        let dummy_proof = self.add_virtual(inner_common_data);
         let dummy_verifier_data = self.add_virtual(inner_common_data.config.fri_config.cap_height);
         self.conditionally_verify_proof::<C>(
             condition,
@@ -401,9 +401,9 @@ mod tests {
         // Conditionally verify the two proofs.
         let mut builder = CircuitBuilder::<F, D>::new(config);
         let mut pw = PartialWitness::new();
-        let pt = builder.add_virtual::<_, _>(&data.common);
+        let pt = builder.add_virtual(&data.common);
         pw.set_proof_with_pis_target(&pt, &proof);
-        let dummy_pt = builder.add_virtual::<_, _>(&data.common);
+        let dummy_pt = builder.add_virtual(&data.common);
         pw.set_proof_with_pis_target::<C, D>(&dummy_pt, &dummy_proof);
         let inner_data = builder.add_virtual(data.common.config.fri_config.cap_height);
         pw.set_verifier_data_target(&inner_data, &data.verifier_only);

--- a/plonky2/src/recursion/conditional_recursive_verifier.rs
+++ b/plonky2/src/recursion/conditional_recursive_verifier.rs
@@ -157,7 +157,7 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
     where
         C::Hasher: AlgebraicHasher<F>,
     {
-        let dummy_proof = self.add_virtual_proof_with_pis::<C>(inner_common_data);
+        let dummy_proof = self.add_virtual::<_, _>(inner_common_data);
         let dummy_verifier_data = VerifierCircuitTarget {
             constants_sigmas_cap: self
                 .add_virtual_cap(inner_common_data.config.fri_config.cap_height),
@@ -405,9 +405,9 @@ mod tests {
         // Conditionally verify the two proofs.
         let mut builder = CircuitBuilder::<F, D>::new(config);
         let mut pw = PartialWitness::new();
-        let pt = builder.add_virtual_proof_with_pis::<C>(&data.common);
+        let pt = builder.add_virtual::<_, _>(&data.common);
         pw.set_proof_with_pis_target(&pt, &proof);
-        let dummy_pt = builder.add_virtual_proof_with_pis::<C>(&data.common);
+        let dummy_pt = builder.add_virtual::<_, _>(&data.common);
         pw.set_proof_with_pis_target::<C, D>(&dummy_pt, &dummy_proof);
         let inner_data = VerifierCircuitTarget {
             constants_sigmas_cap: builder.add_virtual_cap(data.common.config.fri_config.cap_height),

--- a/plonky2/src/recursion/cyclic_recursion.rs
+++ b/plonky2/src/recursion/cyclic_recursion.rs
@@ -109,13 +109,11 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
         common_data.num_public_inputs = self.num_public_inputs();
         self.goal_common_data = Some(common_data.clone());
 
-        let dummy_verifier_data = VerifierCircuitTarget {
-            constants_sigmas_cap: self.add_virtual_cap(self.config.fri_config.cap_height),
-            circuit_digest: self.add_virtual_hash(),
-        };
+        let cap_height = self.config.fri_config.cap_height;
+        let dummy_verifier_data = self.add_virtual(&cap_height);
 
-        let proof = self.add_virtual_proof_with_pis::<C>(common_data);
-        let dummy_proof = self.add_virtual_proof_with_pis::<C>(common_data);
+        let proof: ProofWithPublicInputsTarget<D> = self.add_virtual(common_data);
+        let dummy_proof = self.add_virtual(common_data);
 
         let pis = VerifierCircuitTarget::from_slice::<F, C, D>(&proof.public_inputs, common_data)?;
         // Connect previous verifier data to current one. This guarantees that every proof in the cycle uses the same verifier data.
@@ -266,7 +264,7 @@ mod tests {
     use crate::hash::poseidon::{PoseidonHash, PoseidonPermutation};
     use crate::iop::witness::PartialWitness;
     use crate::plonk::circuit_builder::CircuitBuilder;
-    use crate::plonk::circuit_data::{CircuitConfig, CommonCircuitData, VerifierCircuitTarget};
+    use crate::plonk::circuit_data::{CircuitConfig, CommonCircuitData};
     use crate::plonk::config::{AlgebraicHasher, GenericConfig, Hasher, PoseidonGoldilocksConfig};
     use crate::recursion::cyclic_recursion::{
         check_cyclic_proof_verifier_data, set_cyclic_recursion_data_target, CyclicRecursionData,
@@ -287,21 +285,15 @@ mod tests {
         let data = builder.build::<C>();
         let config = CircuitConfig::standard_recursion_config();
         let mut builder = CircuitBuilder::<F, D>::new(config);
-        let proof = builder.add_virtual_proof_with_pis::<C>(&data.common);
-        let verifier_data = VerifierCircuitTarget {
-            constants_sigmas_cap: builder.add_virtual_cap(data.common.config.fri_config.cap_height),
-            circuit_digest: builder.add_virtual_hash(),
-        };
+        let proof = builder.add_virtual(&data.common);
+        let verifier_data = builder.add_virtual(&data.common.config.fri_config.cap_height);
         builder.verify_proof::<C>(proof, &verifier_data, &data.common);
         let data = builder.build::<C>();
 
         let config = CircuitConfig::standard_recursion_config();
         let mut builder = CircuitBuilder::<F, D>::new(config);
-        let proof = builder.add_virtual_proof_with_pis::<C>(&data.common);
-        let verifier_data = VerifierCircuitTarget {
-            constants_sigmas_cap: builder.add_virtual_cap(data.common.config.fri_config.cap_height),
-            circuit_digest: builder.add_virtual_hash(),
-        };
+        let proof = builder.add_virtual(&data.common);
+        let verifier_data = builder.add_virtual(&data.common.config.fri_config.cap_height);
         builder.verify_proof::<C>(proof, &verifier_data, &data.common);
         while builder.num_gates() < 1 << 12 {
             builder.add_gate(NoopGate, vec![]);

--- a/plonky2/src/recursion/cyclic_recursion.rs
+++ b/plonky2/src/recursion/cyclic_recursion.rs
@@ -109,11 +109,11 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
         common_data.num_public_inputs = self.num_public_inputs();
         self.goal_common_data = Some(common_data.clone());
 
-        let cap_height = self.config.fri_config.cap_height;
-        let dummy_verifier_data = self.add_virtual(&cap_height);
+        let dummy_verifier_data = self.add_virtual(self.config.fri_config.cap_height);
 
-        let proof: ProofWithPublicInputsTarget<D> = self.add_virtual(common_data);
-        let dummy_proof = self.add_virtual(common_data);
+        let immcd: &_ = common_data;
+        let proof: ProofWithPublicInputsTarget<D> = self.add_virtual(immcd);
+        let dummy_proof = self.add_virtual(immcd);
 
         let pis = VerifierCircuitTarget::from_slice::<F, C, D>(&proof.public_inputs, common_data)?;
         // Connect previous verifier data to current one. This guarantees that every proof in the cycle uses the same verifier data.
@@ -286,14 +286,14 @@ mod tests {
         let config = CircuitConfig::standard_recursion_config();
         let mut builder = CircuitBuilder::<F, D>::new(config);
         let proof = builder.add_virtual(&data.common);
-        let verifier_data = builder.add_virtual(&data.common.config.fri_config.cap_height);
+        let verifier_data = builder.add_virtual(data.common.config.fri_config.cap_height);
         builder.verify_proof::<C>(proof, &verifier_data, &data.common);
         let data = builder.build::<C>();
 
         let config = CircuitConfig::standard_recursion_config();
         let mut builder = CircuitBuilder::<F, D>::new(config);
         let proof = builder.add_virtual(&data.common);
-        let verifier_data = builder.add_virtual(&data.common.config.fri_config.cap_height);
+        let verifier_data = builder.add_virtual(data.common.config.fri_config.cap_height);
         builder.verify_proof::<C>(proof, &verifier_data, &data.common);
         while builder.num_gates() < 1 << 12 {
             builder.add_gate(NoopGate, vec![]);

--- a/plonky2/src/recursion/cyclic_recursion.rs
+++ b/plonky2/src/recursion/cyclic_recursion.rs
@@ -259,7 +259,7 @@ mod tests {
 
     use crate::field::types::Field;
     use crate::gates::noop::NoopGate;
-    use crate::hash::hash_types::RichField;
+    use crate::hash::hash_types::{HashOutTarget, RichField};
     use crate::hash::hashing::hash_n_to_hash_no_pad;
     use crate::hash::poseidon::{PoseidonHash, PoseidonPermutation};
     use crate::iop::witness::PartialWitness;
@@ -312,13 +312,13 @@ mod tests {
         let mut builder = CircuitBuilder::<F, D>::new(config);
 
         // Circuit that computes a repeated hash.
-        let initial_hash = builder.add_virtual_hash();
+        let initial_hash: HashOutTarget = builder.add_virtual(());
         builder.register_public_inputs(&initial_hash.elements);
         // Hash from the previous proof.
-        let old_hash = builder.add_virtual_hash();
+        let old_hash: HashOutTarget = builder.add_virtual(());
         // The input hash is either the previous hash or the initial hash depending on whether
         // the last proof was a base case.
-        let input_hash = builder.add_virtual_hash();
+        let input_hash: HashOutTarget = builder.add_virtual(());
         let h = builder.hash_n_to_hash_no_pad::<PoseidonHash>(input_hash.elements.to_vec());
         builder.register_public_inputs(&h.elements);
         // Previous counter.

--- a/plonky2/src/recursion/recursive_verifier.rs
+++ b/plonky2/src/recursion/recursive_verifier.rs
@@ -317,10 +317,8 @@ mod tests {
         let pt = builder.add_virtual::<_, _>(&inner_cd);
         pw.set_proof_with_pis_target(&pt, &inner_proof);
 
-        let inner_data = VerifierCircuitTarget {
-            constants_sigmas_cap: builder.add_virtual_cap(inner_cd.config.fri_config.cap_height),
-            circuit_digest: builder.add_virtual_hash(),
-        };
+        let inner_data: VerifierCircuitTarget =
+            builder.add_virtual(inner_cd.config.fri_config.cap_height);
         pw.set_cap_target(
             &inner_data.constants_sigmas_cap,
             &inner_vd.constants_sigmas_cap,

--- a/plonky2/src/recursion/recursive_verifier.rs
+++ b/plonky2/src/recursion/recursive_verifier.rs
@@ -372,7 +372,7 @@ mod tests {
     {
         let mut builder = CircuitBuilder::<F, D>::new(config.clone());
         let mut pw = PartialWitness::new();
-        let pt = builder.add_virtual_proof_with_pis::<InnerC>(&inner_cd);
+        let pt = builder.add_virtual::<_, _>(&inner_cd);
         pw.set_proof_with_pis_target(&pt, &inner_proof);
 
         let inner_data = VerifierCircuitTarget {

--- a/plonky2/src/util/from_targets.rs
+++ b/plonky2/src/util/from_targets.rs
@@ -1,12 +1,10 @@
 use crate::iop::target::Target;
 
 pub trait FromTargets<'a, F, const D: usize> {
-    type Config;
+    type Config: Copy;
 
-    fn len(config: &Self::Config) -> usize;
+    fn len(config: Self::Config) -> usize;
 
-    fn from_targets<I: Iterator<Item = Target>>(
-        targets: &mut I,
-        common_data: &Self::Config,
-    ) -> Self;
+    fn from_targets<I: Iterator<Item = Target>>(targets: &mut I, common_data: Self::Config)
+        -> Self;
 }

--- a/plonky2/src/util/from_targets.rs
+++ b/plonky2/src/util/from_targets.rs
@@ -5,6 +5,62 @@ pub trait FromTargets<'a, F, const D: usize> {
 
     fn len(config: Self::Config) -> usize;
 
-    fn from_targets<I: Iterator<Item = Target>>(targets: &mut I, common_data: Self::Config)
-        -> Self;
+    fn from_targets<I: Iterator<Item = Target>>(targets: &mut I, config: Self::Config) -> Self;
+}
+
+impl<'a, F, const D: usize> FromTargets<'a, F, D> for Target {
+    type Config = ();
+
+    fn len(_config: Self::Config) -> usize {
+        1
+    }
+
+    fn from_targets<I: Iterator<Item = Target>>(targets: &mut I, _config: Self::Config) -> Self {
+        targets.next().unwrap()
+    }
+}
+
+impl<'a, F, T: FromTargets<'a, F, D>, const D: usize> FromTargets<'a, F, D> for Vec<T> {
+    type Config = (T::Config, usize); // (config, size)
+
+    fn len(config: Self::Config) -> usize {
+        T::len(config.0) * config.1
+    }
+
+    fn from_targets<I: Iterator<Item = Target>>(targets: &mut I, config: Self::Config) -> Self {
+        (0..config.1)
+            .map(|_| T::from_targets(targets, config.0))
+            .collect()
+    }
+}
+
+impl<'a, F, T: FromTargets<'a, F, D>, const D: usize, const N: usize> FromTargets<'a, F, D>
+    for [T; N]
+{
+    type Config = T::Config;
+
+    fn len(config: Self::Config) -> usize {
+        T::len(config) * N
+    }
+
+    fn from_targets<I: Iterator<Item = Target>>(targets: &mut I, config: Self::Config) -> Self {
+        std::array::from_fn(|_| T::from_targets(targets, config))
+    }
+}
+
+impl<'a, F, T: FromTargets<'a, F, D>, S: FromTargets<'a, F, D>, const D: usize>
+    FromTargets<'a, F, D> for (T, S)
+{
+    type Config = (T::Config, S::Config);
+
+    fn len(config: Self::Config) -> usize {
+        T::len(config.0) + S::len(config.1)
+    }
+
+    fn from_targets<I: Iterator<Item = Target>>(targets: &mut I, config: Self::Config) -> Self {
+        (
+            T::from_targets(targets, config.0),
+            S::from_targets(targets, config.1),
+        )
+    }
 }

--- a/plonky2/src/util/from_targets.rs
+++ b/plonky2/src/util/from_targets.rs
@@ -1,0 +1,12 @@
+use crate::iop::target::Target;
+
+pub trait FromTargets<'a, F, const D: usize> {
+    type Config;
+
+    fn len(config: &Self::Config) -> usize;
+
+    fn from_targets<I: Iterator<Item = Target>>(
+        targets: &mut I,
+        common_data: &Self::Config,
+    ) -> Self;
+}

--- a/plonky2/src/util/mod.rs
+++ b/plonky2/src/util/mod.rs
@@ -2,6 +2,7 @@ use plonky2_field::polynomial::PolynomialValues;
 use plonky2_field::types::Field;
 
 pub(crate) mod context_tree;
+pub mod from_targets;
 pub(crate) mod partial_products;
 pub mod reducing;
 pub mod serialization;

--- a/plonky2/src/util/reducing.rs
+++ b/plonky2/src/util/reducing.rs
@@ -331,7 +331,7 @@ mod tests {
         let manual_reduce = builder.constant_extension(manual_reduce);
 
         let mut alpha_t = ReducingFactorTarget::new(builder.constant_extension(alpha));
-        let vs_t = builder.add_virtual_extension_targets(vs.len());
+        let vs_t: Vec<_> = builder.add_virtual(((), vs.len()));
         pw.set_extension_targets(&vs_t, &vs);
         let circuit_reduce = alpha_t.reduce(&vs_t, &mut builder);
 

--- a/starky/src/recursive_verifier.rs
+++ b/starky/src/recursive_verifier.rs
@@ -216,25 +216,18 @@ pub fn add_virtual_stark_proof<F: RichField + Extendable<D>, S: Stark<F, D>, con
     let fri_params = config.fri_params(degree_bits);
     let cap_height = fri_params.config.cap_height;
 
-    let num_leaves_per_oracle = once(S::COLUMNS)
-        .chain(
-            stark
-                .uses_permutation_args()
-                .then(|| stark.num_permutation_batches(config)),
-        )
-        .chain(once(stark.quotient_degree_factor() * config.num_challenges))
-        .collect_vec();
-
     let permutation_zs_cap = stark
         .uses_permutation_args()
-        .then(|| builder.add_virtual_cap(cap_height));
+        .then(|| builder.add_virtual(cap_height));
+
+    let fri_instance_info = stark.fri_instance(F::Extension::ONE, F::ONE, config);
 
     StarkProofTarget {
-        trace_cap: builder.add_virtual_cap(cap_height),
+        trace_cap: builder.add_virtual(cap_height),
         permutation_zs_cap,
-        quotient_polys_cap: builder.add_virtual_cap(cap_height),
+        quotient_polys_cap: builder.add_virtual(cap_height),
         openings: add_stark_opening_set_target::<F, S, D>(builder, stark, config),
-        opening_proof: builder.add_virtual_fri_proof(&num_leaves_per_oracle, &fri_params),
+        opening_proof: builder.add_virtual((&fri_params, &fri_instance_info)),
     }
 }
 
@@ -245,16 +238,15 @@ fn add_stark_opening_set_target<F: RichField + Extendable<D>, S: Stark<F, D>, co
 ) -> StarkOpeningSetTarget<D> {
     let num_challenges = config.num_challenges;
     StarkOpeningSetTarget {
-        local_values: builder.add_virtual_extension_targets(S::COLUMNS),
-        next_values: builder.add_virtual_extension_targets(S::COLUMNS),
+        local_values: builder.add_virtual(((), S::COLUMNS)),
+        next_values: builder.add_virtual(((), S::COLUMNS)),
         permutation_zs: stark
             .uses_permutation_args()
-            .then(|| builder.add_virtual_extension_targets(stark.num_permutation_batches(config))),
+            .then(|| builder.add_virtual(((), stark.num_permutation_batches(config)))),
         permutation_zs_next: stark
             .uses_permutation_args()
-            .then(|| builder.add_virtual_extension_targets(stark.num_permutation_batches(config))),
-        quotient_polys: builder
-            .add_virtual_extension_targets(stark.quotient_degree_factor() * num_challenges),
+            .then(|| builder.add_virtual(((), stark.num_permutation_batches(config)))),
+        quotient_polys: builder.add_virtual(((), stark.quotient_degree_factor() * num_challenges)),
     }
 }
 

--- a/starky/src/stark_testing.rs
+++ b/starky/src/stark_testing.rs
@@ -118,19 +118,19 @@ where
     let mut builder = CircuitBuilder::<F, D>::new(circuit_config);
     let mut pw = PartialWitness::<F>::new();
 
-    let locals_t = builder.add_virtual_extension_targets(S::COLUMNS);
+    let locals_t: Vec<_> = builder.add_virtual(((), S::COLUMNS));
     pw.set_extension_targets(&locals_t, vars.local_values);
-    let nexts_t = builder.add_virtual_extension_targets(S::COLUMNS);
+    let nexts_t: Vec<_> = builder.add_virtual(((), S::COLUMNS));
     pw.set_extension_targets(&nexts_t, vars.next_values);
-    let pis_t = builder.add_virtual_extension_targets(S::PUBLIC_INPUTS);
+    let pis_t: Vec<_> = builder.add_virtual(((), S::PUBLIC_INPUTS));
     pw.set_extension_targets(&pis_t, vars.public_inputs);
-    let alphas_t = builder.add_virtual_targets(1);
+    let alphas_t: Vec<_> = builder.add_virtual(((), 1));
     pw.set_target(alphas_t[0], alphas[0]);
-    let z_last_t = builder.add_virtual_extension_target();
+    let z_last_t = builder.add_virtual(());
     pw.set_extension_target(z_last_t, z_last);
-    let lagrange_first_t = builder.add_virtual_extension_target();
+    let lagrange_first_t = builder.add_virtual(());
     pw.set_extension_target(lagrange_first_t, lagrange_first);
-    let lagrange_last_t = builder.add_virtual_extension_target();
+    let lagrange_last_t = builder.add_virtual(());
     pw.set_extension_target(lagrange_last_t, lagrange_last);
 
     let vars = StarkEvaluationTargets::<D, { S::COLUMNS }, { S::PUBLIC_INPUTS }> {


### PR DESCRIPTION
Tentative refactor introducing a new `FromTargets` trait with a fn to go from an iterator of `Target`s to `Self`.

Using this trait, functions like `builder.add_virtual_*` or `add_virtual_*(builder,...)` can be removed and replaced with a call to a new `builder.add_virtual()` function that infers the return type. 

As a next step, this can also be used to add functions like `builder.add_constant()` which would create a constant `StructTarget` from `Struct` or `builder.add_with_generators()` which would create a `StructTarget` set non-deterministically in the trace.