### PR TITLE
Introduce crate to seamlessly aggregate proofs of different circuits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # Cargo build
-/target
+target/
 Cargo.lock
 
 # Profile-guided optimization
@@ -8,3 +8,5 @@ pgo-data.profdata
 
 # MacOS nuisances
 .DS_Store
+.idea
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["ecdsa", "evm", "field", "insertion", "maybe_rayon", "plonky2", "starky", "system_zero", "u32", "util", "waksman"]
+members = ["ecdsa", "evm", "field", "generic_recursion", "insertion", "maybe_rayon", "plonky2", "starky", "system_zero", "u32", "util", "waksman"]
 
 [profile.release]
 opt-level = 3

--- a/generic_recursion/Cargo.toml
+++ b/generic_recursion/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "generic_recursion"
+version = "0.1.0"
+edition = "2021"
+authors = [
+    "Daniele Di Benedetto",
+    "Daniele Di Tullio",
+    "Michele d'Amico",
+    "Nicholas Mainardi",
+]
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+plonky2 = { version = "0.1.1", default-features = false, features = ["parallel", "std"]}
+plonky2_util = { version = "0.1.0", default-features = false }
+anyhow = "1.0.40"
+log = "0.4.17"
+itertools = "0.10.5"
+
+[dev-dependencies]
+rand = "0.8.4"
+rstest = "0.16.0"
+serial_test = "0.10.0"
+env_logger = "0.10.0"
+plonky2_u32 = { path = "../u32" }
+# [workspace]

--- a/generic_recursion/LICENSE-APACHE
+++ b/generic_recursion/LICENSE-APACHE
@@ -1,0 +1,202 @@
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+

--- a/generic_recursion/LICENSE-MIT
+++ b/generic_recursion/LICENSE-MIT
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2022 The Plonky2 Authors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/generic_recursion/README.md
+++ b/generic_recursion/README.md
@@ -1,0 +1,132 @@
+# generic_recursion
+
+**Version:** 0.1.0
+
+
+`generic_recursion` is a crate that allows to easily aggregate an unlimited amount of plonky2 proofs,
+generated with a circuit belong to a specific set of circuits, in a single recursive proof,
+which can be verified with the same verifier data independently from the number of proofs being
+aggregated.
+
+The main component of the crate is the `AggregationScheme` data structure, which implements the
+`RecursiveCircuit` trait. This data structure already provides all the methods necessary to
+aggregate an unlimited number of plonky2 proofs generated with a set of circuits specified as
+input by the user, which will be henceforth referred to as _base_circuits_.
+
+All the base circuits in the set specified by the user are required to employ the same format
+for their public inputs, and the `AggregationScheme` needs to know such a format.
+To specify the public input format of the base circuits, and the information about them which
+are needed by the `AggregationScheme` in order to compute the public inputs of the aggregated
+proof from the public inputs of the proofs to be aggregated, this crate introduces the
+`PublicInputAggregation` trait. The crate already provides implementations of this trait
+for several public input formats, which can be found in the `shared_state` module.
+
+## Tests
+
+Tests can be run with:
+```sh
+cargo test --release
+```
+## Usage
+
+An `AggregationScheme` can be instantiated with the method `build_circuit`, which requires the
+user to provide the set of circuits that define which proofs can be aggregated with the
+instantiated `AggregationScheme`. Refer to section [How To Specify the Set of Circuits](#how-to-specify-the-set-of-circuits)
+to learn how to specify such set of circuits.
+
+Once an `AggregationScheme` is instantiated, the user can start providing proofs to be
+aggregated, which must be generated with a circuit belonging to the set specified when
+instantiating the `AggregationScheme`.
+Before being aggregated, each proof must be preprocessed by invoking the
+`prepare_base_proof_for_aggregation` method, which yields a `PreparedProof`;
+the methods of `AggregationScheme` that recursively aggregate proofs accept as input only
+`PreparedProof`s.
+Once a proof is converted to a `PreparedProof`, the user can add it to the set of proofs to be
+aggregated with the `add_proofs_for_aggregation` method; the final aggregated proof is
+then computed by invoking the `aggregate_proofs_with` method, where the user can also provide
+other `PreparedProof`s to be aggregated that have not been previously added to the set of
+proofs to be aggregated.
+
+For a real example on how to use the `AggregationScheme`, users can refer to the integration
+test `test_recursive_aggregation` found in `tests/integration.rs`
+
+### How To Specify the Set of Circuits
+To specify the set of circuits that define which proofs can be aggregated the user must
+implement the `BaseCircuitInfo` trait for the data structure representing each circuit. The
+main purpose of such trait is binding to each circuit the format of the public inputs, by
+specifying the implementation of the `PublicInputAggregation` trait corresponding to such
+format:
+
+```rust
+pub trait BaseCircuitInfo<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
+{
+    type PIScheme: PublicInputAggregation;
+
+    fn get_verifier_circuit_data(&self) -> VerifierCircuitData<F, C, D>;
+}
+```
+
+The constraints that all the base circuits in the set employed to construct the
+`AggregationScheme` must share the same public input format is imposed by the fact that all
+the circuits provided as input to the `build_circuit` method must implement `BaseCircuitInfo`
+trait specifying the same implementation of `PublicInputAggregation` as their `PIScheme`.
+
+#### Example
+
+For example, suppose that a user wants to aggregate proofs generated from a set of circuits
+with 2 base circuits, represented by data-structures `BaseCircuit1` and `BaseCircuit2`, which
+employ the format for their public input specified by `SimpleStatePublicInput` (which is one
+of the implementations of `PublicInputAggregation` provided by this crate). To instantiate an
+`AggregationScheme` for such set of circuits, the user should do as follows:
+1. Implement `BaseCircuitInfo` trait for both the circuits, specifying `SimpleStatePublicInput`
+as their `PIScheme`:
+```rust
+impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
+        BaseCircuitInfo<F, C, D> for BaseCircuit1
+    {
+        type PIScheme = SimpleStatePublicInput;
+
+        fn get_verifier_circuit_data(&self) -> VerifierCircuitData<F, C, D> {
+            // custom implementation
+        }
+   }
+
+impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
+BaseCircuitInfo<F, C, D> for BaseCircuit2<F, C, D>
+{
+    type PIScheme = SimpleStatePublicInput;
+
+    fn get_verifier_circuit_data(&self) -> VerifierCircuitData<F, C, D> {
+        // custom implementation
+    }
+}
+```
+2. Given 2 instances of the `BaseCircuit1` and `BaseCircuit2` data-structures, called
+`base_circuit_1` and `base_circuit_2`, respectively, build the set of circuits and instantiate
+the `AggregationScheme` with the `build_circuit` method as follows:
+
+```rust
+let circuit_set = vec![prepare_base_circuit_for_circuit_set(base_circuit_1),
+    prepare_base_circuit_for_circuit_set(base_circuit_2)];
+
+        let aggregation_scheme =
+            AggregationScheme::build_circuit(
+                circuit_set.into_iter(),
+            )?;
+```
+
+
+## License
+
+Licensed under either of
+
+- Apache License, Version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or <http://www.apache.org/licenses/LICENSE-2.0>)
+- MIT license ([LICENSE-MIT](LICENSE-MIT) or <http://opensource.org/licenses/MIT>)
+
+at your option.
+
+### Contribution
+
+Unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in
+the work by you, as defined in the Apache-2.0 license, shall be dual licensed as above, without
+any additional terms or conditions

--- a/generic_recursion/README.tpl
+++ b/generic_recursion/README.tpl
@@ -1,0 +1,20 @@
+# {{crate}}
+
+**Version:** {{version}}
+
+{{readme}}
+
+## License
+
+Licensed under either of
+
+- Apache License, Version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or <http://www.apache.org/licenses/LICENSE-2.0>)
+- MIT license ([LICENSE-MIT](LICENSE-MIT) or <http://opensource.org/licenses/MIT>)
+
+at your option.
+
+### Contribution
+
+Unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in
+the work by you, as defined in the Apache-2.0 license, shall be dual licensed as above, without
+any additional terms or conditions

--- a/generic_recursion/src/lib.rs
+++ b/generic_recursion/src/lib.rs
@@ -1,0 +1,124 @@
+#![feature(generic_const_exprs)]
+
+//!
+//! `generic_recursion` is a crate that allows to easily aggregate an unlimited amount of plonky2 proofs,
+//! generated with a circuit belong to a specific set of circuits, in a single recursive proof,
+//! which can be verified with the same verifier data independently from the number of proofs being
+//! aggregated.
+//!
+//! The main component of the crate is the `AggregationScheme` data structure, which implements the
+//! `RecursiveCircuit` trait. This data structure already provides all the methods necessary to
+//! aggregate an unlimited number of plonky2 proofs generated with a set of circuits specified as
+//! input by the user, which will be henceforth referred to as _base_circuits_.
+//!
+//! All the base circuits in the set specified by the user are required to employ the same format
+//! for their public inputs, and the `AggregationScheme` needs to know such a format.
+//! To specify the public input format of the base circuits, and the information about them which
+//! are needed by the `AggregationScheme` in order to compute the public inputs of the aggregated
+//! proof from the public inputs of the proofs to be aggregated, this crate introduces the
+//! `PublicInputAggregation` trait. The crate already provides implementations of this trait
+//! for several public input formats, which can be found in the `shared_state` module.
+//!
+//! # Tests
+//!
+//! Tests can be run with:
+//! ```sh
+//! cargo test --release
+//! ```
+//! # Usage
+//!
+//! An `AggregationScheme` can be instantiated with the method `build_circuit`, which requires the
+//! user to provide the set of circuits that define which proofs can be aggregated with the
+//! instantiated `AggregationScheme`. Refer to section [How To Specify the Set of Circuits](#how-to-specify-the-set-of-circuits)
+//! to learn how to specify such set of circuits.
+//!
+//! Once an `AggregationScheme` is instantiated, the user can start providing proofs to be
+//! aggregated, which must be generated with a circuit belonging to the set specified when
+//! instantiating the `AggregationScheme`.
+//! Before being aggregated, each proof must be preprocessed by invoking the
+//! `prepare_base_proof_for_aggregation` method, which yields a `PreparedProof`;
+//! the methods of `AggregationScheme` that recursively aggregate proofs accept as input only
+//! `PreparedProof`s.
+//! Once a proof is converted to a `PreparedProof`, the user can add it to the set of proofs to be
+//! aggregated with the `add_proofs_for_aggregation` method; the final aggregated proof is
+//! then computed by invoking the `aggregate_proofs_with` method, where the user can also provide
+//! other `PreparedProof`s to be aggregated that have not been previously added to the set of
+//! proofs to be aggregated.
+//!
+//! For a real example on how to use the `AggregationScheme`, users can refer to the integration
+//! test `test_recursive_aggregation` found in `tests/integration.rs`
+//!
+//! ## How To Specify the Set of Circuits
+//! To specify the set of circuits that define which proofs can be aggregated the user must
+//! implement the `BaseCircuitInfo` trait for the data structure representing each circuit. The
+//! main purpose of such trait is binding to each circuit the format of the public inputs, by
+//! specifying the implementation of the `PublicInputAggregation` trait corresponding to such
+//! format:
+//!
+//! ```ignore
+//! pub trait BaseCircuitInfo<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
+//! {
+//!     type PIScheme: PublicInputAggregation;
+//!
+//!     fn get_verifier_circuit_data(&self) -> VerifierCircuitData<F, C, D>;
+//! }
+//! ```
+//!
+//! The constraints that all the base circuits in the set employed to construct the
+//! `AggregationScheme` must share the same public input format is imposed by the fact that all
+//! the circuits provided as input to the `build_circuit` method must implement `BaseCircuitInfo`
+//! trait specifying the same implementation of `PublicInputAggregation` as their `PIScheme`.
+//!
+//! ### Example
+//!
+//! For example, suppose that a user wants to aggregate proofs generated from a set of circuits
+//! with 2 base circuits, represented by data-structures `BaseCircuit1` and `BaseCircuit2`, which
+//! employ the format for their public input specified by `SimpleStatePublicInput` (which is one
+//! of the implementations of `PublicInputAggregation` provided by this crate). To instantiate an
+//! `AggregationScheme` for such set of circuits, the user should do as follows:
+//! 1. Implement `BaseCircuitInfo` trait for both the circuits, specifying `SimpleStatePublicInput`
+//! as their `PIScheme`:
+//! ```ignore
+//! impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
+//!         BaseCircuitInfo<F, C, D> for BaseCircuit1
+//!     {
+//!         type PIScheme = SimpleStatePublicInput;
+//!
+//!         fn get_verifier_circuit_data(&self) -> VerifierCircuitData<F, C, D> {
+//!             // custom implementation
+//!         }
+//!    }
+//!
+//! impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
+//! BaseCircuitInfo<F, C, D> for BaseCircuit2<F, C, D>
+//! {
+//!     type PIScheme = SimpleStatePublicInput;
+//!
+//!     fn get_verifier_circuit_data(&self) -> VerifierCircuitData<F, C, D> {
+//!         // custom implementation
+//!     }
+//! }
+//! ```
+//! 2. Given 2 instances of the `BaseCircuit1` and `BaseCircuit2` data-structures, called
+//! `base_circuit_1` and `base_circuit_2`, respectively, build the set of circuits and instantiate
+//! the `AggregationScheme` with the `build_circuit` method as follows:
+//!
+//! ```ignore
+//! let circuit_set = vec![prepare_base_circuit_for_circuit_set(base_circuit_1),
+//!     prepare_base_circuit_for_circuit_set(base_circuit_2)];
+//!
+//!         let aggregation_scheme =
+//!             AggregationScheme::build_circuit(
+//!                 circuit_set.into_iter(),
+//!             )?;
+//! ```
+//!
+
+pub mod public_input_aggregation;
+pub mod recursion;
+
+// re-export main traits and data structures needed by the users of the crate
+pub use public_input_aggregation::PublicInputAggregation;
+pub use public_input_aggregation::shared_state::{State, SimpleStatePublicInput, MerkleRootPublicInput};
+pub use recursion::{BaseCircuitInfo, PreparedProof, RecursionCircuit, prepare_base_circuit_for_circuit_set,
+                    recursive_circuit::{AggregationScheme, PreparedProofForAggregation}};

--- a/generic_recursion/src/public_input_aggregation/mod.rs
+++ b/generic_recursion/src/public_input_aggregation/mod.rs
@@ -1,0 +1,371 @@
+//! `public_input_aggregation` module provides the utilities to allow users to specify the format
+//! of the public inputs of their base circuits.
+//! In particular, the module provides the `PublicInputAggregation` trait, which defines the
+//! information about the public input format needed to aggregate proofs whose public inputs have
+//! such format, and several implementations of such trait, corresponding to different public
+//! input formats.
+//!
+
+use plonky2::hash::hash_types::RichField;
+use plonky2::iop::target::{BoolTarget, Target};
+use plonky2::iop::witness::{PartialWitness, WitnessWrite};
+use plonky2::plonk::circuit_builder::CircuitBuilder;
+use plonky2::plonk::circuit_data::CircuitConfig;
+use plonky2::plonk::config::GenericConfig;
+use plonky2::field::extension::Extendable;
+use anyhow::Result;
+use itertools::Itertools;
+
+pub mod shared_state;
+
+// aggregate `public_input` to `aggregated_input` if and only if `condition == true`
+pub(crate) fn conditionally_aggregate_public_input<
+    F: RichField + Extendable<D>,
+    C: GenericConfig<D, F = F>,
+    const D: usize,
+    PI: PublicInputAggregation,
+>(
+    builder: &mut CircuitBuilder<F, D>,
+    condition: &BoolTarget,
+    aggregated_input: &PI,
+    public_input: &PI,
+) -> Result<PI> {
+    let updated_input = aggregated_input.aggregate_public_input(builder, &public_input);
+    PI::try_from_public_input_targets(
+        aggregated_input
+            .get_targets()
+            .into_iter()
+            .zip(updated_input.get_targets().into_iter())
+            .map(|(agg_target, upd_target)| builder.select(*condition, upd_target, agg_target))
+            .collect::<Vec<_>>()
+            .as_slice(),
+    )
+}
+
+/// `check_consistency_of_dummy_public_inputs_aggregation` is meant to be employed to test, for an
+/// implementation `PI` of the trait `PublicInputAggregation`, the consistency between the aggregation
+/// logic of public inputs and the implementations of the methods of the trait dealing with dummy
+/// proofs (i.e., `dummy_circuit_inputs_logic`, `set_dummy_circuit_inputs`,
+/// `can_aggregate_public_inputs_of_dummy_proofs`): indeed, the default implementations found in the
+/// `PublicInputAggregation` trait for such methods will not work with any public input aggregation
+/// strategy; for instance, though public inputs of dummy proofs are never aggregated when such
+/// default implementations are employed, if the aggregation strategy requires some constraints on
+/// the public inputs of proofs to be aggregated, then the default implementations will not be able
+/// to generate public inputs fulfilling such constraints, hence leading to a failure in proof
+/// aggregation.
+/// This function is meant to help implementors of `PI` spotting such incompatibility: if the function
+/// yields an error or return `false`, then the implementations of the methods of `PI` dealing with
+/// dummy proofs might need to be fixed in order to ensure compatibility with the public input
+/// aggregation logic
+pub fn check_consistency_of_dummy_public_inputs_aggregation<
+    F: RichField + Extendable<D>,
+    C: GenericConfig<D, F = F>,
+    const D: usize,
+    PI: PublicInputAggregation,
+>() -> Result<bool>
+{
+    // Step 1: generate a non-dummy proof
+    let config = CircuitConfig::standard_recursion_config();
+
+    let mut builder = CircuitBuilder::<F, D>::new(config.clone());
+    let mut pw = PartialWitness::new();
+    let pi_targets = (0..PI::num_public_inputs())
+        .map(|_| {
+            let pi_t = builder.add_virtual_target();
+            pw.set_target(pi_t, F::rand());
+            pi_t
+        })
+        .collect::<Vec<_>>();
+    let public_inputs = PI::try_from_public_input_targets(pi_targets.as_slice())?;
+    public_inputs.register_public_inputs(&mut builder);
+
+    let real_circuit_data = builder.build::<C>();
+
+    let real_proof = real_circuit_data.prove(pw)?;
+    let real_public_inputs = real_proof.public_inputs.clone();
+
+    // Step 2: build dummy circuit according to the logic in PI trait
+    let mut builder = CircuitBuilder::<F,D>::new(config.clone());
+    let public_inputs = PI::dummy_circuit_inputs_logic(&mut builder);
+
+    let dummy_circuit_data = builder.build::<C>();
+
+    // generate 2 dummy proofs
+    let mut to_be_aggregated_proofs = vec![real_proof];
+    for _ in 0..2 {
+        let mut pw = PartialWitness::new();
+        PI::set_dummy_circuit_inputs(
+            to_be_aggregated_proofs.last().unwrap().public_inputs.as_slice(),
+            &public_inputs,
+            &mut pw,
+        );
+        to_be_aggregated_proofs.push(dummy_circuit_data.prove(pw)?)
+    }
+
+    // Build a circuit that aggregates the public inputs of the non-dummy proofs with the ones of
+    // the 2 dummy proofs
+    let mut aggregate_circuit_builder = CircuitBuilder::<F, D>::new(config.clone());
+    let mut aggregate_circuit_pw = PartialWitness::new();
+    let public_input_targets = to_be_aggregated_proofs
+        .iter()
+        .map(|proof| {
+            let targets = aggregate_circuit_builder.add_virtual_targets(PI::num_public_inputs());
+            for (input, target) in proof.public_inputs.iter().zip(targets.iter()) {
+                aggregate_circuit_pw.set_target(*target, *input);
+            }
+            targets
+        })
+        .collect::<Vec<_>>();
+
+    let mut aggregation_input = PI::try_from_public_input_targets(public_input_targets[0].as_slice())?;
+    let selector = aggregate_circuit_builder._false();
+    aggregation_input =
+        public_input_targets[1..]
+            .iter()
+            .fold(Ok(aggregation_input), |agg_input, targets| {
+                let input = PI::try_from_public_input_targets(targets.as_slice())?;
+                if PI::can_aggregate_public_inputs_of_dummy_proofs() {
+                    Ok(agg_input?.aggregate_public_input(&mut aggregate_circuit_builder, &input))
+                } else {
+                    conditionally_aggregate_public_input::<F, C, D, PI>(
+                        &mut aggregate_circuit_builder,
+                        &selector,
+                        &agg_input?,
+                        &input,
+                    )
+                }
+            })?;
+    aggregation_input.register_public_inputs(&mut aggregate_circuit_builder);
+
+    let aggregation_circuit_data = aggregate_circuit_builder.build::<C>();
+
+    let proof = aggregation_circuit_data.prove(aggregate_circuit_pw)?;
+
+    // check that the public inputs of the dummy proofs were not aggregated, which means that the
+    // public inputs of the proof generated with the aggregation circuit are equal to the public
+    // inputs of the non-dummy proof
+    let are_pi_equals = proof.public_inputs == real_public_inputs;
+
+    aggregation_circuit_data.verify(proof)?;
+
+    Ok(are_pi_equals)
+}
+
+/// `PublicInputAggregation` can be implemented for a type of public inputs employed in a circuit to
+/// specify how to aggregate public inputs of different proofs all having this type of public inputs.
+/// This trait should be implemented for data-structures that collect all the public input targets
+/// employed for the given type of public inputs, providing a set of operations, to be performed
+/// inside a circuit, that allow to aggregate multiple instances of such data-structure to a single
+/// one, which will represent the public inputs of an aggregated proof.
+pub trait PublicInputAggregation: Sized {
+    type TargetList: IntoIterator<Item = Target>;
+    /// Return to the caller the number of public inputs for this scheme
+    fn num_public_inputs() -> usize;
+
+    /// Method to register the targets found in `self` as public inputs
+    /// of a proof
+    fn register_public_inputs<F: RichField + Extendable<D>, const D: usize>(
+        &self,
+        builder: &mut CircuitBuilder<F, D>,
+    );
+
+    /// Method to add the logic related to the public input scheme for a dummy circuit with builder
+    /// `builder`.
+    /// The dummy circuit enforces a trivial statement while being
+    /// compliant with the public input scheme specified by `Self`.
+    fn dummy_circuit_inputs_logic<F: RichField + Extendable<D>, const D: usize>(
+        builder: &mut CircuitBuilder<F,D>,
+    ) -> Self {
+        let targets = (0..Self::num_public_inputs())
+            .map(|_| builder.add_virtual_target())
+            .collect::<Vec<_>>();
+        let public_inputs = Self::try_from_public_input_targets(targets.as_slice()).unwrap();
+        public_inputs.register_public_inputs(builder);
+        // build the circuit
+        public_inputs
+    }
+
+    /// Method employed by the builder of the merge circuit to determine
+    /// if the public inputs of dummy proofs can be safely aggregated with
+    /// public inputs of non-dummy proofs
+    fn can_aggregate_public_inputs_of_dummy_proofs() -> bool {
+        false
+    }
+
+    /// Method to set the input values of the dummy circuit employing a set of
+    /// input values; it expects `input_values` to have the same size of the number of targets
+    /// employed in `input_targets`, that is `Self::num_public_inputs()`
+    fn set_dummy_circuit_inputs<
+        F: RichField + Extendable<D>,
+        const D: usize,
+    >(
+        input_values: &[F],
+        input_targets: &Self,
+        pw: &mut PartialWitness<F>,
+    ) {
+        let input_target_list = input_targets.get_targets();
+        for (target, input) in input_target_list
+            .into_iter()
+            .zip_eq(input_values.iter())
+        {
+            pw.set_target(target, input.clone());
+        }
+    }
+
+    /// Retrieve the list of public inputs targets in the same order they are
+    /// appended in a `ProofWithPublicInputs` data structure
+    fn get_targets(&self) -> Self::TargetList;
+
+    /// Specify how to map the public input targets found in
+    /// `ProofWithPublicInputsTarget` to the targets in `Self`.
+    /// The function expects exactly `Self::num_public_inputs()` targets as input, it should return
+    /// an error otherwise
+    fn try_from_public_input_targets(targets: &[Target]) -> Result<Self>;
+
+    /// Specify how to aggregate a public input to another public input; this
+    /// forces user to specify a public input aggregation scheme which is
+    /// incremental
+    fn aggregate_public_input<F: RichField + Extendable<D>, const D: usize>(
+        &self,
+        builder: &mut CircuitBuilder<F, D>,
+        public_input: &Self,
+    ) -> Self;
+
+    /// Aggregates the public inputs of a set of proofs in the public inputs of
+    /// the recursive proof; can be overridden by the user in case it is more
+    /// efficient (in terms of number of gates) to aggregate in a single step all the public inputs
+    /// instead of aggregating one public input at a time
+    fn aggregate_public_inputs<F: RichField + Extendable<D>, const D: usize>(
+        builder: &mut CircuitBuilder<F, D>,
+        mut public_inputs: impl Iterator<Item = Self>,
+    ) {
+        // check that there are at least 2 public inputs to be aggregated
+        let first_public_input = public_inputs.next();
+        let second_public_input = public_inputs.next();
+        assert!(first_public_input.is_some());
+        assert!(second_public_input.is_some());
+        let mut aggregate_input = first_public_input
+            .unwrap()
+            .aggregate_public_input(builder, &second_public_input.unwrap());
+        for input in public_inputs {
+            aggregate_input = aggregate_input.aggregate_public_input(builder, &input);
+        }
+        aggregate_input.register_public_inputs(builder);
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod tests {
+    use plonky2::hash::hash_types::{HashOutTarget, RichField};
+    use plonky2::field::extension::Extendable;
+    use plonky2::iop::target::Target;
+    use anyhow::Result;
+    use plonky2::hash::poseidon::PoseidonHash;
+    use plonky2::plonk::circuit_builder::CircuitBuilder;
+    use plonky2::plonk::config::{GenericConfig, PoseidonGoldilocksConfig};
+    use crate::public_input_aggregation::check_consistency_of_dummy_public_inputs_aggregation;
+
+    use super::PublicInputAggregation;
+
+    /** "Toy" public input aggregation scheme to be employed to test the conditional aggregation of
+     public inputs for dummy proofs, relying on the default implementations of the
+     `PublicInputAggregation` trait. Specifically, this public input scheme accumulates public
+     inputs and public outputs of base proofs by hashing them, that is the input/output accumulators
+     of an aggregated proof will be the hash of the inputs/outputs of the base proofs.
+     To have a consistent public input interface among base proofs and aggregated proofs, the public input
+     format requires that the input and the output public inputs of a base proof are hash
+     themselves, that is they correspond to the hash of the corresponding input/output values,
+     which are instead provided as witnesses.
+    */
+    pub(crate) struct PublicInputAccumulator {
+        input_accumulator: HashOutTarget,
+        output_accumulator: HashOutTarget,
+    }
+
+    impl PublicInputAccumulator {
+        pub(crate) fn new(input_accumulator: HashOutTarget, output_accumulator: HashOutTarget)
+            -> Self {
+            Self {
+                input_accumulator,
+                output_accumulator,
+            }
+        }
+    }
+
+    impl PublicInputAggregation for PublicInputAccumulator {
+        type TargetList = Vec<Target>;
+
+        fn num_public_inputs() -> usize {
+            let hash_target = HashOutTarget::from_partial(vec![].as_slice(), Target::wire(0, 0));
+            2 * hash_target.elements.len()
+        }
+
+        fn register_public_inputs<F: RichField + Extendable<D>, const D: usize>
+        (
+            &self,
+            builder: &mut plonky2::plonk::circuit_builder::CircuitBuilder<F, D>,
+        ) {
+            builder.register_public_inputs(&self.input_accumulator.elements);
+            builder.register_public_inputs(&self.output_accumulator.elements);
+        }
+
+        fn get_targets(&self) -> Self::TargetList {
+            self.input_accumulator.elements.into_iter()
+                .chain(self.output_accumulator.elements.into_iter())
+                .collect()
+        }
+
+        fn try_from_public_input_targets(targets: &[Target]) -> Result<Self> {
+            if targets.len() != Self::num_public_inputs() {
+                Err(anyhow::Error::msg(format!("expected {} targets to build PublicInputAccumulator, found {}", Self::num_public_inputs(), targets.len())))
+            } else {
+                let num_hash_elements = Self::num_public_inputs() / 2;
+                let input_accumulator = HashOutTarget::try_from(&targets[..num_hash_elements]).unwrap();
+                let output_accumulator = HashOutTarget::try_from(&targets[num_hash_elements..]).unwrap();
+                Ok(
+                    Self {
+                        input_accumulator,
+                        output_accumulator,
+                    }
+                )
+            }
+        }
+
+        fn aggregate_public_input<F: RichField + Extendable<D>, const D: usize>(
+            &self,
+            builder: &mut CircuitBuilder<F, D>,
+            public_input: &Self,
+        ) -> Self {
+            let mut input_accumulator = self.input_accumulator.elements.to_vec();
+            input_accumulator.extend_from_slice(
+                &public_input.input_accumulator.elements
+            );
+            let aggregated_input = builder.hash_n_to_hash_no_pad::<PoseidonHash>(input_accumulator);
+            let mut output_accumulator = self.output_accumulator.elements.to_vec();
+            output_accumulator.extend_from_slice(
+                &public_input.output_accumulator.elements
+            );
+            let aggregated_output = builder.hash_n_to_hash_no_pad::<PoseidonHash>(output_accumulator);
+            Self {
+                input_accumulator: aggregated_input,
+                output_accumulator: aggregated_output,
+            }
+        }
+    }
+
+
+    #[test]
+    fn test_consistency_public_input_accumulator() {
+        const D: usize = 2;
+        type C = PoseidonGoldilocksConfig;
+        type F = <C as GenericConfig<D>>::F;
+
+        assert!(check_consistency_of_dummy_public_inputs_aggregation::<
+            F,
+            C,
+            D,
+            PublicInputAccumulator,
+        >()
+            .unwrap());
+    }
+}

--- a/generic_recursion/src/public_input_aggregation/shared_state.rs
+++ b/generic_recursion/src/public_input_aggregation/shared_state.rs
@@ -1,0 +1,264 @@
+//! `shared_state` module provides several implementations of the `PublicInputAggregation` trait.
+//! All these implementations refer to a public input format where there is a public input state and
+//! a public output state, which is computed from the input according to the logic of a circuit;
+//! they mostly differ in how such state is defined.
+//!
+
+use plonky2::hash::hash_types::{HashOutTarget, MerkleCapTarget, RichField};
+use plonky2::iop::target::Target;
+use plonky2::iop::witness::{PartialWitness, WitnessWrite};
+use plonky2::plonk::circuit_builder::CircuitBuilder;
+use plonky2::field::extension::Extendable;
+
+use crate::public_input_aggregation::PublicInputAggregation;
+
+/// `State` is a trait that represents a generic public state that is managed by a set of circuits.
+/// A state corresponds to a collection of targets, which will correspond to public inputs of a proof
+/// generated with one of the circuits belonging to the set of circuits managing such a state.
+/// This trait is employed by the `SharedStatePublicInput` to implement a generic
+/// `PublicInputAggregation` scheme for circuits that take as input a public state and compute an
+/// output public state according to some logic.
+pub trait State: for<'a> TryFrom<&'a[Target], Error = anyhow::Error> {
+    /// Return the number of targets needed to represent the `State`
+    fn num_targets() -> usize;
+    /// Return the set of targets representing `State`
+    fn to_vec(&self) -> Vec<Target>;
+}
+
+/// `SharedStatePublicInput` is an implementation of `PublicInputAggregation` scheme for circuits
+/// that take as input a public state of type `ST` and compute an output public state (of the same
+/// type) according to some logic.
+pub struct SharedStatePublicInput<ST: State> {
+    initial_state: ST,
+    end_state: ST,
+}
+
+impl<ST: State> PublicInputAggregation for SharedStatePublicInput<ST> {
+    type TargetList = Vec<Target>;
+
+    fn num_public_inputs() -> usize {
+        ST::num_targets() * 2
+    }
+
+    fn register_public_inputs<F: RichField + Extendable<D>, const D: usize>(
+        &self,
+        builder: &mut CircuitBuilder<F, D>,
+    ) {
+        self.initial_state
+            .to_vec()
+            .into_iter()
+            .for_each(|target| builder.register_public_input(target));
+
+        self.end_state
+            .to_vec()
+            .into_iter()
+            .for_each(|target| builder.register_public_input(target));
+    }
+
+    fn dummy_circuit_inputs_logic<F: RichField + Extendable<D>, const D: usize>(
+        builder: &mut CircuitBuilder<F,D>,
+    ) -> Self {
+        let (initial_state_targets, end_state_targets) = (0..ST::num_targets())
+            .map(|_| {
+                let initial_state_target = builder.add_virtual_target();
+                let end_state_target = builder.add_virtual_target();
+                builder.connect(initial_state_target, end_state_target);
+                builder.generate_copy(initial_state_target, end_state_target);
+                (initial_state_target, end_state_target)
+            })
+            .unzip::<_, _, Vec<_>, Vec<_>>();
+        let initial_state = ST::try_from(initial_state_targets.as_slice()).unwrap();
+        let end_state = ST::try_from(end_state_targets.as_slice()).unwrap();
+        let public_inputs = Self {
+            initial_state,
+            end_state,
+        };
+        public_inputs.register_public_inputs(builder);
+        // build the circuit
+        public_inputs
+    }
+
+    fn can_aggregate_public_inputs_of_dummy_proofs() -> bool {
+        true
+    }
+
+    fn set_dummy_circuit_inputs<
+        F: RichField + Extendable<D>,
+        const D: usize,
+    >(
+        input_values: &[F],
+        input_targets: &Self,
+        pw: &mut PartialWitness<F>,
+    ) {
+        assert_eq!(input_values.len(), Self::num_public_inputs());
+        input_targets
+            .initial_state
+            .to_vec()
+            .into_iter()
+            .enumerate()
+            .for_each(|(i, target)| {
+                pw.set_target(
+                    target,
+                    input_values[ST::num_targets() + i].clone(),
+                );
+            })
+    }
+
+    fn get_targets(&self) -> Self::TargetList {
+        self.initial_state
+            .to_vec()
+            .into_iter()
+            .chain(self.end_state.to_vec().into_iter())
+            .collect::<Vec<_>>()
+    }
+
+    fn try_from_public_input_targets(targets: &[Target]) -> anyhow::Result<Self> {
+        if targets.len() != Self::num_public_inputs() {
+            Err(anyhow::Error::msg(format!("expected {} targets to build SharedStatePublicInput, found {}", Self::num_public_inputs(), targets.len())))
+        } else {
+            Ok(
+                Self {
+                    initial_state: ST::try_from(&targets[..ST::num_targets()])?,
+                    end_state: ST::try_from(&targets[ST::num_targets()..])?,
+                }
+            )
+        }
+    }
+
+    fn aggregate_public_input<F: RichField + Extendable<D>, const D: usize>(
+        &self,
+        builder: &mut CircuitBuilder<F, D>,
+        public_input: &Self,
+    ) -> Self {
+        self.end_state
+            .to_vec()
+            .into_iter()
+            .zip(public_input.initial_state.to_vec().into_iter())
+            .for_each(|(end_state_target, initial_state_target)| {
+                builder.connect(end_state_target, initial_state_target)
+            });
+        Self {
+            initial_state: ST::try_from(self.initial_state.to_vec().as_slice()).unwrap(),
+            end_state: ST::try_from(public_input.end_state.to_vec().as_slice()).unwrap(),
+        }
+    }
+}
+
+/// Data structure representing a simple state which is made only by a single target
+#[repr(transparent)]
+pub struct SimpleState(Target);
+
+impl FromIterator<Target> for SimpleState {
+    fn from_iter<T: IntoIterator<Item = Target>>(iter: T) -> Self {
+        let target = iter.into_iter().next();
+        assert!(target.is_some());
+        SimpleState(target.unwrap())
+    }
+}
+
+impl TryFrom<&[Target]> for SimpleState {
+    type Error = anyhow::Error;
+
+    fn try_from(value: &[Target]) -> Result<Self, Self::Error> {
+        if value.len() != 1 {
+            Err(anyhow::Error::msg(format!("expected 1 target to build SimpleState, found {}", value.len())))
+        } else {
+            Ok(Self(*value.first().unwrap()))
+        }
+    }
+}
+
+impl State for SimpleState {
+
+    fn num_targets() -> usize {
+        1
+    }
+
+    fn to_vec(&self) -> Vec<Target> {
+        vec!(self.0)
+    }
+}
+
+/// Type alias for the `SharedStatePublicInput` scheme employing `SimpleState` as state
+/// representation
+pub type SimpleStatePublicInput = SharedStatePublicInput<SimpleState>;
+
+/// Data structure representing a state given by a Merkle-tree; the state is given by the Merkle-cap
+/// of such a Merkle-tree
+pub struct MerkleRootState<const CAP_HEIGHT: usize>(MerkleCapTarget);
+
+impl<const CAP_HEIGHT: usize> TryFrom<&[Target]> for MerkleRootState<CAP_HEIGHT> {
+    type Error = anyhow::Error;
+
+    fn try_from(targets: &[Target]) -> Result<Self, Self::Error> {
+        if targets.len() != Self::num_targets() {
+            Err(anyhow::Error::msg(format!("expected {} targets to build MerkleRootState, found {}", Self::num_targets(), targets.len())))
+        } else {
+            Ok(
+                Self(
+                    MerkleCapTarget(
+                        targets
+                            .chunks(4)
+                            .map(|chunk| HashOutTarget::from_vec(chunk.to_vec()))
+                            .collect(),
+                    )
+                )
+            )
+        }
+    }
+}
+
+impl<const CAP_HEIGHT: usize> State for MerkleRootState<CAP_HEIGHT> {
+    fn num_targets() -> usize {
+        // A `MerkleCapTarget` is given by 2^CAP_HEIGHT hash targets,
+        // and each hash target is made of 4 targets, so the overall number of targets for a
+        // `MerkleCapTarget` are 4*2^CAP_HEIGHT
+        4 * (1 << CAP_HEIGHT)
+    }
+
+    fn to_vec(&self) -> Vec<Target> {
+        self.0
+             .0
+            .iter()
+            .flat_map(|hash| hash.elements)
+            .collect::<Vec<_>>()
+    }
+}
+
+/// Type alias for the `SharedStatePublicInput` scheme employing `MerkleRootState` as state
+/// representation
+pub type MerkleRootPublicInput<const CAP_HEIGHT: usize> =
+    SharedStatePublicInput<MerkleRootState<CAP_HEIGHT>>;
+
+#[cfg(test)]
+mod tests {
+    use plonky2::plonk::config::{GenericConfig, PoseidonGoldilocksConfig};
+
+    use crate::public_input_aggregation::check_consistency_of_dummy_public_inputs_aggregation;
+    use crate::public_input_aggregation::shared_state::{
+        MerkleRootPublicInput, SimpleStatePublicInput,
+    };
+
+    #[test]
+    fn test_consistency() {
+        const D: usize = 2;
+        type C = PoseidonGoldilocksConfig;
+        type F = <C as GenericConfig<D>>::F;
+
+        assert!(check_consistency_of_dummy_public_inputs_aggregation::<
+            F,
+            C,
+            D,
+            SimpleStatePublicInput,
+        >()
+        .unwrap());
+
+        assert!(check_consistency_of_dummy_public_inputs_aggregation::<
+            F,
+            C,
+            D,
+            MerkleRootPublicInput<0>,
+        >()
+        .unwrap());
+    }
+}

--- a/generic_recursion/src/recursion/common_data_for_recursion.rs
+++ b/generic_recursion/src/recursion/common_data_for_recursion.rs
@@ -1,0 +1,82 @@
+use plonky2::gates::noop::NoopGate;
+use plonky2::hash::hash_types::RichField;
+use plonky2::plonk::circuit_builder::CircuitBuilder;
+use plonky2::plonk::circuit_data::{CircuitConfig, CircuitData, CommonCircuitData};
+use plonky2::plonk::config::{AlgebraicHasher, GenericConfig, Hasher};
+use plonky2::field::extension::Extendable;
+
+use crate::recursion::util::num_targets_for_circuit_set;
+use crate::recursion::wrap_circuit::WrapCircuit;
+
+// degree bits of a base circuit guaranteeing that 2 wrap steps are necessary to shrink a proof
+// generated for such a circuit up to the recursion threshold
+const SHRINK_LIMIT: usize = 15;
+
+fn dummy_circuit<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>(
+    config: CircuitConfig,
+    num_gates: usize,
+    num_public_inputs: usize,
+) -> CircuitData<F, C, D>
+{
+    let mut builder = CircuitBuilder::new(config);
+    for _ in 0..num_public_inputs {
+        let target = builder.add_virtual_target();
+        builder.register_public_input(target);
+    }
+    // pad the number of gates of the circuit up to `num_gates` with noop operations
+    for _ in 0..(num_gates - num_public_inputs) {
+        builder.add_gate(NoopGate, vec![]);
+    }
+
+    builder.build::<C>()
+}
+
+pub(crate) fn build_data_for_recursive_aggregation<
+    F: RichField + Extendable<D>,
+    C: GenericConfig<D, F = F>,
+    const D: usize,
+>(
+    config: CircuitConfig,
+    num_public_inputs: usize,
+) -> CommonCircuitData<F, D>
+where
+    C::Hasher: AlgebraicHasher<F>,
+    [(); C::Hasher::HASH_SIZE]:,
+{
+    let num_public_inputs = num_public_inputs + num_targets_for_circuit_set::<F, D>(config.clone());
+    let circuit_data =
+        dummy_circuit::<F, C, D>(config.clone(), 1 << SHRINK_LIMIT, num_public_inputs);
+
+    let wrap_circuit = WrapCircuit::<F, C, D>::build_wrap_circuit(
+        &circuit_data.verifier_only,
+        &circuit_data.common,
+        &config,
+    );
+
+    wrap_circuit.final_proof_circuit_data().common.clone()
+}
+
+#[cfg(test)]
+mod test {
+    use plonky2::plonk::circuit_data::CircuitConfig;
+    use plonky2::plonk::config::{GenericConfig, PoseidonGoldilocksConfig};
+    use rstest::rstest;
+
+    use crate::recursion::common_data_for_recursion::build_data_for_recursive_aggregation;
+    use crate::recursion::test_circuits::logger;
+    use crate::recursion::RECURSION_THRESHOLD;
+
+    #[rstest]
+    fn test_common_data_for_recursion(_logger: ()) {
+        const D: usize = 2;
+        type C = PoseidonGoldilocksConfig;
+        type F = <C as GenericConfig<D>>::F;
+
+        let cd = build_data_for_recursive_aggregation::<F, C, D>(
+            CircuitConfig::standard_recursion_config(),
+            3,
+        );
+
+        assert_eq!(dbg!(cd).degree_bits(), RECURSION_THRESHOLD);
+    }
+}

--- a/generic_recursion/src/recursion/merge_circuit.rs
+++ b/generic_recursion/src/recursion/merge_circuit.rs
@@ -1,0 +1,1574 @@
+use std::collections::HashMap;
+
+use anyhow::{Error, Result};
+use plonky2::gates::noop::NoopGate;
+use plonky2::hash::hash_types::{HashOutTarget, MerkleCapTarget, RichField};
+use plonky2::hash::merkle_proofs::MerkleProofTarget;
+use plonky2::hash::merkle_tree::{MerkleCap, MerkleTree};
+use plonky2::iop::target::{BoolTarget, Target};
+use plonky2::iop::witness::{PartialWitness, WitnessWrite};
+use plonky2::plonk::circuit_builder::CircuitBuilder;
+use plonky2::plonk::circuit_data::{
+    CircuitConfig, CircuitData, VerifierCircuitTarget, VerifierOnlyCircuitData,
+};
+use plonky2::plonk::config::{AlgebraicHasher, GenericConfig, GenericHashOut, Hasher};
+use plonky2::plonk::proof::{ProofWithPublicInputs, ProofWithPublicInputsTarget};
+use plonky2::field::extension::Extendable;
+use plonky2_util::log2_ceil;
+
+use crate::public_input_aggregation::{
+    conditionally_aggregate_public_input, PublicInputAggregation,
+};
+use crate::recursion::common_data_for_recursion::build_data_for_recursive_aggregation;
+use crate::recursion::util::{
+    check_circuit_digest_target, merkle_cap_to_targets, num_targets_for_circuit_set,
+};
+use crate::recursion::wrap_circuit::WrapCircuit;
+use crate::recursion::RECURSION_THRESHOLD;
+
+// cap height for the Merkle-tree employed to represent the set of circuits that can be aggregated with
+// `MergeCircuit`; it is now set to 0 for simplicity, which is equivalent to a traditional
+// Merkle-tree with a single root.
+//ToDo: evaluate if changing the value depending on the number of circuits in the set
+const CIRCUIT_SET_CAP_HEIGHT: usize = 0;
+
+// Set of targets employed to prove that the circuit employed to generate a proof being aggregated
+// by `MergeCircuit` belongs to the set of circuits that can be aggregated by the `MergeCircuit`
+// itself
+struct CircuitSetMembershipTargets {
+    merkle_proof_target: MerkleProofTarget,
+    leaf_index_bits: Vec<BoolTarget>,
+}
+
+// The target employed to represent the set of circuits that can be aggregated by the `MergeCircuit`
+pub(crate) struct CircuitSetTarget(MerkleCapTarget);
+
+impl CircuitSetTarget {
+    pub(crate) fn build_target<F: RichField + Extendable<D>, const D: usize>(
+        builder: &mut CircuitBuilder<F, D>,
+    ) -> Self {
+        Self(builder.add_virtual_cap(CIRCUIT_SET_CAP_HEIGHT))
+    }
+
+    pub(crate) fn to_targets(&self) -> Vec<Target> {
+        merkle_cap_to_targets(&self.0)
+    }
+
+    // Enforce that `circuit_digest_target` is a leaf in the merkle-tree
+    // with root `circuit_set_target`
+    fn check_circuit_digest_membership<
+        F: RichField + Extendable<D>,
+        C: GenericConfig<D, F = F>,
+        const D: usize,
+    >(
+        builder: &mut CircuitBuilder<F, D>,
+        circuit_set_target: &Self,
+        circuit_digest_target: &HashOutTarget,
+        num_circuit_digests: usize,
+    ) -> CircuitSetMembershipTargets
+    where
+        C::Hasher: AlgebraicHasher<F>,
+    {
+        let full_tree_height = log2_ceil(num_circuit_digests);
+        assert!(full_tree_height >= CIRCUIT_SET_CAP_HEIGHT, "CIRCUIT_SET_CAP_HEIGHT={} is too high: it should be no greater than ceil(log2(num_leaves)) = {}", CIRCUIT_SET_CAP_HEIGHT, full_tree_height);
+        let height = full_tree_height - CIRCUIT_SET_CAP_HEIGHT;
+        let mpt = MerkleProofTarget {
+            siblings: builder.add_virtual_hashes(height),
+        };
+        let leaf_index_bits = (0..height)
+            .map(|_| builder.add_virtual_bool_target_safe())
+            .collect::<Vec<_>>();
+
+        builder.verify_merkle_proof_to_cap::<C::Hasher>(
+            circuit_digest_target.elements.to_vec(),
+            leaf_index_bits.as_slice(),
+            &circuit_set_target.0,
+            &mpt,
+        );
+
+        CircuitSetMembershipTargets {
+            merkle_proof_target: mpt,
+            leaf_index_bits,
+        }
+    }
+}
+
+// Data structure employed by the `MergeCircuit` to store and manage the set of circuits that can
+// be aggregated by the `MergeCircuit`
+struct CircuitSet<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize> {
+    circuit_digests_to_leaf_indexes: HashMap<Vec<F>, usize>,
+    mt: MerkleTree<F, C::Hasher>,
+}
+
+impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize> CircuitSet<F, C, D>
+where
+    C::Hasher: AlgebraicHasher<F>,
+    [(); C::Hasher::HASH_SIZE]:,
+{
+    fn build_circuit_set(circuit_digests: Vec<<C::Hasher as Hasher<F>>::Hash>) -> Self {
+        let (circuit_digests_to_leaf_indexes, mut leaves) : (HashMap<Vec<F>, usize>, Vec<_>) = circuit_digests
+            .iter()
+            .enumerate()
+            .map(|(index, hash)| {
+                let hash_to_fes = hash.to_vec();
+                ((hash_to_fes, index), hash.to_vec())
+            })
+            .unzip();
+
+        let num_leaves_padded: usize = 1 << log2_ceil(leaves.len());
+        leaves.resize_with(num_leaves_padded, || vec![F::ZERO]);
+
+        Self {
+            circuit_digests_to_leaf_indexes,
+            mt: MerkleTree::<F, C::Hasher>::new(leaves, CIRCUIT_SET_CAP_HEIGHT),
+        }
+    }
+
+    fn leaf_index(&self, digest: &[F]) -> Option<usize> {
+        self.circuit_digests_to_leaf_indexes.get(digest).cloned()
+    }
+
+    // set a `CircuitSetMembershipTargets` to prove membership of `circuit_digest` in the set of
+    // circuits that can be aggregated by the `MergeCircuit`
+    fn set_circuit_membership_target(
+        &self,
+        pw: &mut PartialWitness<F>,
+        membership_target: &CircuitSetMembershipTargets,
+        circuit_digest: <C::Hasher as Hasher<F>>::Hash,
+    ) -> Result<()> {
+        // compute merkle proof for `circuit_digest`
+        let leaf_index = self
+            .leaf_index(&circuit_digest.to_vec().as_slice())
+            .ok_or(Error::msg("circuit digest not found"))?;
+
+        let merkle_proof = self.mt.prove(leaf_index);
+
+        // set leaf index bits targets with the little-endian bit decomposition of leaf_index
+        for (i, bool_target) in membership_target.leaf_index_bits.iter().enumerate() {
+            let mask = (1 << i) as usize;
+            pw.set_bool_target(*bool_target, (leaf_index & mask) != 0);
+        }
+        // set merkle proof target
+        assert_eq!(
+            merkle_proof.len(),
+            membership_target.merkle_proof_target.siblings.len()
+        );
+        for (&mp, &mpt) in merkle_proof
+            .siblings
+            .iter()
+            .zip(membership_target.merkle_proof_target.siblings.iter())
+        {
+            pw.set_hash_target(mpt, mp);
+        }
+
+        Ok(())
+    }
+}
+
+// A short representation (e.g., a digest) of the set of circuits that can be aggregated by
+// `MergeCircuit`; this should represent values assignable to a `CircuitSetTarget`
+#[derive(Debug, Clone)]
+pub(crate) struct CircuitSetDigest<
+    F: RichField + Extendable<D>,
+    C: GenericConfig<D, F = F>,
+    const D: usize,
+>(MerkleCap<F, C::Hasher>);
+
+impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
+    CircuitSetDigest<F, C, D>
+where
+    C::Hasher: AlgebraicHasher<F>,
+{
+    pub(crate) fn set_circuit_set_target(
+        &self,
+        pw: &mut PartialWitness<F>,
+        target: &CircuitSetTarget,
+    ) {
+        pw.set_cap_target(&target.0, &self.0);
+    }
+
+    pub(crate) fn flatten(&self) -> Vec<F> {
+        self.0.flatten()
+    }
+}
+
+impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize> Default
+    for CircuitSetDigest<F, C, D>
+where
+    [(); C::Hasher::HASH_SIZE]:,
+{
+    fn default() -> Self {
+        Self(MerkleCap(
+            (0..(1 << CIRCUIT_SET_CAP_HEIGHT))
+                .map(|_| {
+                    <<C as GenericConfig<D>>::Hasher as Hasher<F>>::Hash::from_bytes(
+                        &[0u8; <<C as GenericConfig<D>>::Hasher as Hasher<F>>::HASH_SIZE],
+                    )
+                })
+                .collect::<Vec<_>>(),
+        ))
+    }
+}
+
+impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
+    From<&CircuitSet<F, C, D>> for CircuitSetDigest<F, C, D>
+{
+    fn from(circuit_set: &CircuitSet<F, C, D>) -> Self {
+        Self(circuit_set.mt.cap.clone())
+    }
+}
+
+fn are_digest_equal<F: RichField + Extendable<D>, const D: usize>(
+    builder: &mut CircuitBuilder<F, D>,
+    first_digest: &HashOutTarget,
+    second_digest: &HashOutTarget,
+) -> BoolTarget {
+    let result = builder._true();
+    first_digest
+        .elements
+        .iter()
+        .zip(second_digest.elements.iter())
+        .fold(result, |result, (first_el, second_el)| {
+            let is_eq = builder.is_equal(*first_el, *second_el);
+            builder.and(is_eq, result)
+        })
+}
+
+struct MergeCircuitInputTargets<const D: usize> {
+    proof_targets: Vec<ProofWithPublicInputsTarget<D>>,
+    inner_vk_targets: Vec<VerifierCircuitTarget>,
+    circuit_set_target: CircuitSetTarget,
+    circuit_set_membership_targets: Vec<CircuitSetMembershipTargets>,
+}
+// `DummyCircuit` is the circuit employed to generate dummy proofs, that are useless proofs which are
+// aggregated with real proofs by the `MergeCircuit` if there are less than `N` real proofs to be
+// aggregated, where `N` is the number of proofs to be aggregated expected by the `MergeCircuit`.
+struct DummyCircuit<
+    F: RichField + Extendable<D>,
+    C: GenericConfig<D, F = F>,
+    const D: usize,
+    PI: PublicInputAggregation,
+> {
+    circuit_data: CircuitData<F, C, D>,
+    public_input_targets: PI,
+    circuit_set_target: CircuitSetTarget,
+    fake_proof_target: ProofWithPublicInputsTarget<D>,
+    fake_vk_target: VerifierCircuitTarget,
+    fake_proof: ProofWithPublicInputs<F, C, D>,
+    fake_circuit: VerifierOnlyCircuitData<C, D>,
+}
+
+impl<
+        F: RichField + Extendable<D>,
+        C: GenericConfig<D, F = F>,
+        const D: usize,
+        PI: PublicInputAggregation,
+    > DummyCircuit<F, C, D, PI>
+where
+    C::Hasher: AlgebraicHasher<F>,
+    [(); C::Hasher::HASH_SIZE]:,
+{
+    fn build_circuit(config: CircuitConfig) -> Self {
+        let mut dummy_circuit_builder = CircuitBuilder::<F,D>::new(config.clone());
+        let dummy_circuit_input_targets =
+            PI::dummy_circuit_inputs_logic(&mut dummy_circuit_builder);
+
+        // add public input for the circuit set digest to the dummy circuit, to make it compatible
+        // with the public input format expected by the MergeCircuit
+        let pi_target = CircuitSetTarget::build_target(&mut dummy_circuit_builder);
+        dummy_circuit_builder.register_public_inputs(pi_target.to_targets().as_slice());
+
+        // To ensure that the dummy circuit has the same set of gates expected by the `MergeCircuit`,
+        // we add a recursive verifier for a useless circuit identified as the `fake_circuit`.
+        // The `build_fake_proof` function instantiates the `fake_circuit` and generates the proof
+        // for such circuit which is recursively verified by the dummy circuit
+        let build_fake_proof = || {
+            let mut builder = CircuitBuilder::new(config.clone());
+            let mut pw = PartialWitness::new();
+            let target = builder.add_virtual_target();
+            builder.register_public_input(target);
+            pw.set_target(target, F::rand());
+            // in order for the recursive verifier wrapping the proof generated with this circuit to have
+            // the same set of gates of circuits that can be aggregated by the `MergeCircuit`, we need
+            // to have at least 2^6 gates
+            for _ in 0..32 {
+                builder.add_gate(NoopGate, vec![]);
+            }
+
+            let data = builder.build::<C>();
+            let proof = data.prove(pw).unwrap();
+            (data, proof)
+        };
+        let (fake_circuit, fake_proof) = build_fake_proof();
+
+        let (pt, vt) = (
+            dummy_circuit_builder.add_virtual_proof_with_pis::<C>(&fake_circuit.common),
+            VerifierCircuitTarget {
+                constants_sigmas_cap: dummy_circuit_builder
+                    .add_virtual_cap(fake_circuit.common.config.fri_config.cap_height),
+                circuit_digest: dummy_circuit_builder.add_virtual_hash(),
+            },
+        );
+
+        dummy_circuit_builder.verify_proof::<C>(&pt, &vt, &fake_circuit.common);
+
+
+        // pad dummy circuit with Noop gates to reach the RECURSION_THRESHOLD size
+        while dummy_circuit_builder.num_gates() < (1 << (RECURSION_THRESHOLD - 1)) {
+            dummy_circuit_builder.add_gate(NoopGate, vec![]);
+        }
+
+        let dummy_circuit_data = dummy_circuit_builder.build::<C>();
+
+        DummyCircuit {
+            circuit_data: dummy_circuit_data,
+            public_input_targets: dummy_circuit_input_targets,
+            circuit_set_target: pi_target,
+            fake_proof_target: pt,
+            fake_vk_target: vt,
+            fake_proof,
+            fake_circuit: fake_circuit.verifier_only,
+        }
+    }
+
+    fn generate_dummy_proof(
+        &self,
+        input_values: &[F],
+        circuit_set: &CircuitSet<F, C, D>,
+    ) -> Result<ProofWithPublicInputs<F, C, D>> {
+        let mut pw = PartialWitness::new();
+        PI::set_dummy_circuit_inputs(input_values, &self.public_input_targets, &mut pw);
+        CircuitSetDigest::from(circuit_set)
+            .set_circuit_set_target(&mut pw, &self.circuit_set_target);
+        pw.set_proof_with_pis_target(&self.fake_proof_target, &self.fake_proof);
+        pw.set_cap_target(
+            &self.fake_vk_target.constants_sigmas_cap,
+            &self.fake_circuit.constants_sigmas_cap,
+        );
+        pw.set_hash_target(
+            self.fake_vk_target.circuit_digest,
+            self.fake_circuit.circuit_digest,
+        );
+
+        self.circuit_data.prove(pw)
+    }
+}
+
+pub(crate) struct MergeCircuit<
+    F: RichField + Extendable<D>,
+    C: GenericConfig<D, F = F>,
+    const D: usize,
+    PI: PublicInputAggregation,
+> {
+    input_targets: MergeCircuitInputTargets<D>,
+    circuit_set: CircuitSet<F, C, D>,
+    circuit_data: CircuitData<F, C, D>,
+    wrap_circuit: WrapCircuit<F, C, D>,
+    dummy_circuit: DummyCircuit<F, C, D, PI>,
+}
+
+impl<F, C, const D: usize, PI: PublicInputAggregation> MergeCircuit<F, C, D, PI>
+where
+    F: RichField + Extendable<D>,
+    C: GenericConfig<D, F = F> + 'static,
+    C::Hasher: AlgebraicHasher<F>,
+    [(); C::Hasher::HASH_SIZE]:,
+{
+    pub(crate) fn build_merge_circuit(
+        config: CircuitConfig,
+        num_proofs_to_merge: usize,
+        mut circuit_digests: Vec<<C::Hasher as Hasher<F>>::Hash>,
+    ) -> Result<Self> {
+        if num_proofs_to_merge < 2 {
+            return Err(Error::msg("meaningless to merge less than 2 proofs, provide a higher number of proofs to merge"))
+        }
+        let num_public_inputs = PI::num_public_inputs();
+
+        let rec_data =
+            build_data_for_recursive_aggregation::<F, C, D>(config.clone(), num_public_inputs);
+
+        // build the dummy circuit for the PI scheme
+        let dummy_circuit = DummyCircuit::<F,C,D,PI>::build_circuit(config.clone());
+        assert_eq!(&rec_data, &dummy_circuit.circuit_data.common);
+
+        circuit_digests.push(dummy_circuit.circuit_data.verifier_only.circuit_digest);
+
+        let mut builder = CircuitBuilder::<F, D>::new(config.clone());
+        let dummy_circuit_digest =
+            builder.constant_hash(dummy_circuit.circuit_data.verifier_only.circuit_digest);
+        let (proof_targets, inner_data): (Vec<_>, Vec<_>) = (0..num_proofs_to_merge)
+            .map(|_| {
+                (
+                    builder.add_virtual_proof_with_pis::<C>(&rec_data),
+                    VerifierCircuitTarget {
+                        constants_sigmas_cap: builder
+                            .add_virtual_cap(rec_data.config.fri_config.cap_height),
+                        circuit_digest: builder.add_virtual_hash(),
+                    },
+                )
+            })
+            .unzip();
+
+        // verify proofs and check circuit digests
+        let circuit_set_target = CircuitSetTarget::build_target(&mut builder);
+        let proof_membership_targets = proof_targets
+            .iter()
+            .zip(inner_data.iter())
+            .map(|(pt, inner_vd)| {
+                builder.verify_proof::<C>(pt, inner_vd, &rec_data);
+                check_circuit_digest_target::<_, C, D>(&mut builder, inner_vd, RECURSION_THRESHOLD);
+                CircuitSetTarget::check_circuit_digest_membership::<F, C, D>(
+                    &mut builder,
+                    &circuit_set_target,
+                    &inner_vd.circuit_digest,
+                    circuit_digests.len() + 1, // later on we will add the merge circuit digest to the set,
+                                               // so the merkle-tree that will be built will have one additional leaf
+                )
+            })
+            .collect::<Vec<_>>();
+
+        // public input aggregation
+        let circuit_set_targets = circuit_set_target.to_targets();
+        debug_assert_eq!(
+            circuit_set_targets.len(),
+            num_targets_for_circuit_set::<F, D>(config.clone())
+        );
+
+        let public_inputs = proof_targets
+            .iter()
+            .map(|pt| {
+                // check that the circuit set public input targets of each proof are equal to
+                // `circuit_set_targets`
+                for (cs_t, pi_t) in circuit_set_targets
+                    .iter()
+                    .zip(pt.public_inputs.iter().skip(num_public_inputs))
+                {
+                    builder.connect(*cs_t, *pi_t);
+                }
+                PI::try_from_public_input_targets(&pt.public_inputs[..num_public_inputs])
+            })
+            .collect::<Result<Vec<_>>>()?;
+        if PI::can_aggregate_public_inputs_of_dummy_proofs() {
+            PI::aggregate_public_inputs(&mut builder, public_inputs.into_iter());
+        } else {
+            // we always aggregate at least 2 real proofs
+            let mut aggregation_input =
+                public_inputs[0].aggregate_public_input(&mut builder, &public_inputs[1]);
+            // Since we don't conditionally aggregate the public inputs of the first 2 proofs,
+            // we need to enforce that the first two proofs aren't dummy ones: this is necessary to
+            // avoid that a malicious prover may arbitrarily update the aggregated public input by
+            // providing dummy proofs
+            let is_first_circuit_dummy = are_digest_equal(
+                &mut builder,
+                &inner_data[0].circuit_digest,
+                &dummy_circuit_digest,
+            );
+            builder.assert_zero(is_first_circuit_dummy.target);
+            let is_second_circuit_dummy = are_digest_equal(
+                &mut builder,
+                &inner_data[1].circuit_digest,
+                &dummy_circuit_digest,
+            );
+            builder.assert_zero(is_second_circuit_dummy.target);
+
+            // conditionally aggregate all the remaining public inputs: `aggregation_input` is updated
+            // only if the proof is not a dummy one, which is determined by comparing
+            // `inner_vd.circuit_digest` with the circuit digest of the dummy circuit
+            for (input, inner_vd) in public_inputs[2..].iter().zip(inner_data[2..].iter()) {
+                let is_circuit_dummy = are_digest_equal(
+                    &mut builder,
+                    &inner_vd.circuit_digest,
+                    &dummy_circuit_digest,
+                );
+                let selector = builder.not(is_circuit_dummy);
+                aggregation_input = conditionally_aggregate_public_input::<F, C, D, PI>(
+                    &mut builder,
+                    &selector,
+                    &aggregation_input,
+                    input,
+                )?;
+            }
+            aggregation_input.register_public_inputs(&mut builder);
+        }
+        builder.register_public_inputs(circuit_set_targets.as_slice());
+
+        let data = builder.build::<C>();
+
+        let wrap_circuit =
+            WrapCircuit::build_wrap_circuit(&data.verifier_only, &data.common, &config);
+
+        // add the circuit digest of the wrap circuit for the aggregated proof to the set of circuits
+        // that can be merged with the `MergeCircuit`
+        circuit_digests.push(
+            wrap_circuit
+                .final_proof_circuit_data()
+                .verifier_only
+                .circuit_digest,
+        );
+
+        Ok(
+            Self {
+                input_targets: MergeCircuitInputTargets {
+                    proof_targets,
+                    inner_vk_targets: inner_data,
+                    circuit_set_target,
+                    circuit_set_membership_targets: proof_membership_targets,
+                },
+                circuit_set: CircuitSet::build_circuit_set(circuit_digests),
+                circuit_data: data,
+                wrap_circuit,
+                dummy_circuit,
+            }
+        )
+    }
+    /// Merge `input_proofs`, generated for circuits with verifier data found in `input_vds`, into a
+    /// single proof, employing `self` circuit. `self` always merges N proofs, where N is the aggregation
+    /// factor employed to build the circuit; if less than N proofs are provided as input,
+    /// a dummy proof is generated to have N proofs to be merged
+    pub(crate) fn merge_proofs<'a>(
+        &'a self,
+        input_proofs: &[ProofWithPublicInputs<F, C, D>],
+        input_vds: impl Iterator<Item = &'a VerifierOnlyCircuitData<C, D>>,
+    ) -> Result<ProofWithPublicInputs<F, C, D>> {
+        let mut pw = PartialWitness::new();
+        let mut input_proofs_iterator = self.input_targets.proof_targets.iter();
+        for (proof, pt) in input_proofs.iter().zip(&mut input_proofs_iterator) {
+            pw.set_proof_with_pis_target(pt, proof);
+        }
+        if input_proofs.len() < 2 {
+            return Err(Error::msg("provide at least 2 proofs to be merged"))
+        }
+        let previous_proof = input_proofs.last().unwrap();
+        let tmp_dummy_proof;
+        let mut dummy_vds = vec![];
+        let dummy_proof = if let Some(pt) = input_proofs_iterator.next() {
+            tmp_dummy_proof = self
+                .dummy_circuit
+                .generate_dummy_proof(&previous_proof.public_inputs[..PI::num_public_inputs()], &self.circuit_set)?;
+            pw.set_proof_with_pis_target(pt, &tmp_dummy_proof);
+            dummy_vds.push(&self.dummy_circuit.circuit_data.verifier_only);
+            &tmp_dummy_proof
+        } else {
+            previous_proof
+        };
+
+        for pt in input_proofs_iterator {
+            pw.set_proof_with_pis_target(pt, dummy_proof);
+            dummy_vds.push(&self.dummy_circuit.circuit_data.verifier_only);
+        }
+
+        for ((verifier_data, vt), membership_proof_target) in input_vds
+            .chain(dummy_vds.into_iter())
+            .zip(self.input_targets.inner_vk_targets.iter())
+            .zip(self.input_targets.circuit_set_membership_targets.iter())
+        {
+            pw.set_cap_target(
+                &vt.constants_sigmas_cap,
+                &verifier_data.constants_sigmas_cap,
+            );
+            pw.set_hash_target(vt.circuit_digest, verifier_data.circuit_digest);
+
+            self.circuit_set.set_circuit_membership_target(
+                &mut pw,
+                membership_proof_target,
+                verifier_data.circuit_digest,
+            )?;
+        }
+
+        CircuitSetDigest::from(&self.circuit_set)
+            .set_circuit_set_target(&mut pw, &self.input_targets.circuit_set_target);
+
+        let aggregated_proof = self.circuit_data.prove(pw)?;
+        // wrap the aggregated proof to reduce its size to RECURSION_THRESHOLD
+        self.wrap_circuit.wrap_proof(aggregated_proof)
+    }
+
+    pub(crate) fn get_circuit_set_digest(&self) -> CircuitSetDigest<F, C, D> {
+        CircuitSetDigest::from(&self.circuit_set)
+    }
+
+    pub(crate) fn aggregated_proof_circuit_data(&self) -> &CircuitData<F, C, D> {
+        self.wrap_circuit.final_proof_circuit_data()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::cmp::min;
+
+    use plonky2::plonk::config::PoseidonGoldilocksConfig;
+    use plonky2::field::types::Sample;
+    use rstest::{fixture, rstest};
+    use serial_test::serial;
+    use plonky2::hash::hashing::hash_n_to_hash_no_pad;
+
+    use super::*;
+    use crate::public_input_aggregation::shared_state::{
+        MerkleRootPublicInput, SimpleStatePublicInput,
+    };
+    use crate::public_input_aggregation::tests::PublicInputAccumulator;
+    use crate::recursion::test_circuits::{check_panic, logger, ExpBaseCircuit, MulBaseCircuit};
+    use crate::recursion::wrap_circuit::test::mutable_final_proof_circuit_data;
+    use crate::recursion::wrap_circuit::WrapCircuitForBaseProofs;
+
+
+
+    impl<
+        F: RichField + Extendable<D>,
+        C: GenericConfig<D, F = F> + 'static,
+        const D: usize,
+        PI: PublicInputAggregation,
+    > MergeCircuit<F,C,D,PI>
+        where
+            C::Hasher: AlgebraicHasher<F>,
+            [(); C::Hasher::HASH_SIZE]:,
+    {
+        fn aggregate_proofs(
+            &self,
+            proofs: &[ProofWithPublicInputs<F, C, D>],
+            verifier_data: &[&VerifierOnlyCircuitData<C, D>],
+            aggregation_factor: usize,
+        ) -> Result<ProofWithPublicInputs<F, C, D>>
+            where
+                C::Hasher: AlgebraicHasher<F>,
+                [(); C::Hasher::HASH_SIZE]:,
+        {
+            let num_proofs = proofs.len();
+            assert_eq!(verifier_data.len(), num_proofs);
+            let num_proofs_to_be_aggregated = min(num_proofs, aggregation_factor);
+            let mut aggregated_proof = self.merge_proofs(
+                &proofs[..num_proofs_to_be_aggregated],
+                verifier_data[..num_proofs_to_be_aggregated]
+                    .into_iter()
+                    .cloned(),
+            )?;
+            println!("first {} proofs aggregated", num_proofs_to_be_aggregated);
+
+            let merge_circuit_data = self.aggregated_proof_circuit_data();
+
+            let merge_next_chunk = |chunk_index, accum, proof_chunk, vd_chunk| {
+                let mut proofs = vec![accum];
+                proofs.extend_from_slice(proof_chunk);
+                let mut merge_vd = vec![&merge_circuit_data.verifier_only];
+                merge_vd.extend_from_slice(vd_chunk);
+                assert!(proofs.len() <= aggregation_factor);
+                assert!(merge_vd.len() <= aggregation_factor);
+                let proof = self
+                    .merge_proofs(&proofs, merge_vd.into_iter())
+                    .unwrap();
+                println!("aggregation of {}-th chunk done", chunk_index + 1);
+                proof
+            };
+
+            aggregated_proof = proofs[num_proofs_to_be_aggregated..]
+                .chunks(aggregation_factor - 1)
+                .zip(verifier_data[num_proofs_to_be_aggregated..].chunks(aggregation_factor - 1))
+                .enumerate()
+                .fold(aggregated_proof, |accum, (i, (proof_chunk, vd_chunk))| {
+                    self.check_proof(&accum).unwrap();
+                    merge_next_chunk(i, accum, proof_chunk, vd_chunk)
+                });
+
+            self.check_proof(&aggregated_proof)?;
+
+            Ok(aggregated_proof)
+
+        }
+
+        // multiple checks to ensure the validity of an aggregated proof
+        fn check_proof(
+            &self,
+            proof: &ProofWithPublicInputs<F, C, D>,
+        ) -> Result<()>
+            where
+                [(); C::Hasher::HASH_SIZE]:,
+        {
+            self.aggregated_proof_circuit_data().verify(proof.clone())?;
+
+            let num_public_inputs = proof.public_inputs.len();
+            assert_eq!(
+                PI::num_public_inputs() + num_targets_for_circuit_set::<F, D>(self.circuit_data.common.config.clone()),
+                num_public_inputs
+            );
+
+            // negative test: change each of the public inputs
+            for i in 0..num_public_inputs {
+                let mut proof = proof.clone();
+                proof.public_inputs[i] = F::rand();
+                self.aggregated_proof_circuit_data().verify(proof).unwrap_err();
+            }
+
+            assert_eq!(RECURSION_THRESHOLD, self.aggregated_proof_circuit_data().common.degree_bits());
+
+            Ok(())
+        }
+    }
+
+    struct Circuits<
+        F: RichField + Extendable<D>,
+        C: GenericConfig<D, F = F> + 'static,
+        const D: usize,
+        PI: PublicInputAggregation,
+    > {
+        mul_base_circuit: MulBaseCircuit<F, C, D>,
+        exp_base_circuit: ExpBaseCircuit<F, C, D>,
+        mul_wrap_circuit: WrapCircuitForBaseProofs<F, C, D>,
+        exp_wrap_circuit: WrapCircuitForBaseProofs<F, C, D>,
+        merge_circuit: MergeCircuit<F, C, D, PI>,
+    }
+
+    impl<
+            F: RichField + Extendable<D>,
+            C: GenericConfig<D, F = F> + 'static,
+            const D: usize,
+            PI: PublicInputAggregation,
+        > Circuits<F, C, D, PI>
+    where
+        C::Hasher: AlgebraicHasher<F>,
+        [(); C::Hasher::HASH_SIZE]:,
+    {
+        fn build_circuits(
+            config: CircuitConfig,
+            aggregation_factor: usize,
+        ) -> Circuits<F, C, D, PI> {
+            let exp_base_circuit =
+                ExpBaseCircuit::<F, C, D>::build_base_circuit(&config, RECURSION_THRESHOLD);
+            let mul_base_circuit = MulBaseCircuit::<F, C, D>::build_base_circuit(
+                &config,
+                RECURSION_THRESHOLD,
+                false,
+            );
+            println!("base circuit built");
+            let exp_wrap_circuit = WrapCircuitForBaseProofs::build_wrap_circuit(
+                &exp_base_circuit.get_circuit_data().verifier_only,
+                &exp_base_circuit.get_circuit_data().common,
+                &config,
+            );
+            let mul_wrap_circuit = WrapCircuitForBaseProofs::build_wrap_circuit(
+                &mul_base_circuit.get_circuit_data().verifier_only,
+                &mul_base_circuit.get_circuit_data().common,
+                &config,
+            );
+            println!("start build aggregation circuit");
+            let base_circuit_digests = vec![
+                mul_wrap_circuit
+                    .final_proof_circuit_data()
+                    .verifier_only
+                    .circuit_digest,
+                exp_wrap_circuit
+                    .final_proof_circuit_data()
+                    .verifier_only
+                    .circuit_digest,
+            ];
+            let merge_circuit = MergeCircuit::<F, C, D, PI>::build_merge_circuit(
+                config.clone(),
+                aggregation_factor,
+                base_circuit_digests,
+            ).unwrap();
+            println!(
+                "aggregation circuit size: {}",
+                merge_circuit.circuit_data.common.degree_bits()
+            );
+
+            Circuits {
+                mul_base_circuit,
+                exp_base_circuit,
+                mul_wrap_circuit,
+                exp_wrap_circuit,
+                merge_circuit,
+            }
+        }
+
+        fn generate_base_proofs(
+            &self,
+            num_proofs: usize,
+            init: F,
+            test_case: Option<&WrongPublicInputTestCases>,
+        ) -> (
+            Vec<ProofWithPublicInputs<F, C, D>>,
+            Vec<&VerifierOnlyCircuitData<C, D>>,
+            F,
+        ) {
+            // employ a random circuit set digest to be employed as a public input when
+            // wrapping base proofs in case of `CraftedCircuitSetPublicInput` test case
+            let circuit_set_digest =
+                if let Some(&WrongPublicInputTestCases::CraftedCircuitSetPublicInput) = test_case {
+                    CircuitSetDigest::default()
+                } else {
+                    CircuitSetDigest::from(&self.merge_circuit.circuit_set)
+                };
+
+            let mut state = init;
+            // generate base proofs interleaving the 2 base circuits, and shrink each generated proof
+            // up to RECURSION_THRESHOLD size in order to later aggregate all of them
+            let (base_proofs, verifier_data) = (0..num_proofs)
+                .map(|i| {
+                    let (proof, vd) = if i % 2 == 0 {
+                        let base_proof = self.mul_base_circuit.generate_base_proof(state).unwrap();
+                        (
+                            self.mul_wrap_circuit
+                                .wrap_proof(base_proof, circuit_set_digest.clone())
+                                .unwrap(),
+                            &self
+                                .mul_wrap_circuit
+                                .final_proof_circuit_data()
+                                .verifier_only,
+                        )
+                    } else {
+                        // use a wrong initial state for the base proof in case of `WrongPublicInputInBaseProof` negative test
+                        let input_state =
+                            if let Some(&WrongPublicInputTestCases::WrongPublicInputInBaseProof) =
+                                test_case
+                            {
+                                F::rand()
+                            } else {
+                                state
+                            };
+                        let base_proof = self
+                            .exp_base_circuit
+                            .generate_base_proof(input_state)
+                            .unwrap();
+                        (
+                            self.exp_wrap_circuit
+                                .wrap_proof(base_proof, circuit_set_digest.clone())
+                                .unwrap(),
+                            &self
+                                .exp_wrap_circuit
+                                .final_proof_circuit_data()
+                                .verifier_only,
+                        )
+                    };
+                    println!("generated {}-th base proof", i + 1);
+                    state = proof.public_inputs[1];
+                    (proof, vd)
+                })
+                .unzip::<_, _, Vec<_>, Vec<_>>();
+
+            (base_proofs, verifier_data, state)
+        }
+
+        fn aggregate_proofs(
+            &self,
+            proofs: &[ProofWithPublicInputs<F, C, D>],
+            verifier_data: &[&VerifierOnlyCircuitData<C, D>],
+            aggregation_factor: usize,
+        ) -> Result<ProofWithPublicInputs<F, C, D>>
+        where
+            C::Hasher: AlgebraicHasher<F>,
+            [(); C::Hasher::HASH_SIZE]:,
+        {
+            self.merge_circuit.aggregate_proofs(proofs,verifier_data,aggregation_factor)
+        }
+    }
+
+    const D: usize = 2;
+    type PC = PoseidonGoldilocksConfig;
+    type F = <PC as GenericConfig<D>>::F;
+    const AGGREGATION_FACTOR: usize = 4;
+
+    #[fixture]
+    #[once]
+    fn circuits(_logger: ()) -> Circuits<F, PC, D, SimpleStatePublicInput> {
+        Circuits::<F, PC, D, SimpleStatePublicInput>::build_circuits(
+            CircuitConfig::standard_recursion_config(),
+            AGGREGATION_FACTOR,
+        )
+    }
+
+    #[rstest]
+    #[case::no_pad(10)]
+    #[case::one_proof_pad(9)]
+    #[case::two_proofs_pad(5)]
+    #[case::min_proofs(2)]
+    #[should_panic(expected = "provide at least 2 proofs to be merged")]
+    #[case::too_few_proofs_to_merge(1)]
+    #[serial]
+    fn test_merge_circuit(
+        #[case] num_proofs: usize,
+        circuits: &Circuits<F, PC, D, SimpleStatePublicInput>,
+    ) {
+        let circuit_set_digest = CircuitSetDigest::from(&circuits.merge_circuit.circuit_set);
+
+        let init = F::rand();
+        let (base_proofs, verifier_data, state) =
+            circuits.generate_base_proofs(num_proofs, init, None);
+
+        let final_output = state;
+
+        let aggregated_proof = circuits
+            .aggregate_proofs(
+                base_proofs.as_slice(),
+                verifier_data.as_slice(),
+                AGGREGATION_FACTOR,
+            )
+            .unwrap();
+
+        assert_eq!(aggregated_proof.public_inputs[0], init);
+        assert_eq!(aggregated_proof.public_inputs[1], final_output);
+        assert_eq!(
+            aggregated_proof.public_inputs[2..].to_vec(),
+            circuit_set_digest.flatten(),
+        );
+    }
+
+    // set of test cases for negative tests that tamper with the public inputs of aggregated proofs
+    enum WrongPublicInputTestCases {
+        WrongPublicInputInBaseProof, // generate base proofs with inconsistent inputs, i.e., such
+        // that the public output of a proof does not correspond to the public input of the
+        // subsequent proof, hereby breaking the constraint for public input aggregation imposed
+        // by the public input interface specified by `SimpleStatePublicInput`
+        CraftedInputState, // replace public input of first base proof with an arbitrary
+        // value, attempting to change the initial state
+        CraftedOutputState, // replace public output of last base proof with an arbitrary
+        // value, attempting to change the final state
+        CraftedCircuitSetPublicInput, // generate wrapped proofs employing a wrong value for the
+                                      // public input representing the set of circuits that can be aggregated
+    }
+
+    #[rstest]
+    #[case::wrong_public_input(WrongPublicInputTestCases::WrongPublicInputInBaseProof)]
+    #[case::crafted_final_state(WrongPublicInputTestCases::CraftedOutputState)]
+    #[case::crafted_initial_state(WrongPublicInputTestCases::CraftedInputState)]
+    #[case::crafted_circuit_set(WrongPublicInputTestCases::CraftedCircuitSetPublicInput)]
+    #[serial]
+    fn test_wrong_public_inputs(
+        #[case] test_case: WrongPublicInputTestCases,
+        circuits: &Circuits<F, PC, D, SimpleStatePublicInput>,
+    ) {
+        const NUM_PROOFS: usize = 5;
+
+        let init = F::rand();
+        let (mut base_proofs, verifier_data, _state) =
+            circuits.generate_base_proofs(NUM_PROOFS, init, Some(&test_case));
+
+        match test_case {
+            WrongPublicInputTestCases::CraftedInputState => {
+                base_proofs.first_mut().unwrap().public_inputs[0] = F::rand()
+            }
+            WrongPublicInputTestCases::CraftedOutputState => {
+                base_proofs.last_mut().unwrap().public_inputs[1] = F::rand()
+            }
+            _ => (),
+        };
+
+        check_panic!(
+            || circuits
+                .aggregate_proofs(
+                    base_proofs.as_slice(),
+                    verifier_data.as_slice(),
+                    AGGREGATION_FACTOR,
+                )
+                .unwrap(),
+            "proof aggregation failed with wrong public inputs"
+        );
+    }
+
+    // set of test cases for negative tests that tries to include a proof generated with a circuit that
+    // does not belong to the set of circuits allowed by the merge circuit
+    enum WrongCircuitSetTestCases {
+        WrongWrapCircuit, // try to wrap base proof generated with the wrong circuit with a wrap
+        // circuit belonging to the correct set of circuits
+        WrapCircuitNotInSet, // employ a proper wrap circuit for the base proof generated with
+        // the wrong circuit, providing as input to the merge circuit the actual verifier data
+        // of such wrap circuit
+        WrongVerifierData, // associate to the proof generate with the wrong circuit a wrong
+        // `VerifierOnlyCircuitData`, which belongs to the correct set of circuits
+        WrongSet, // associate to the proof generate with the wrong circuit a valid circuit
+        // membership statement but for a fake set which includes a circuit not belonging to
+        // the correct set of circuits
+        WrongCircuitDigest, // associate to the proof generated with the wrong circuit a crafted
+        // `VerifierOnlyData` with a `circuit_digest` belonging to the correct set
+        WrongCircuitMembership, //  associate to the proof generated with the wrong circuit a fake
+                                // circuit membership statement for the correct set of circuits
+    }
+
+    #[rstest]
+    #[case::wrong_wrap_circuit(WrongCircuitSetTestCases::WrongWrapCircuit)]
+    #[should_panic(expected = "circuit digest not found")]
+    #[case::wrap_circuit_not_in_set(WrongCircuitSetTestCases::WrapCircuitNotInSet)]
+    #[case::wrong_circuit_digest(WrongCircuitSetTestCases::WrongCircuitDigest)]
+    #[case::wrong_verifier_data(WrongCircuitSetTestCases::WrongVerifierData)]
+    #[serial]
+    fn test_proof_with_wrong_circuit(
+        #[case] test_case: WrongCircuitSetTestCases,
+        circuits: &Circuits<F, PC, D, SimpleStatePublicInput>,
+    ) {
+        const NUM_PROOFS: usize = 4;
+        let config = &circuits
+            .mul_wrap_circuit
+            .final_proof_circuit_data()
+            .common
+            .config;
+
+        let init = F::rand();
+        let (mut base_proofs, mut verifier_data, state) =
+            circuits.generate_base_proofs(NUM_PROOFS, init, None);
+
+        let mul_wrong_circuit = MulBaseCircuit::<F, PC, D>::build_base_circuit(
+            config,
+            circuits
+                .mul_base_circuit
+                .get_circuit_data()
+                .common
+                .degree_bits(),
+            true,
+        );
+        let mut mul_wrap_circuit_tmp;
+        let mul_wrap_circuit = match &test_case {
+            &WrongCircuitSetTestCases::WrongWrapCircuit =>
+            // employ a wrap circuit in the correct set to wrap the proof, even if this wrap
+            // circuit should expect proofs generated with a different base circuit
+            {
+                &circuits.mul_wrap_circuit
+            }
+            &WrongCircuitSetTestCases::WrongCircuitDigest => {
+                // build the proper wrap circuit but change the circuit digest to the one of a
+                // circuit in the set
+                mul_wrap_circuit_tmp = WrapCircuitForBaseProofs::build_wrap_circuit(
+                    &mul_wrong_circuit.get_circuit_data().verifier_only,
+                    &mul_wrong_circuit.get_circuit_data().common,
+                    config,
+                );
+                let circuit_data = mutable_final_proof_circuit_data(&mut mul_wrap_circuit_tmp);
+                // change the circuit digest both for prover and verifier data to ensure that the wrapped
+                // proof is generated employing a circuit digest belonging to the correct set of circuits
+                circuit_data.verifier_only.circuit_digest = circuits
+                    .mul_wrap_circuit
+                    .final_proof_circuit_data()
+                    .verifier_only
+                    .circuit_digest;
+                circuit_data.prover_only.circuit_digest = circuits
+                    .mul_wrap_circuit
+                    .final_proof_circuit_data()
+                    .prover_only
+                    .circuit_digest;
+                &mul_wrap_circuit_tmp
+            }
+            _ => {
+                // in all other test cases we wrap the proof generated with the wrong circuit with
+                // the proper wrap circuit
+                mul_wrap_circuit_tmp = WrapCircuitForBaseProofs::build_wrap_circuit(
+                    &mul_wrong_circuit.get_circuit_data().verifier_only,
+                    &mul_wrong_circuit.get_circuit_data().common,
+                    config,
+                );
+                &mul_wrap_circuit_tmp
+            }
+        };
+
+        let base_proof = mul_wrong_circuit.generate_base_proof(state).unwrap();
+        let wrap_proof = {
+            let wrap_proof = || {
+                mul_wrap_circuit.wrap_proof(
+                    base_proof,
+                    CircuitSetDigest::from(&circuits.merge_circuit.circuit_set),
+                )
+            };
+            match &test_case {
+                &WrongCircuitSetTestCases::WrongWrapCircuit => {
+                    check_panic!(wrap_proof, "wrap proof did not fail");
+                    return;
+                }
+                _ => wrap_proof(),
+            }
+        }
+        .unwrap();
+        base_proofs.push(wrap_proof);
+
+        let mul_wrap_circuit_vd = match &test_case {
+            &WrongCircuitSetTestCases::WrongVerifierData =>
+            // associate to the proof generated with the wrong circuit a `VerifierOnlyData`
+            // that belongs to the set of circuits expected by the merge circuit
+            {
+                &circuits
+                    .mul_wrap_circuit
+                    .final_proof_circuit_data()
+                    .verifier_only
+            }
+            _ => &mul_wrap_circuit.final_proof_circuit_data().verifier_only,
+        };
+        verifier_data.push(mul_wrap_circuit_vd);
+
+        let aggregate_proofs_fn = || {
+            circuits.aggregate_proofs(
+                base_proofs.as_slice(),
+                verifier_data.as_slice(),
+                AGGREGATION_FACTOR,
+            )
+        };
+
+        {
+            match &test_case {
+                &WrongCircuitSetTestCases::WrapCircuitNotInSet => aggregate_proofs_fn(),
+                _ => {
+                    check_panic!(aggregate_proofs_fn, "proof aggregation did not fail");
+                    return;
+                }
+            }
+        }
+        .unwrap();
+    }
+
+    #[rstest]
+    #[serial]
+    fn test_add_dummy_proofs(circuits: &Circuits<F, PC, D, SimpleStatePublicInput>) {
+        const NUM_PROOFS: usize = 4;
+        let circuit_set_digest = CircuitSetDigest::from(&circuits.merge_circuit.circuit_set);
+
+        let init = F::rand();
+        let (mut base_proofs, mut verifier_data, state) =
+            circuits.generate_base_proofs(NUM_PROOFS, init, None);
+
+        // add a useless dummy proof for aggregation
+        let dummy_proof = circuits
+            .merge_circuit
+            .dummy_circuit
+            .generate_dummy_proof(
+                &base_proofs.last().unwrap().public_inputs[..SimpleStatePublicInput::num_public_inputs()],
+                &circuits.merge_circuit.circuit_set,
+            )
+            .unwrap();
+        let final_output = dummy_proof.public_inputs[1];
+
+        base_proofs.push(dummy_proof);
+        verifier_data.push(
+            &circuits
+                .merge_circuit
+                .dummy_circuit
+                .circuit_data
+                .verifier_only,
+        );
+
+        let aggregated_proof = circuits
+            .aggregate_proofs(
+                base_proofs.as_slice(),
+                verifier_data.as_slice(),
+                AGGREGATION_FACTOR,
+            )
+            .unwrap();
+
+        // check that the dummy proof has not changed the state
+        assert_eq!(aggregated_proof.public_inputs[1], state);
+
+        assert_eq!(aggregated_proof.public_inputs[0], init);
+        assert_eq!(aggregated_proof.public_inputs[1], final_output);
+        assert_eq!(
+            aggregated_proof.public_inputs[2..].to_vec(),
+            circuit_set_digest.flatten()
+        );
+    }
+
+    #[rstest]
+    #[case::wrong_set(WrongCircuitSetTestCases::WrongSet)]
+    #[case::wrong_merkle_proof(WrongCircuitSetTestCases::WrongCircuitMembership)]
+    #[serial]
+    fn test_circuit_set_membership(
+        #[case] test_case: WrongCircuitSetTestCases,
+        circuits: &Circuits<F, PC, D, SimpleStatePublicInput>,
+    ) {
+        const NUM_PROOFS: usize = 3;
+        let config = &circuits
+            .mul_wrap_circuit
+            .final_proof_circuit_data()
+            .common
+            .config;
+        let circuit_set_digest = CircuitSetDigest::from(&circuits.merge_circuit.circuit_set);
+
+        let init = F::rand();
+        let (mut base_proofs, mut verifier_data, state) =
+            circuits.generate_base_proofs(NUM_PROOFS, init, None);
+
+        let mul_wrong_circuit = MulBaseCircuit::<F, PC, D>::build_base_circuit(
+            config,
+            circuits
+                .mul_base_circuit
+                .get_circuit_data()
+                .common
+                .degree_bits(),
+            true,
+        );
+        let mul_wrap_circuit = WrapCircuitForBaseProofs::build_wrap_circuit(
+            &mul_wrong_circuit.get_circuit_data().verifier_only,
+            &mul_wrong_circuit.get_circuit_data().common,
+            config,
+        );
+
+        let base_proof = mul_wrong_circuit.generate_base_proof(state).unwrap();
+        let wrap_proof = mul_wrap_circuit
+            .wrap_proof(base_proof, circuit_set_digest)
+            .unwrap();
+        base_proofs.push(wrap_proof);
+        verifier_data.push(&mul_wrap_circuit.final_proof_circuit_data().verifier_only);
+
+        // here we employ a modified version of `merge_proofs` function that allows to wrongly set
+        // specific targets of the `MergeCircuit` to test that specific constraints are actually
+        // enforced
+        let mut pw = PartialWitness::new();
+        for (pt, proof) in circuits
+            .merge_circuit
+            .input_targets
+            .proof_targets
+            .iter()
+            .zip(base_proofs.iter())
+        {
+            pw.set_proof_with_pis_target(pt, proof);
+        }
+
+        for ((vt, vd), mpt) in circuits
+            .merge_circuit
+            .input_targets
+            .inner_vk_targets
+            .iter()
+            .zip(verifier_data.into_iter())
+            .zip(
+                circuits
+                    .merge_circuit
+                    .input_targets
+                    .circuit_set_membership_targets
+                    .iter(),
+            )
+        {
+            // `wrong_proof` is true iff the verifier data in this iteration corresponds to the one
+            // of the circuit which is not included in the correct set of circuits
+            let wrong_proof = vd.circuit_digest
+                == mul_wrap_circuit
+                    .final_proof_circuit_data()
+                    .verifier_only
+                    .circuit_digest;
+
+            pw.set_cap_target(&vt.constants_sigmas_cap, &vd.constants_sigmas_cap);
+            pw.set_hash_target(vt.circuit_digest, vd.circuit_digest);
+
+            if wrong_proof {
+                match &test_case {
+                    &WrongCircuitSetTestCases::WrongSet => {
+                        // build a fake set which includes the wrong circuit
+                        let circuit_set = CircuitSet::<F, PC, D>::build_circuit_set(vec![
+                            mul_wrap_circuit
+                                .final_proof_circuit_data()
+                                .verifier_only
+                                .circuit_digest,
+                            circuits
+                                .mul_wrap_circuit
+                                .final_proof_circuit_data()
+                                .verifier_only
+                                .circuit_digest,
+                            circuits
+                                .exp_wrap_circuit
+                                .final_proof_circuit_data()
+                                .verifier_only
+                                .circuit_digest,
+                        ]);
+                        // employ this set to set values for circuit membership targets
+                        circuit_set
+                            .set_circuit_membership_target(&mut pw, mpt, vd.circuit_digest)
+                            .unwrap()
+                    }
+                    &WrongCircuitSetTestCases::WrongCircuitMembership => circuits
+                        .merge_circuit
+                        .circuit_set
+                        .set_circuit_membership_target(
+                            &mut pw,
+                            mpt,
+                            // employ to compute assignments to the circuit set membership target a
+                            // circuit digest which is in `merge_circuit.circuit_set` but
+                            // it does not correspond to the one of the circuit employed to generate
+                            // the proof being recursively verified in the
+                            circuits
+                                .mul_wrap_circuit
+                                .final_proof_circuit_data()
+                                .verifier_only
+                                .circuit_digest,
+                        )
+                        .unwrap(),
+                    _ => panic!("unexpected test case"),
+                }
+            } else {
+                circuits
+                    .merge_circuit
+                    .circuit_set
+                    .set_circuit_membership_target(&mut pw, mpt, vd.circuit_digest)
+                    .unwrap();
+            }
+        }
+
+        CircuitSetDigest::from(&circuits.merge_circuit.circuit_set).set_circuit_set_target(
+            &mut pw,
+            &circuits.merge_circuit.input_targets.circuit_set_target,
+        );
+
+        check_panic!(
+            || circuits.merge_circuit.circuit_data.prove(pw),
+            "proof aggregation with wrong circuit set did not fail"
+        );
+    }
+
+    #[rstest]
+    #[serial]
+    fn test_wrong_public_input_aggregation_scheme(_logger: ()) {
+        let config = CircuitConfig::standard_recursion_config();
+        // build circuits specifying an inconsistent public input aggregation scheme to be
+        // employed by the `MergeCircuit` to aggregate public inputs
+        let circuits = Circuits::<F, PC, D, MerkleRootPublicInput<0>>::build_circuits(
+            config.clone(),
+            AGGREGATION_FACTOR,
+        );
+        let num_proofs = 5;
+
+        let init = F::rand();
+        let (base_proofs, verifier_data, _) = circuits.generate_base_proofs(num_proofs, init, None);
+
+        check_panic!(
+            || circuits
+                .aggregate_proofs(
+                    base_proofs.as_slice(),
+                    verifier_data.as_slice(),
+                    AGGREGATION_FACTOR,
+                )
+                .unwrap(),
+            "proof aggregation with wrong public input scheme did not panic"
+        )
+    }
+
+    // Simple circuit to test the `PublicInputAccumulator` public input scheme, which employs the
+    // conditional aggregation of public inputs for dummy proofs
+    struct PublicInputAccumulatorBaseCircuit<F: RichField + Extendable<D>,
+        C: GenericConfig<D, F=F>,
+        const D: usize> {
+        private_input_values: [Target; 2],
+        circuit_data: CircuitData<F,C,D>
+    }
+
+    impl<F: RichField + Extendable<D>,
+        C: GenericConfig<D, F=F>,
+        const D: usize> PublicInputAccumulatorBaseCircuit<F,C,D>
+        where
+            C::Hasher: AlgebraicHasher<F>,
+    {
+
+        fn build_base_circuit(config: CircuitConfig) -> Self {
+            let mut builder = CircuitBuilder::<F,D>::new(config);
+
+            let private_input_values: [Target; 2] = builder.add_virtual_targets(2).try_into().unwrap();
+            let input_hash = builder.hash_n_to_hash_no_pad::<C::Hasher>(private_input_values.to_vec());
+
+            let output_value = (0..1024).fold(private_input_values, |values, i| {
+                let next = builder.mul_const_add(F::from_canonical_u64(i),values[0], values[1]);
+                [values[1], next]
+            })[1];
+
+            let output_hash = builder.hash_n_to_hash_no_pad::<C::Hasher>(vec![output_value]);
+
+            let public_inputs = PublicInputAccumulator::new(input_hash, output_hash);
+            public_inputs.register_public_inputs(&mut builder);
+
+            let data = builder.build::<C>();
+
+            Self {
+                private_input_values,
+                circuit_data: data,
+            }
+        }
+
+        fn generate_base_proof(&self, init_values: [F; 2]) -> Result<ProofWithPublicInputs<F,C,D>> {
+            let mut pw = PartialWitness::<F>::new();
+
+            pw.set_target_arr(self.private_input_values, init_values);
+
+            self.circuit_data.prove(pw)
+        }
+    }
+
+    struct CircuitsForPublicInputAccumulatorTests<
+        F: RichField + Extendable<D>,
+        C: GenericConfig<D, F = F> + 'static,
+        const D: usize,
+    > {
+        base_circuit: PublicInputAccumulatorBaseCircuit<F, C, D>,
+        wrap_circuit: WrapCircuitForBaseProofs<F, C, D>,
+        merge_circuit: MergeCircuit<F, C, D, PublicInputAccumulator>,
+    }
+
+    impl<
+        F: RichField + Extendable<D>,
+        C: GenericConfig<D, F = F> + 'static,
+        const D: usize,
+    > CircuitsForPublicInputAccumulatorTests<F,C,D>
+    where
+        C::Hasher: AlgebraicHasher<F>,
+        [(); C::Hasher::HASH_SIZE]:,
+    {
+        fn build_circuits(config: CircuitConfig) -> Self {
+            let base_circuit = PublicInputAccumulatorBaseCircuit::<F,C,D>::build_base_circuit(config.clone());
+
+            let wrap_circuit = WrapCircuitForBaseProofs::build_wrap_circuit(
+                &base_circuit.circuit_data.verifier_only,
+                &base_circuit.circuit_data.common,
+                &config,
+            );
+
+
+            let merge_circuit = MergeCircuit::<F,C,D,PublicInputAccumulator>::build_merge_circuit(
+                config,
+                AGGREGATION_FACTOR,
+                vec![wrap_circuit.final_proof_circuit_data().verifier_only.circuit_digest],
+            ).unwrap();
+
+            assert_eq!(wrap_circuit.final_proof_circuit_data().common, merge_circuit.aggregated_proof_circuit_data().common);
+
+            Self {
+                base_circuit,
+                wrap_circuit,
+                merge_circuit
+            }
+        }
+
+        fn generate_base_proofs(&self, num_proofs: usize) -> Result<Vec<ProofWithPublicInputs<F,C,D>>> {
+            (0..num_proofs).map(
+                |_| {
+                    let input_values = [F::rand(), F::rand()];
+                    let proof = self.base_circuit.generate_base_proof(input_values)?;
+                    self.wrap_circuit.wrap_proof(proof, CircuitSetDigest::from(&self.merge_circuit.circuit_set))
+                }
+            ).collect::<Result<Vec<_>>>()
+        }
+    }
+
+    #[fixture]
+    #[once]
+    fn circuits_for_public_input_accumulator(_logger: ())
+        -> CircuitsForPublicInputAccumulatorTests<F,PC,D> {
+        CircuitsForPublicInputAccumulatorTests::<F,PC,D>::build_circuits(
+            CircuitConfig::standard_recursion_config()
+        )
+    }
+
+    #[rstest]
+    #[serial]
+    fn test_merge_circuit_with_conditional_input_aggregation(
+        circuits_for_public_input_accumulator: &CircuitsForPublicInputAccumulatorTests<F,PC,D>,
+    ) {
+        let num_proofs = 8;
+        let base_proofs = circuits_for_public_input_accumulator.generate_base_proofs(num_proofs).unwrap();
+
+        let aggregated_proof = circuits_for_public_input_accumulator.merge_circuit.aggregate_proofs(
+            &base_proofs[..num_proofs-1],
+            vec![&circuits_for_public_input_accumulator.wrap_circuit.final_proof_circuit_data().verifier_only; num_proofs-1].as_slice(),
+            AGGREGATION_FACTOR
+        ).unwrap();
+
+        // compute the final input/output accumulators expected by merging `aggregated_proof` with
+        // the last base proofs, which have not been merged with the other proofs yet.
+        // According to the `PublicInputAccumulator` aggregation strategy, the aggregated input
+        // accumulator is computed as H(input1||input2), and similarly for the output accumulator
+        let num_public_inputs = PublicInputAccumulator::num_public_inputs();
+        let mut input_accumulator = aggregated_proof.public_inputs[..num_public_inputs/2].to_vec();
+        let mut output_accumulator = aggregated_proof.public_inputs[num_public_inputs/2..num_public_inputs].to_vec();
+
+        input_accumulator.extend_from_slice(&base_proofs[num_proofs-1].public_inputs[..num_public_inputs/2]);
+        output_accumulator.extend_from_slice(&base_proofs[num_proofs-1].public_inputs[num_public_inputs/2..num_public_inputs]);
+
+        let final_public_input = hash_n_to_hash_no_pad::<
+            _,
+            <<PC as GenericConfig<D>>::Hasher as Hasher<F>>::Permutation,
+        >(&input_accumulator);
+        let final_public_output = hash_n_to_hash_no_pad::<
+            _,
+            <<PC as GenericConfig<D>>::Hasher as Hasher<F>>::Permutation,
+        >(&output_accumulator);
+
+        // explicitly add a dummy proof to be aggregated in order to check that it does not affect
+        // the final accumulators of the aggregated proof
+        let dummy_proof = circuits_for_public_input_accumulator
+            .merge_circuit
+            .dummy_circuit
+            .generate_dummy_proof(
+                &base_proofs.last().unwrap().public_inputs[..PublicInputAccumulator::num_public_inputs()],
+                &circuits_for_public_input_accumulator.merge_circuit.circuit_set,
+            )
+            .unwrap();
+
+        let final_aggregated_proof = circuits_for_public_input_accumulator.merge_circuit.aggregate_proofs(
+            vec![aggregated_proof, base_proofs[num_proofs-1].clone(), dummy_proof].as_slice(),
+            vec![
+                &circuits_for_public_input_accumulator.merge_circuit.aggregated_proof_circuit_data().verifier_only,
+                &circuits_for_public_input_accumulator.wrap_circuit.final_proof_circuit_data().verifier_only,
+                &circuits_for_public_input_accumulator.merge_circuit.dummy_circuit.circuit_data.verifier_only,
+            ].as_slice(),
+            AGGREGATION_FACTOR
+        ).unwrap();
+
+
+        assert_eq!(
+            final_public_input.to_vec().as_slice(),
+            &final_aggregated_proof.public_inputs[..num_public_inputs/2],
+        );
+
+        assert_eq!(
+            final_public_output.to_vec().as_slice(),
+            &final_aggregated_proof.public_inputs[num_public_inputs/2..num_public_inputs],
+        );
+    }
+
+    #[rstest]
+    #[serial]
+    fn test_aggregation_of_dummy_proofs_only(
+        circuits_for_public_input_accumulator: &CircuitsForPublicInputAccumulatorTests<F,PC,D>,
+    ) {
+        let dummy_proofs = (0..2).map(|_|
+              {
+                  // generate random values as public inputs
+                  let input_values = (0..PublicInputAccumulator::num_public_inputs()).map(|_|
+                    F::rand()
+                  ).collect::<Vec<_>>();
+                  circuits_for_public_input_accumulator.merge_circuit.dummy_circuit.generate_dummy_proof(
+                      input_values.as_slice(),
+                      &circuits_for_public_input_accumulator.merge_circuit.circuit_set,
+                    )
+              }
+        ).collect::<Result<Vec<_>>>().unwrap();
+
+
+        check_panic!(
+            ||
+            circuits_for_public_input_accumulator.merge_circuit.aggregate_proofs(dummy_proofs.as_slice(), vec![
+                &circuits_for_public_input_accumulator.merge_circuit.dummy_circuit.circuit_data.verifier_only; 2
+                ].as_slice(),
+            AGGREGATION_FACTOR,
+            )
+            .unwrap(),
+            "proof aggregation with only dummy proofs did not panic"
+        );
+    }
+
+
+    #[rstest]
+    #[serial]
+    fn test_aggregation_of_real_proof_with_dummy_proof(
+        circuits_for_public_input_accumulator: &CircuitsForPublicInputAccumulatorTests<F,PC,D>,
+    ) {
+        let real_proof = {
+            let proof = circuits_for_public_input_accumulator.base_circuit.generate_base_proof([F::rand(), F::rand()]).unwrap();
+            circuits_for_public_input_accumulator.wrap_circuit.wrap_proof(proof, CircuitSetDigest::from(&circuits_for_public_input_accumulator.merge_circuit.circuit_set)
+            ).unwrap()
+        };
+        let dummy_proof = circuits_for_public_input_accumulator.merge_circuit.dummy_circuit.generate_dummy_proof(
+            &real_proof.public_inputs[..PublicInputAccumulator::num_public_inputs()],
+            &circuits_for_public_input_accumulator.merge_circuit.circuit_set,
+        ).unwrap();
+
+        check_panic!(
+            ||
+            circuits_for_public_input_accumulator.merge_circuit.aggregate_proofs(
+                vec![real_proof, dummy_proof].as_slice(),
+                vec![
+                    &circuits_for_public_input_accumulator.merge_circuit.wrap_circuit.final_proof_circuit_data().verifier_only,
+                    &circuits_for_public_input_accumulator.merge_circuit.dummy_circuit.circuit_data.verifier_only,
+                ].as_slice(),
+                AGGREGATION_FACTOR,
+            ).unwrap(),
+            "proof aggregation of real and dummy proof did not panic"
+        );
+    }
+
+}

--- a/generic_recursion/src/recursion/mod.rs
+++ b/generic_recursion/src/recursion/mod.rs
@@ -1,0 +1,576 @@
+//!
+//! `recursion` module defines the interfaces to recursively aggregate an unlimited
+//! number of proofs in a single aggregated proof, which can be verified with the same verifier
+//! data independently from the number of proofs being aggregated.
+//! The module provides also an actual implementation of such interfaces that can be used to
+//! recursively aggregate proofs.
+//!
+
+use anyhow::Result;
+use plonky2::hash::hash_types::RichField;
+use plonky2::plonk::circuit_data::{CircuitData, VerifierCircuitData};
+use plonky2::plonk::config::GenericConfig;
+use plonky2::plonk::proof::ProofWithPublicInputs;
+use plonky2::field::extension::Extendable;
+
+use crate::public_input_aggregation::PublicInputAggregation;
+use crate::recursion::util::VerifierOnlyCircuitDataWrapper;
+
+mod common_data_for_recursion;
+mod merge_circuit;
+pub mod recursive_circuit;
+mod util;
+mod wrap_circuit;
+
+pub(crate) const RECURSION_THRESHOLD: usize = 12;
+
+/// Construct an instance of `VerifierCircuitData` from a `CircuitData`: it replaces the function
+/// provided by plonky2 which takes ownership of the circuit data
+pub fn build_verifier_circuit_data<
+    F: RichField + Extendable<D>,
+    C: GenericConfig<D, F = F>,
+    const D: usize,
+>(
+    circuit_data: &CircuitData<F, C, D>,
+) -> VerifierCircuitData<F, C, D> {
+    let vd = VerifierOnlyCircuitDataWrapper::from(&circuit_data.verifier_only);
+    VerifierCircuitData {
+        verifier_only: vd.0,
+        common: circuit_data.common.clone(),
+    }
+}
+
+/// `BaseCircuitInfo` trait should be implemented for each base circuit whose proofs needs to be
+/// aggregated with the mod circuit: it exposes to the recursion circuit the information
+/// about a base circuit that are necessary for mod
+pub trait BaseCircuitInfo<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
+{
+    /// Specify the type of public input for the circuit
+    type PIScheme: PublicInputAggregation;
+
+    fn get_verifier_circuit_data(&self) -> VerifierCircuitData<F, C, D>;
+}
+
+/// `PreparedProof` trait provides the operations available on a proof which is ready to be
+/// aggregated with other prepared proofs
+pub trait PreparedProof<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>:
+    Clone
+{
+    fn get_proof(&self) -> &ProofWithPublicInputs<F, C, D>;
+}
+
+/// `RecursionCircuit` specifies the interface to recursively aggregate a set of proofs belonging
+/// to a set of circuits in a single aggregated proof
+pub trait RecursionCircuit<
+    F: RichField + Extendable<D>,
+    C: GenericConfig<D, F = F>,
+    const D: usize,
+    PI: PublicInputAggregation,
+>: Sized
+{
+    /// Define the type of proofs which are ready to be aggregated
+    type PreparedProof: PreparedProof<F, C, D>;
+
+    fn build_circuit<'a>(
+        circuit_set: impl Iterator<Item = Box<dyn BaseCircuitInfo<F, C, D, PIScheme = PI> + 'a>>,
+    ) -> Result<Self>;
+
+    /// variant of build_circuit function which allows to specify the numbers of
+    /// proofs to be aggregated in a single recursive layer
+    fn build_circuit_with_custom_aggregation_factor<'a>(
+        circuit_set: impl Iterator<Item = Box<dyn BaseCircuitInfo<F, C, D, PIScheme = PI> + 'a>>,
+        aggregation_factor: usize,
+    ) -> Result<Self>;
+
+    /// make a base proof ready to be aggregated, converting into a `Self::PreparedProof`
+    fn prepare_proof_for_aggregation(
+        &self,
+        proof: ProofWithPublicInputs<F, C, D>,
+        circuit_data: &VerifierCircuitData<F, C, D>,
+    ) -> Result<Self::PreparedProof>;
+
+    /// add a prepared proof to the set of proofs to be aggregated
+    fn add_proofs_for_aggregation(
+        self,
+        prepared_proofs: impl IntoIterator<Item = Self::PreparedProof>,
+    ) -> Self;
+
+    /// compute an aggregated proof for the set of proofs to be aggregated
+    fn aggregate_proofs(self) -> Result<(Self, Self::PreparedProof)> {
+        self.aggregate_proofs_with([].into_iter())
+    }
+
+    /// compute an aggregated proof for the set of proofs to be aggregated and
+    /// the prepared_proofs provided as input
+    fn aggregate_proofs_with(
+        self,
+        prepared_proofs: impl IntoIterator<Item = Self::PreparedProof>,
+    ) -> Result<(Self, Self::PreparedProof)>;
+
+    /// verify an aggregated proof
+    fn verify_aggregated_proof(&self, prepared_proof: Self::PreparedProof) -> Result<()>;
+}
+
+
+/// This method should be called on each base circuit to be included in the sets of circuits that is
+/// provided as input to the `build_circuit` method of the `RecursionCircuit` trait.
+/// In particular, this method allows to convert the base circuit to a data structure that fulfills
+/// the trait bounds expected for circuits in the input set by the `build_circuit` method
+pub fn prepare_base_circuit_for_circuit_set<'a,
+    F: RichField + Extendable<D>,
+    C: GenericConfig<D, F = F>,
+    const D: usize,
+    PI: PublicInputAggregation,
+>(
+    circuit: impl BaseCircuitInfo<F,C,D,PIScheme=PI>+'a,
+) -> Box<dyn BaseCircuitInfo<F, C, D, PIScheme = PI> + 'a> {
+    Box::new(circuit)
+}
+
+#[cfg(test)]
+mod test_circuits {
+    use anyhow::Result;
+    use plonky2::gates::arithmetic_base::ArithmeticGate;
+    use plonky2::hash::hash_types::{MerkleCapTarget, RichField};
+    use plonky2::hash::hashing::hash_n_to_m_no_pad;
+    use plonky2::hash::merkle_proofs::MerkleProofTarget;
+    use plonky2::hash::merkle_tree::MerkleTree;
+    use plonky2::iop::target::{BoolTarget, Target};
+    use plonky2::iop::witness::{PartialWitness, WitnessWrite};
+    use plonky2::plonk::circuit_builder::CircuitBuilder;
+    use plonky2::plonk::circuit_data::{CircuitConfig, CircuitData, VerifierCircuitData};
+    use plonky2::plonk::config::{AlgebraicHasher, GenericConfig, Hasher};
+    use plonky2::plonk::proof::ProofWithPublicInputs;
+    use plonky2::field::extension::Extendable;
+    use plonky2_util::log2_ceil;
+    use rstest::fixture;
+
+    use crate::public_input_aggregation::shared_state::{
+        MerkleRootPublicInput, SimpleStatePublicInput,
+    };
+    use crate::recursion::{build_verifier_circuit_data, BaseCircuitInfo};
+
+    // check that the closure $f actually panics, printing $msg as error message if the function
+    // did not panic; this macro is employed in tests in place of #[should_panic] to ensure that a
+    // panic occurred in the expected function rather than in other parts of the test
+    macro_rules! check_panic {
+        ($f: expr, $msg: expr) => {{
+            let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe($f));
+            assert!(result.is_err(), $msg);
+        }};
+    }
+
+    pub(crate) use check_panic;
+
+    #[fixture]
+    #[once]
+    pub(crate) fn logger() {
+        env_logger::init()
+    }
+
+    /// Data structure with all input/output targets and the `CircuitData` for a circuit proven
+    /// in base proofs. The circuit is designed to be representative of a common base circuit
+    /// operating on a common public state employing also some private data.
+    /// The computation performed on the state was chosen to employ commonly used gates, such as
+    /// arithmetic and hash ones
+    pub(crate) struct MulBaseCircuit<
+        F: RichField + Extendable<D>,
+        C: GenericConfig<D, F = F>,
+        const D: usize,
+    > {
+        private_input: Target,
+        public_input: Target,
+        public_output: Target,
+        circuit_data: CircuitData<F, C, D>,
+        num_powers: usize,
+    }
+
+    impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
+        MulBaseCircuit<F, C, D>
+    where
+        C::Hasher: AlgebraicHasher<F>,
+        [(); C::Hasher::HASH_SIZE]:,
+    {
+        pub(crate) fn build_base_circuit(
+            config: &CircuitConfig,
+            degree: usize,
+            swap: bool,
+        ) -> Self {
+            let num_gates: usize = 1usize << degree;
+            let num_ops = ArithmeticGate::new_from_config(&config).num_ops;
+            // the number of gates in the circuit depending on `powers` is
+            // `N = powers + 1 + ceil((2 + powers)/num_ops) + 3`.
+            // Thus, to obtain a circuit with N <= num_gates gates, we set `powers` as follows
+            let powers = ((num_gates - 5) * num_ops - 2) / (num_ops + 1);
+
+            let mut builder = CircuitBuilder::<F, D>::new(config.clone());
+
+            let init_t = builder.add_virtual_target();
+            builder.register_public_input(init_t);
+            let mut res_t = builder.add_virtual_target();
+            builder.generate_copy(init_t, res_t);
+            let zero = builder.constant(F::ZERO);
+            let to_be_hashed_t = builder.add_virtual_target();
+            for _ in 0..powers {
+                if swap {
+                    res_t = builder.hash_n_to_m_no_pad::<C::Hasher>(
+                        vec![res_t, to_be_hashed_t, zero, zero],
+                        1,
+                    )[0];
+                    res_t = builder.mul(res_t, init_t);
+                } else {
+                    res_t = builder.mul(res_t, init_t);
+                    res_t = builder.hash_n_to_m_no_pad::<C::Hasher>(
+                        vec![res_t, to_be_hashed_t, zero, zero],
+                        1,
+                    )[0];
+                }
+            }
+
+            let pow_t = builder.add_virtual_target();
+            builder.register_public_input(pow_t);
+            builder.is_equal(res_t, pow_t);
+
+            let data = builder.build::<C>();
+
+            Self {
+                private_input: to_be_hashed_t,
+                public_input: init_t,
+                public_output: pow_t,
+                num_powers: powers,
+                circuit_data: data,
+            }
+        }
+
+        pub(crate) fn generate_base_proof(
+            &self,
+            init: F,
+        ) -> Result<ProofWithPublicInputs<F, C, D>> {
+            let mut pw = PartialWitness::<F>::new();
+
+            pw.set_target(self.public_input, init);
+            let to_be_hashed = F::rand();
+            pw.set_target(self.private_input, to_be_hashed);
+            let res = (0..self.num_powers).fold(init,
+                |acc, _| {
+                    let int = acc.mul(init);
+                    hash_n_to_m_no_pad::<_, <C::Hasher as Hasher<F>>::Permutation>(
+                        &[int, to_be_hashed, F::ZERO, F::ZERO],
+                        1,
+                    )[0]
+                }
+            );
+
+            pw.set_target(self.public_output, res);
+
+            let proof = self.circuit_data.prove(pw)?;
+
+            self.circuit_data.verify(proof.clone())?;
+
+            assert_eq!(proof.public_inputs[1], res);
+
+            Ok(proof)
+        }
+
+        pub(crate) fn get_circuit_data(&self) -> &CircuitData<F, C, D> {
+            &self.circuit_data
+        }
+    }
+
+    /// Data structure with all input/output targets and the `CircuitData` for another base
+    /// circuit proven in base proofs. The set of public input/output of the circuit is the same of
+    /// `MulBaseCircuit`, as the base proofs of such circuits will be merged together, but the
+    /// circuit employs a different set of gates to operate on the public state
+    pub(crate) struct ExpBaseCircuit<
+        F: RichField + Extendable<D>,
+        C: GenericConfig<D, F = F>,
+        const D: usize,
+    > {
+        private_input: Target,
+        public_input: Target,
+        public_output: Target,
+        circuit_data: CircuitData<F, C, D>,
+        num_powers: usize,
+    }
+
+    impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
+        ExpBaseCircuit<F, C, D>
+    where
+        C::Hasher: AlgebraicHasher<F>,
+        [(); C::Hasher::HASH_SIZE]:,
+    {
+        pub(crate) fn build_base_circuit(config: &CircuitConfig, degree: usize) -> Self {
+            // Estimation of the number of exponentiations to be performed in order to ensure that
+            // the number of gates of the circuit will be at most 2^degree, also taking into account
+            // that the `build` method of `CircuitBuilder` adds further gates besides the ones
+            // instantiated in this function
+            let num_powers = (1 << (degree - 1)) - 4;
+            let mut builder = CircuitBuilder::<F, D>::new(config.clone());
+            let mut res_t = builder.add_virtual_target();
+            builder.register_public_input(res_t);
+            let init_t = res_t.clone();
+            let exp = builder.add_virtual_target();
+            for _ in 0..num_powers {
+                res_t = builder.exp(res_t, exp, F::BITS);
+            }
+
+            let pow_t = builder.add_virtual_target();
+            builder.register_public_input(pow_t);
+
+            builder.is_equal(res_t, pow_t);
+
+            let data = builder.build::<C>();
+
+            Self {
+                private_input: exp,
+                public_input: init_t,
+                public_output: pow_t,
+                circuit_data: data,
+                num_powers,
+            }
+        }
+
+        pub(crate) fn generate_base_proof(
+            &self,
+            init: F,
+        ) -> Result<ProofWithPublicInputs<F, C, D>> {
+            let mut pw = PartialWitness::<F>::new();
+
+            pw.set_target(self.public_input, init);
+            let exp = F::rand();
+            pw.set_target(self.private_input, exp);
+            let mut res = init;
+            for _ in 0..self.num_powers {
+                res = res.exp_u64(exp.to_canonical_u64());
+            }
+            pw.set_target(self.public_output, res);
+
+            let proof = self.circuit_data.prove(pw)?;
+
+            self.circuit_data.verify(proof.clone())?;
+
+            assert_eq!(proof.public_inputs[1], res);
+
+            Ok(proof)
+        }
+
+        pub(crate) fn get_circuit_data(&self) -> &CircuitData<F, C, D> {
+            &self.circuit_data
+        }
+    }
+
+    /// Data structure with all input/output targets and the `CircuitData` for a base circuit
+    /// where the input/output state is represented by a Merkle-root. This circuit is employed to
+    /// test the `MerkleRootPublicInput` aggregation scheme. The circuit takes as input a state
+    /// representing a Merkle-tree, a leaf of such Merkle-tree and a value `op` in the range [0,3].
+    /// The circuit updates the provided leaf of the Merkle-tree according to the value of `op` as
+    /// follows:
+    /// - If `op==0` -> `new_leaf = 2*leaf`
+    /// - If `op==1` -> `new_leaf = leaf^2`
+    /// - If `op==2` -> `new_leaf = leaf^leaf`
+    /// - If `op==3` -> `new_leaf = leaf`
+    /// The circuit computes as an output the new state given by the root of the updated Merkle-tree
+    pub(crate) struct MerkleRootStateBaseCircuit<
+        F: RichField + Extendable<D>,
+        C: GenericConfig<D, F = F>,
+        const D: usize,
+        const CAP_HEIGHT: usize,
+    > {
+        initial_root: MerkleCapTarget,
+        initial_mpt: MerkleProofTarget,
+        leaf_index_bits_initial_mpt: Vec<BoolTarget>,
+        leaf_target: Target,
+        op_target: Target,
+        final_root: MerkleCapTarget,
+        final_mpt: MerkleProofTarget,
+        circuit_data: CircuitData<F, C, D>,
+    }
+
+    impl<
+            F: RichField + Extendable<D>,
+            C: GenericConfig<D, F = F>,
+            const D: usize,
+            const CAP_HEIGHT: usize,
+        > MerkleRootStateBaseCircuit<F, C, D, CAP_HEIGHT>
+    where
+        C::Hasher: AlgebraicHasher<F>,
+        [(); C::Hasher::HASH_SIZE]:,
+    {
+        pub(crate) fn build_circuit(config: &CircuitConfig, num_leaves: usize) -> Self {
+            let mut builder = CircuitBuilder::<F, D>::new(config.clone());
+            let leaf_target = builder.add_virtual_target();
+            let op_target = builder.add_virtual_target();
+            let initial_root_target = builder.add_virtual_cap(CAP_HEIGHT);
+            let full_tree_height = log2_ceil(num_leaves);
+            assert!(full_tree_height >= CAP_HEIGHT, "CAP_HEIGHT={} for MerkleRootStateBaseCircuit is \
+            too high: it should be no greater than ceil(log2(num_leaves)) = {}", CAP_HEIGHT, full_tree_height);
+            let height = full_tree_height - CAP_HEIGHT;
+            let mpt = MerkleProofTarget {
+                siblings: builder.add_virtual_hashes(height),
+            };
+            let leaf_index_bits = (0..height)
+                .map(|_| builder.add_virtual_bool_target_safe())
+                .collect::<Vec<_>>();
+
+            let hash_leaf = builder.hash_or_noop::<C::Hasher>(vec![leaf_target]);
+
+            builder.verify_merkle_proof_to_cap::<C::Hasher>(
+                hash_leaf.elements.to_vec(),
+                leaf_index_bits.as_slice(),
+                &initial_root_target,
+                &mpt,
+            );
+
+            let new_leaf_target_doubled = builder.add(leaf_target, leaf_target);
+            let new_leaf_target_squared = builder.mul(leaf_target, leaf_target);
+            let new_leaf_target_powered = builder.exp(leaf_target, leaf_target, F::BITS);
+            let new_leaf_target = builder.random_access(
+                op_target,
+                vec![
+                    new_leaf_target_doubled,
+                    new_leaf_target_squared,
+                    new_leaf_target_powered,
+                    leaf_target,
+                ],
+            );
+
+            builder.range_check(op_target, 2);
+
+            let final_mpt = MerkleProofTarget {
+                siblings: builder.add_virtual_hashes(height),
+            };
+
+            let new_hash_leaf = builder.hash_or_noop::<C::Hasher>(vec![new_leaf_target]);
+
+            let final_root_target = builder.add_virtual_cap(CAP_HEIGHT);
+
+            builder.verify_merkle_proof_to_cap::<C::Hasher>(
+                new_hash_leaf.elements.to_vec(),
+                leaf_index_bits.as_slice(),
+                &final_root_target,
+                &final_mpt,
+            );
+
+            let merkle_cap_to_targets = |target: MerkleCapTarget| {
+                target
+                    .0
+                    .iter()
+                    .flat_map(|hash| hash.elements.to_vec())
+                    .collect::<Vec<_>>()
+            };
+
+            builder.register_public_inputs(
+                merkle_cap_to_targets(initial_root_target.clone()).as_slice(),
+            );
+            builder.register_public_inputs(
+                merkle_cap_to_targets(final_root_target.clone()).as_slice(),
+            );
+
+            let data = builder.build::<C>();
+
+            Self {
+                initial_root: initial_root_target,
+                initial_mpt: mpt,
+                leaf_index_bits_initial_mpt: leaf_index_bits,
+                leaf_target,
+                op_target,
+                final_root: final_root_target,
+                final_mpt,
+                circuit_data: data,
+            }
+        }
+
+        pub(crate) fn generate_base_proof(
+            &self,
+            mt: &mut MerkleTree<F, C::Hasher>,
+            leaf_index: usize,
+            op: u8,
+        ) -> Result<ProofWithPublicInputs<F, C, D>> {
+            let mut pw = PartialWitness::new();
+
+            pw.set_cap_target(&self.initial_root, &mt.cap);
+
+            let leaf = *mt.leaves[leaf_index].first().unwrap();
+            pw.set_target(self.leaf_target, leaf);
+
+            pw.set_target(self.op_target, F::from_canonical_u64(op as u64));
+
+            let merkle_proof = mt.prove(leaf_index);
+
+            for (i, bool_target) in self.leaf_index_bits_initial_mpt.iter().enumerate() {
+                let mask = (1 << i) as usize;
+                pw.set_bool_target(*bool_target, (leaf_index & mask) != 0);
+            }
+            // set merkle proof target
+            assert_eq!(merkle_proof.len(), self.initial_mpt.siblings.len());
+            for (&mp, &mpt) in merkle_proof
+                .siblings
+                .iter()
+                .zip(self.initial_mpt.siblings.iter())
+            {
+                pw.set_hash_target(mpt, mp);
+            }
+
+            let new_leaf = match op {
+                0 => leaf.add(leaf),
+                1 => leaf.mul(leaf),
+                2 => leaf.exp_u64(leaf.to_canonical_u64()),
+                3 => leaf,
+                _ => unreachable!(),
+            };
+
+            mt.leaves[leaf_index] = vec![new_leaf];
+
+            *mt = MerkleTree::new(mt.leaves.clone(), CAP_HEIGHT);
+
+            let merkle_proof = mt.prove(leaf_index);
+            // set merkle proof target
+            assert_eq!(merkle_proof.len(), self.final_mpt.siblings.len());
+            for (&mp, &mpt) in merkle_proof
+                .siblings
+                .iter()
+                .zip(self.final_mpt.siblings.iter())
+            {
+                pw.set_hash_target(mpt, mp);
+            }
+
+            pw.set_cap_target(&self.final_root, &mt.cap);
+
+            self.circuit_data.prove(pw)
+        }
+    }
+
+    impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
+        BaseCircuitInfo<F, C, D> for &MulBaseCircuit<F, C, D>
+    {
+        type PIScheme = SimpleStatePublicInput;
+
+        fn get_verifier_circuit_data(&self) -> VerifierCircuitData<F, C, D> {
+            build_verifier_circuit_data(&self.circuit_data)
+        }
+    }
+
+    impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
+        BaseCircuitInfo<F, C, D> for &ExpBaseCircuit<F, C, D>
+    {
+        type PIScheme = SimpleStatePublicInput;
+
+        fn get_verifier_circuit_data(&self) -> VerifierCircuitData<F, C, D> {
+            build_verifier_circuit_data(&self.circuit_data)
+        }
+    }
+
+    impl<
+            F: RichField + Extendable<D>,
+            C: GenericConfig<D, F = F>,
+            const D: usize,
+            const CAP_HEIGHT: usize,
+        > BaseCircuitInfo<F, C, D> for &MerkleRootStateBaseCircuit<F, C, D, CAP_HEIGHT>
+    {
+        type PIScheme = MerkleRootPublicInput<CAP_HEIGHT>;
+
+        fn get_verifier_circuit_data(&self) -> VerifierCircuitData<F, C, D> {
+            build_verifier_circuit_data(&self.circuit_data)
+        }
+    }
+}

--- a/generic_recursion/src/recursion/recursive_circuit.rs
+++ b/generic_recursion/src/recursion/recursive_circuit.rs
@@ -1,0 +1,455 @@
+//!
+//! This module mainly provides the `AggregationScheme` utilities, which implements the interfaces
+//! exposed externally to the crate to recursively aggregate an unlimited number of proofs in a
+//! single proof.
+//!
+
+use std::collections::HashMap;
+use std::ops::Deref;
+
+use anyhow::{Error, Result};
+use plonky2::hash::hash_types::RichField;
+use plonky2::plonk::circuit_data::{CircuitConfig, VerifierCircuitData};
+use plonky2::plonk::config::{AlgebraicHasher, GenericConfig, GenericHashOut, Hasher};
+use plonky2::plonk::proof::ProofWithPublicInputs;
+use plonky2::field::extension::Extendable;
+
+use crate::public_input_aggregation::PublicInputAggregation;
+use crate::recursion::merge_circuit::MergeCircuit;
+use crate::recursion::wrap_circuit::WrapCircuitForBaseProofs;
+use crate::recursion::{
+    BaseCircuitInfo, PreparedProof, RecursionCircuit, VerifierOnlyCircuitDataWrapper,
+};
+
+#[derive(Clone)]
+/// `PreparedProofForAggregation` represents the `PreparedProof`s employed in `AggregationScheme`.
+/// It is constructed from a base proof by calling the method `prepare_proof_for_aggregation` of
+/// `AggregationScheme`
+pub struct PreparedProofForAggregation<
+    F: RichField + Extendable<D>,
+    C: GenericConfig<D, F = F>,
+    const D: usize,
+> {
+    proof: ProofWithPublicInputs<F, C, D>,
+    circuit_data: VerifierOnlyCircuitDataWrapper<C, D>,
+}
+
+impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
+    PreparedProof<F, C, D> for PreparedProofForAggregation<F, C, D>
+{
+    fn get_proof(&self) -> &ProofWithPublicInputs<F, C, D> {
+        &self.proof
+    }
+}
+
+/// `AggregationScheme` allows to aggregate several base proofs generated from a circuit
+/// belong to a given set of circuits; the public inputs of the proofs are aggregated employing
+/// the strategy specified by the `PublicInputAggregation` scheme `PI`
+pub struct AggregationScheme<
+    F: RichField + Extendable<D>,
+    C: GenericConfig<D, F = F>,
+    const D: usize,
+    PI: PublicInputAggregation,
+> {
+    wrap_circuits: HashMap<Vec<F>, WrapCircuitForBaseProofs<F, C, D>>,
+    merge_circuit: MergeCircuit<F, C, D, PI>,
+    aggregation_factor: usize,
+    // buffer employed to store the set of prepared proofs to be aggregated, that are the proofs
+    // provided by the user with `add_proofs_for_aggregation` function
+    to_be_aggregated_proofs: Vec<PreparedProofForAggregation<F, C, D>>,
+}
+
+impl<
+        F: RichField + Extendable<D>,
+        C: GenericConfig<D, F = F> + 'static,
+        const D: usize,
+        PI: PublicInputAggregation,
+    > RecursionCircuit<F, C, D, PI> for AggregationScheme<F, C, D, PI>
+where
+    C::Hasher: AlgebraicHasher<F>,
+    [(); C::Hasher::HASH_SIZE]:,
+{
+    type PreparedProof = PreparedProofForAggregation<F, C, D>;
+
+    fn build_circuit<'a>(
+        circuit_set: impl Iterator<Item = Box<dyn BaseCircuitInfo<F, C, D, PIScheme = PI> + 'a>>,
+    ) -> Result<Self> {
+        Self::build_circuit_with_custom_aggregation_factor(circuit_set, 2)
+    }
+
+    fn build_circuit_with_custom_aggregation_factor<'a>(
+        circuit_set: impl Iterator<Item = Box<dyn BaseCircuitInfo<F, C, D, PIScheme = PI> + 'a>>,
+        aggregation_factor: usize,
+    ) -> Result<Self> {
+        let config = CircuitConfig::standard_recursion_config();
+        let (circuit_digests, wrap_circuits) = circuit_set.map(|ci| {
+            let ci = ci.deref();
+            let verifier_data = ci.get_verifier_circuit_data();
+            let wrap_circuit = WrapCircuitForBaseProofs::build_wrap_circuit(
+                &verifier_data.verifier_only,
+                &verifier_data.common,
+                &config,
+            );
+            (
+                wrap_circuit.final_proof_circuit_data().verifier_only.circuit_digest,
+                (verifier_data.verifier_only.circuit_digest.to_vec(), wrap_circuit),
+            )
+        }).unzip::<_,_,Vec<<C::Hasher as Hasher<F>>::Hash>,HashMap<Vec<F>, WrapCircuitForBaseProofs<F,C,D>>>();
+        let merge_circuit =
+            MergeCircuit::build_merge_circuit(config.clone(), aggregation_factor, circuit_digests)?;
+
+        Ok(
+            AggregationScheme {
+                wrap_circuits,
+                merge_circuit,
+                aggregation_factor,
+                to_be_aggregated_proofs: vec![],
+            }
+        )
+    }
+
+    fn prepare_proof_for_aggregation(
+        &self,
+        proof: ProofWithPublicInputs<F, C, D>,
+        circuit_data: &VerifierCircuitData<F, C, D>,
+    ) -> Result<Self::PreparedProof> {
+        let wrap_circuit = self
+            .wrap_circuits
+            .get(
+                circuit_data
+                    .verifier_only
+                    .circuit_digest
+                    .to_vec()
+                    .as_slice(),
+            )
+            .ok_or(Error::msg("invalid circuit data"))?;
+        let wrapped_proof =
+            wrap_circuit.wrap_proof(proof, self.merge_circuit.get_circuit_set_digest())?;
+
+        let wrap_circuit_vd = VerifierOnlyCircuitDataWrapper::from(
+            &wrap_circuit.final_proof_circuit_data().verifier_only,
+        );
+
+        Ok(PreparedProofForAggregation {
+            proof: wrapped_proof,
+            circuit_data: wrap_circuit_vd,
+        })
+    }
+
+    fn add_proofs_for_aggregation(
+        mut self,
+        prepared_proofs: impl IntoIterator<Item = Self::PreparedProof>,
+    ) -> Self {
+        for proof in prepared_proofs {
+            self.to_be_aggregated_proofs.push(proof);
+        }
+        self
+    }
+
+    fn aggregate_proofs_with(
+        mut self,
+        prepared_proofs: impl IntoIterator<Item = Self::PreparedProof>,
+    ) -> Result<(Self, Self::PreparedProof)> {
+        let circuit_data = VerifierOnlyCircuitDataWrapper::from(
+            &self
+                .merge_circuit
+                .aggregated_proof_circuit_data()
+                .verifier_only,
+        );
+        let (mut to_be_aggregated_proofs, mut vds): (Vec<_>, Vec<_>) = self
+            .to_be_aggregated_proofs
+            .into_iter()
+            .chain(prepared_proofs)
+            .map(|proof| (proof.proof, proof.circuit_data.0))
+            .unzip();
+
+        if to_be_aggregated_proofs.len() < 2 {
+            return Err(Error::msg("no proofs to be aggregated"));
+        }
+
+        while to_be_aggregated_proofs.len() >= self.aggregation_factor {
+            let mut proofs_iter = to_be_aggregated_proofs.chunks_exact(self.aggregation_factor);
+            let mut vds_iter = vds.chunks_exact(self.aggregation_factor);
+            let mut aggregated_proofs = (&mut proofs_iter)
+                .zip(&mut vds_iter)
+                .map(|(proof_chunk, vd_chunk)| {
+                    self.merge_circuit
+                        .merge_proofs(proof_chunk, vd_chunk.iter())
+                })
+                .collect::<Result<Vec<_>>>()?;
+            let mut aggregated_vds = (0..aggregated_proofs.len())
+                .map(|_| circuit_data.clone().0)
+                .collect::<Vec<_>>();
+            aggregated_proofs.extend_from_slice(proofs_iter.remainder());
+            aggregated_vds.append(
+                &mut vds_iter
+                    .remainder()
+                    .iter()
+                    .map(|vd| VerifierOnlyCircuitDataWrapper::from(vd).0)
+                    .collect::<Vec<_>>(),
+            );
+            to_be_aggregated_proofs = aggregated_proofs;
+            vds = aggregated_vds;
+        }
+
+        let aggregated_proof = if to_be_aggregated_proofs.len() != 1 {
+            self.merge_circuit
+                .merge_proofs(to_be_aggregated_proofs.as_slice(), vds.iter())?
+        } else {
+            to_be_aggregated_proofs.pop().unwrap()
+        };
+
+        self.to_be_aggregated_proofs = vec![];
+        Ok((
+            self,
+            PreparedProofForAggregation {
+                proof: aggregated_proof,
+                circuit_data,
+            },
+        ))
+    }
+
+    fn verify_aggregated_proof(&self, prepared_proof: Self::PreparedProof) -> Result<()> {
+        let aggregated_proof = prepared_proof.get_proof();
+        // check that the public inputs corresponding to the circuit set digest corresponds to the
+        // expected set of circuits
+        assert_eq!(
+            aggregated_proof.public_inputs[PI::num_public_inputs()..]
+                .to_vec(),
+            self.merge_circuit
+                .get_circuit_set_digest()
+                .flatten(),
+        );
+        // verify the proof
+        self.merge_circuit
+            .aggregated_proof_circuit_data()
+            .verify(prepared_proof.get_proof().clone())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use plonky2::hash::hash_types::RichField;
+    use plonky2::hash::merkle_tree::MerkleTree;
+    use plonky2::plonk::circuit_data::CircuitConfig;
+    use plonky2::plonk::config::{
+        AlgebraicHasher, GenericConfig, Hasher, PoseidonGoldilocksConfig,
+    };
+    use plonky2::field::extension::Extendable;
+    use plonky2::field::types::Sample;
+    use rand::{thread_rng, Rng};
+    use rstest::rstest;
+    use serial_test::serial;
+
+    use crate::public_input_aggregation::shared_state::{
+        MerkleRootState, SharedStatePublicInput, SimpleState,
+        State,
+    };
+    use crate::public_input_aggregation::PublicInputAggregation;
+    use crate::recursion::recursive_circuit::{AggregationScheme, PreparedProofForAggregation};
+    use crate::recursion::test_circuits::{
+        logger, ExpBaseCircuit, MerkleRootStateBaseCircuit, MulBaseCircuit,
+    };
+    use crate::recursion::{BaseCircuitInfo, PreparedProof, RECURSION_THRESHOLD, RecursionCircuit, prepare_base_circuit_for_circuit_set};
+
+    const D: usize = 2;
+    type PC = PoseidonGoldilocksConfig;
+    type F = <PC as GenericConfig<D>>::F;
+
+    // multiple checks to ensure the validity of an aggregated proof for a
+    // `SharedStatePublicInput` aggregation scheme employing `ST` as state representation
+    fn check_aggregated_proof<
+        F: RichField + Extendable<D>,
+        C: GenericConfig<D, F = F> + 'static,
+        const D: usize,
+        ST: State,
+    >(
+        aggregated_proof: &PreparedProofForAggregation<F, C, D>,
+        aggregation_scheme: &AggregationScheme<F, C, D, SharedStatePublicInput<ST>>,
+        init: Vec<F>,
+        final_state: Vec<F>,
+    ) where
+        C::Hasher: AlgebraicHasher<F>,
+        [(); C::Hasher::HASH_SIZE]:,
+    {
+        aggregation_scheme
+            .verify_aggregated_proof(aggregated_proof.clone())
+            .unwrap();
+        let aggregated_proof = aggregated_proof.get_proof();
+
+        assert_eq!(aggregated_proof.public_inputs[..ST::num_targets()], init);
+        assert_eq!(
+            aggregated_proof.public_inputs
+                [ST::num_targets()..SharedStatePublicInput::<ST>::num_public_inputs()],
+            final_state
+        );
+    }
+
+    #[rstest]
+    #[case::ok(false, 10, 4, true)]
+    #[case::ok_zk(true, 10, 4, true)]
+    #[case::pad(false, 8, 4, true)]
+    #[case::less_than_aggregation_factor(false, 2, 4, true)]
+    #[case::aggregate_circuits_with_different_size(false, 6, 2, false)]
+    #[case::aggregation_factor_not_power_of_2(false, 8, 6, true)]
+    #[should_panic(expected = "meaningless to merge less than 2 proofs, provide a higher number of proofs to merge")]
+    #[case::aggregation_factor_less_than_2(false, 4, 1, true)]
+    #[serial]
+    fn test_recursive_circuit(
+        #[case] zk: bool,
+        #[case] num_proofs: usize,
+        #[case] aggregation_factor: usize,
+        #[case] aggregate_circuits_with_same_size: bool,
+        _logger: (),
+    ) {
+        let config = if zk {
+            CircuitConfig::standard_recursion_config()
+        } else {
+            CircuitConfig::standard_recursion_zk_config()
+        };
+        let mut rng = thread_rng();
+        let (exp_circuit_degree, mul_circuit_degree) = if aggregate_circuits_with_same_size {
+            (RECURSION_THRESHOLD, RECURSION_THRESHOLD)
+        } else {
+            (
+                RECURSION_THRESHOLD+1,
+                RECURSION_THRESHOLD+2,
+            )
+        };
+        let exp_base_circuit =
+            ExpBaseCircuit::<F, PC, D>::build_base_circuit(&config, exp_circuit_degree);
+        let mul_base_circuit =
+            MulBaseCircuit::<F, PC, D>::build_base_circuit(&config, mul_circuit_degree, false);
+        println!("base circuit built");
+        let exp_vd = (&exp_base_circuit).get_verifier_circuit_data();
+        let mul_vd = (&mul_base_circuit).get_verifier_circuit_data();
+
+        let init = F::rand();
+        let mut state = init;
+        // generate base proofs interleaving the 2 base circuits
+        let base_proofs = (0..num_proofs)
+            .map(|i| {
+                let (proof, vd) = if rng.gen() {
+                    (
+                        mul_base_circuit.generate_base_proof(state).unwrap(),
+                        &mul_vd,
+                    )
+                } else {
+                    (
+                        exp_base_circuit.generate_base_proof(state).unwrap(),
+                        &exp_vd,
+                    )
+                };
+                println!("generated {}-th base proof", i + 1);
+                state = proof.public_inputs[1];
+                (proof, vd)
+            })
+            .collect::<Vec<_>>();
+
+        let final_output = state;
+
+        let circuit_set= vec![prepare_base_circuit_for_circuit_set(&exp_base_circuit),
+                              prepare_base_circuit_for_circuit_set(&mul_base_circuit)];
+
+        let mut aggregation_scheme =
+            AggregationScheme::build_circuit_with_custom_aggregation_factor(
+                circuit_set.into_iter(),
+                aggregation_factor,
+            ).unwrap();
+
+        for (proof, vd) in base_proofs.into_iter() {
+            let prepared_proof = aggregation_scheme.prepare_proof_for_aggregation(proof, vd);
+            aggregation_scheme = aggregation_scheme.add_proofs_for_aggregation(prepared_proof);
+        }
+
+        let (aggregation_scheme, aggregated_proof) = aggregation_scheme.aggregate_proofs().unwrap();
+
+        check_aggregated_proof::<_, _, D, SimpleState>(
+            &aggregated_proof,
+            &aggregation_scheme,
+            vec![init],
+            vec![final_output],
+        );
+    }
+
+    #[rstest]
+    #[serial]
+    fn test_recursive_circuit_with_merkle_root_base_circuit(_logger: ()) {
+        const CAP_HEIGHT: usize = 0;
+
+        let config = CircuitConfig::standard_recursion_config();
+        let num_leaves = 1 << 12;
+        let base_circuit =
+            MerkleRootStateBaseCircuit::<F, PC, D, CAP_HEIGHT>::build_circuit(&config, num_leaves);
+        let verifier_data = (&base_circuit).get_verifier_circuit_data();
+
+        let mut rng = thread_rng();
+
+        let leaves = (0..num_leaves).map(|_| vec![F::rand()]).collect::<Vec<_>>();
+
+        let mut mt = MerkleTree::<F, <PC as GenericConfig<D>>::Hasher>::new(leaves, CAP_HEIGHT);
+        let initial_state = mt.cap.clone();
+        let num_proofs = 4;
+        let base_proofs = (0..num_proofs)
+            .map(|_| {
+                base_circuit.generate_base_proof(
+                    &mut mt,
+                    rng.gen_range(0..num_leaves),
+                    rng.gen_range(0..4),
+                )
+            })
+            .collect::<anyhow::Result<Vec<_>>>()
+            .unwrap();
+
+        let circuit_set = vec![prepare_base_circuit_for_circuit_set(&base_circuit)];
+
+        let mut aggregation_scheme =
+            AggregationScheme::build_circuit(
+                circuit_set.into_iter(),
+            ).unwrap();
+
+        for proof in base_proofs {
+            let prepared_proof =
+                aggregation_scheme.prepare_proof_for_aggregation(proof, &verifier_data);
+            aggregation_scheme = aggregation_scheme.add_proofs_for_aggregation(prepared_proof);
+        }
+
+        // add a further proof
+        let base_proof = base_circuit
+            .generate_base_proof(&mut mt, rng.gen_range(0..num_leaves), rng.gen_range(0..4))
+            .unwrap();
+        let final_state = mt.cap.clone();
+        let prepared_proof =
+            aggregation_scheme.prepare_proof_for_aggregation(base_proof, &verifier_data);
+
+        let (aggregation_scheme, aggregated_proof) = aggregation_scheme
+            .aggregate_proofs_with(prepared_proof)
+            .unwrap();
+
+        check_aggregated_proof::<_, _, D, MerkleRootState<CAP_HEIGHT>>(
+            &aggregated_proof,
+            &aggregation_scheme,
+            initial_state.flatten(),
+            final_state.flatten(),
+        );
+
+        // verify that the proof computed by the aggregation scheme can be further aggregated with other proofs
+        let base_proof = base_circuit
+            .generate_base_proof(&mut mt, rng.gen_range(0..num_leaves), rng.gen_range(0..4))
+            .unwrap();
+        let final_state = mt.cap.clone();
+        let prepared_proof = aggregation_scheme
+            .prepare_proof_for_aggregation(base_proof, &verifier_data)
+            .unwrap();
+
+        let (aggregation_scheme, aggregated_proof) = aggregation_scheme
+            .aggregate_proofs_with(vec![aggregated_proof, prepared_proof].into_iter())
+            .unwrap();
+        check_aggregated_proof::<_, _, D, MerkleRootState<CAP_HEIGHT>>(
+            &aggregated_proof,
+            &aggregation_scheme,
+            initial_state.flatten(),
+            final_state.flatten(),
+        );
+    }
+}

--- a/generic_recursion/src/recursion/util.rs
+++ b/generic_recursion/src/recursion/util.rs
@@ -1,0 +1,71 @@
+use plonky2::hash::hash_types::{MerkleCapTarget, RichField};
+use plonky2::iop::target::Target;
+use plonky2::plonk::circuit_builder::CircuitBuilder;
+use plonky2::plonk::circuit_data::{CircuitConfig, VerifierCircuitTarget, VerifierOnlyCircuitData};
+use plonky2::plonk::config::{AlgebraicHasher, GenericConfig, Hasher};
+use plonky2::field::extension::Extendable;
+
+use crate::recursion::merge_circuit::CircuitSetTarget;
+
+pub(crate) struct VerifierOnlyCircuitDataWrapper<C: GenericConfig<D>, const D: usize>(
+    pub(crate) VerifierOnlyCircuitData<C, D>,
+);
+
+impl<C: GenericConfig<D>, const D: usize> From<&VerifierOnlyCircuitData<C, D>>
+    for VerifierOnlyCircuitDataWrapper<C, D>
+{
+    fn from(vd: &VerifierOnlyCircuitData<C, D>) -> Self {
+        VerifierOnlyCircuitDataWrapper(VerifierOnlyCircuitData {
+            constants_sigmas_cap: vd.constants_sigmas_cap.clone(),
+            circuit_digest: vd.circuit_digest.clone(),
+        })
+    }
+}
+
+impl<C: GenericConfig<D>, const D: usize> Clone for VerifierOnlyCircuitDataWrapper<C, D> {
+    fn clone(&self) -> Self {
+        VerifierOnlyCircuitDataWrapper(VerifierOnlyCircuitData {
+            constants_sigmas_cap: self.0.constants_sigmas_cap.clone(),
+            circuit_digest: self.0.circuit_digest.clone(),
+        })
+    }
+}
+
+// get the list of targets composing a `MerkleCapTarget`
+pub(crate) fn merkle_cap_to_targets(merkle_cap: &MerkleCapTarget) -> Vec<Target> {
+    merkle_cap.0.iter().flat_map(|h| h.elements).collect()
+}
+
+pub(crate) fn num_targets_for_circuit_set<F: RichField + Extendable<D>, const D: usize>(
+    config: CircuitConfig,
+) -> usize {
+    let mut builder = CircuitBuilder::<F, D>::new(config);
+    let target = CircuitSetTarget::build_target(&mut builder);
+    target.to_targets().len()
+}
+
+// check in the circuit that the circuit digest in `verifier_data` is correctly computed from
+// `verifier_data.constants_sigmas_cap` and the degree bits of the circuit
+pub(crate) fn check_circuit_digest_target<
+    F: RichField + Extendable<D>,
+    C: GenericConfig<D, F = F>,
+    const D: usize,
+>(
+    builder: &mut CircuitBuilder<F, D>,
+    verifier_data: &VerifierCircuitTarget,
+    degree_bits: usize,
+) where
+    C::Hasher: AlgebraicHasher<F>,
+{
+    let cap_targets = merkle_cap_to_targets(&verifier_data.constants_sigmas_cap);
+    // we assume the circuit was generated without a domain generator
+    let domain_separator_target = builder
+        .constant_hash(C::Hasher::hash_pad(&vec![]))
+        .elements
+        .to_vec();
+    let degree_target = vec![builder.constant(F::from_canonical_usize(degree_bits))];
+    let cap_hash = builder.hash_n_to_hash_no_pad::<C::Hasher>(
+        [cap_targets, domain_separator_target, degree_target].concat(),
+    );
+    builder.connect_hashes(verifier_data.circuit_digest, cap_hash);
+}

--- a/generic_recursion/src/recursion/wrap_circuit.rs
+++ b/generic_recursion/src/recursion/wrap_circuit.rs
@@ -1,0 +1,378 @@
+use anyhow::Result;
+use plonky2::hash::hash_types::{MerkleCapTarget, RichField};
+use plonky2::iop::witness::{PartialWitness, WitnessWrite};
+use plonky2::plonk::circuit_builder::CircuitBuilder;
+use plonky2::plonk::circuit_data::{
+    CircuitConfig, CircuitData, CommonCircuitData, VerifierCircuitTarget, VerifierOnlyCircuitData,
+};
+use plonky2::plonk::config::{AlgebraicHasher, GenericConfig, Hasher};
+use plonky2::plonk::proof::{ProofWithPublicInputs, ProofWithPublicInputsTarget};
+use plonky2::field::extension::Extendable;
+
+use crate::recursion::merge_circuit::{CircuitSetDigest, CircuitSetTarget};
+use crate::recursion::util::check_circuit_digest_target;
+use crate::recursion::RECURSION_THRESHOLD;
+
+// Data structure with all input/output targets and the `CircuitData` for each circuit employed
+// to recursively wrap a proof up to the recursion threshold. The data structure contains a set
+// of targets and a `CircuitData` for each wrap step. This data structure is employed as a building
+// block to construct 2 different types of wrap circuits:
+// - The wrap circuit for base proofs, which needs to add to the set of public inputs of the wrapped
+//      base proof a further public input that makes the public input interface of the wrapped
+//      proofs compatible with the one of merged proofs
+// - A generic wrap circuit that has the same public inputs of the wrapped proof
+struct WrapCircuitInner<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize> {
+    proof_targets: Vec<ProofWithPublicInputsTarget<D>>,
+    circuit_data: Vec<CircuitData<F, C, D>>,
+    inner_data: Vec<VerifierCircuitTarget>,
+    // this target is only necessary when the data structure is employed to wrap base proofs, as
+    // it represents the additional public input added by the wrap circuit
+    circuit_set_target: Option<CircuitSetTarget>,
+}
+
+impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
+    WrapCircuitInner<F, C, D>
+where
+    C::Hasher: AlgebraicHasher<F>,
+    [(); C::Hasher::HASH_SIZE]:,
+{
+    // build the wrap circuit for a proof enforcing the circuit with verifier data `inner_vd`
+    // and `inner_cd`; if `add_public_input` is `true`, then the set of public inputs of the wrapped
+    // proof is enriched with a further public input that makes the public input interface of the wrapped
+    // proofs compatible with the one of merged proofs
+    fn build_wrap_circuit(
+        inner_vd: &VerifierOnlyCircuitData<C, D>,
+        inner_cd: &CommonCircuitData<F, D>,
+        config: &CircuitConfig,
+        mut add_public_input: bool,
+    ) -> Self {
+        let mut vd = inner_vd;
+        let mut cd = inner_cd;
+        let mut wrap_circuit = Self {
+            proof_targets: Vec::new(),
+            circuit_data: Vec::new(),
+            inner_data: Vec::new(),
+            circuit_set_target: None,
+        };
+
+        loop {
+            let mut builder = CircuitBuilder::<F, D>::new(config.clone());
+            let wrap_step = wrap_circuit.circuit_data.len();
+            let pt = builder.add_virtual_proof_with_pis::<C>(cd);
+            let inner_data = VerifierCircuitTarget {
+                constants_sigmas_cap:
+                    // we allocate `constants_sigmas_cap` as constants only in the first wrapping step,
+                    // as otherwise it is not possible to obtain a wrapping circuit which is as
+                    // small as the recursion threshold
+                    if wrap_step != 0 {
+                        builder.add_virtual_cap(cd.config.fri_config.cap_height)
+                    } else {
+                        MerkleCapTarget(
+                            vd.constants_sigmas_cap.0.iter().map(|hash|
+                            builder.constant_hash(*hash)
+                            ).collect::<Vec<_>>()
+                        )
+                    },
+                // instead, `circuit_digest` is a constant for all the wrapping circuits
+                circuit_digest: builder.constant_hash(vd.circuit_digest),
+            };
+            builder.verify_proof::<C>(&pt, &inner_data, cd);
+
+            if wrap_step != 0 {
+                // in wrapping circuits where the `constants_sigmas_cap` are allocated as private
+                // inputs, their correctness is enforced by re-computing the circuit digest and
+                // comparing it with the constant one hardcoded in the wrapping circuit at hand
+                check_circuit_digest_target::<_, C, D>(&mut builder, &inner_data, cd.degree_bits());
+            }
+
+            for pi_t in pt.public_inputs.iter() {
+                builder.register_public_input(pi_t.clone())
+            }
+
+            if add_public_input {
+                // add a `MerkleCapTarget` as a public input representing the set of circuits that
+                // can be merged with the `MergeCircuit`
+                let pi_target = CircuitSetTarget::build_target(&mut builder);
+                builder.register_public_inputs(pi_target.to_targets().as_slice());
+                // we need to add the public input only for the first wrap step
+                add_public_input = false;
+                wrap_circuit.circuit_set_target = Some(pi_target);
+            }
+
+            let data = builder.build::<C>();
+
+            wrap_circuit.proof_targets.push(pt);
+            wrap_circuit.circuit_data.push(data);
+            wrap_circuit.inner_data.push(inner_data);
+            let circuit_data = wrap_circuit.circuit_data.last().unwrap();
+            (cd, vd) = (&circuit_data.common, &circuit_data.verifier_only);
+
+            log::debug!(
+                "wrap step {} done. circuit size is {}",
+                wrap_step + 1,
+                cd.degree_bits()
+            );
+            if circuit_data.common.degree_bits() == RECURSION_THRESHOLD {
+                break;
+            }
+        }
+
+        wrap_circuit
+    }
+
+    // wrap a proof `inner_proof` enforcing the circuit with data `inner_cd` employing the wrap
+    // circuit. The `circuit_set_digest` input is needed only when `self.circuit_set_target` is
+    // employed, that is when a wrap circuit for base proofs is employed
+    fn wrap_proof(
+        &self,
+        inner_proof: ProofWithPublicInputs<F, C, D>,
+        circuit_set_digest: Option<CircuitSetDigest<F, C, D>>,
+    ) -> Result<ProofWithPublicInputs<F, C, D>> {
+        let mut proof = inner_proof;
+        let mut circuit_data: Option<&VerifierOnlyCircuitData<C, D>> = None;
+
+        let mut circuit_set_public_input = self.circuit_set_target.is_some();
+
+        for ((pt, cd), inner_data) in self
+            .proof_targets
+            .iter()
+            .zip(self.circuit_data.iter())
+            .zip(self.inner_data.iter())
+        {
+            let mut pw = PartialWitness::new();
+            pw.set_proof_with_pis_target(pt, &proof);
+            if let Some(vd) = circuit_data {
+                // no need to set `constants_sigmas_cap` target in the first wrapping step, as they
+                // are hardcoded as constant in the first wrapping circuit
+                pw.set_cap_target(&inner_data.constants_sigmas_cap, &vd.constants_sigmas_cap);
+            }
+
+            if circuit_set_public_input {
+                circuit_set_digest
+                    .as_ref()
+                    .unwrap()
+                    .set_circuit_set_target(&mut pw, self.circuit_set_target.as_ref().unwrap());
+                circuit_set_public_input = false;
+            }
+            proof = cd.prove(pw)?;
+            circuit_data = Some(&cd.verifier_only);
+        }
+
+        Ok(proof)
+    }
+}
+
+// Wrap circuit employed to wrap base proofs; such wrap circuit needs to add to the set of public
+// inputs of the wrapped base proof a further public input that makes the public input interface
+// of the wrapped proofs compatible with one of merged proofs
+pub(crate) struct WrapCircuitForBaseProofs<
+    F: RichField + Extendable<D>,
+    C: GenericConfig<D, F = F>,
+    const D: usize,
+>(WrapCircuitInner<F, C, D>);
+
+impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
+    WrapCircuitForBaseProofs<F, C, D>
+where
+    C::Hasher: AlgebraicHasher<F>,
+    [(); C::Hasher::HASH_SIZE]:,
+{
+    pub(crate) fn build_wrap_circuit(
+        inner_vd: &VerifierOnlyCircuitData<C, D>,
+        inner_cd: &CommonCircuitData<F, D>,
+        config: &CircuitConfig,
+    ) -> Self {
+        WrapCircuitForBaseProofs::<F, C, D>(WrapCircuitInner::build_wrap_circuit(
+            inner_vd, inner_cd, config, true,
+        ))
+    }
+
+    pub(crate) fn wrap_proof(
+        &self,
+        inner_proof: ProofWithPublicInputs<F, C, D>,
+        circuit_set_digest: CircuitSetDigest<F, C, D>,
+    ) -> Result<ProofWithPublicInputs<F, C, D>> {
+        self.0.wrap_proof(inner_proof, Some(circuit_set_digest))
+    }
+
+    // Helper function that returns a pointer to the circuit data of the circuit for the last
+    // wrap step
+    pub(crate) fn final_proof_circuit_data(&self) -> &CircuitData<F, C, D> {
+        self.0.circuit_data.last().unwrap()
+    }
+}
+
+// Generic wrap circuit that simply copies the public inputs of the wrapped proof
+pub(crate) struct WrapCircuit<
+    F: RichField + Extendable<D>,
+    C: GenericConfig<D, F = F>,
+    const D: usize,
+>(WrapCircuitInner<F, C, D>);
+
+impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize> WrapCircuit<F, C, D>
+where
+    C::Hasher: AlgebraicHasher<F>,
+    [(); C::Hasher::HASH_SIZE]:,
+{
+    pub(crate) fn build_wrap_circuit(
+        inner_vd: &VerifierOnlyCircuitData<C, D>,
+        inner_cd: &CommonCircuitData<F, D>,
+        config: &CircuitConfig,
+    ) -> Self {
+        WrapCircuit::<F, C, D>(WrapCircuitInner::build_wrap_circuit(
+            inner_vd, inner_cd, config, false,
+        ))
+    }
+
+    pub(crate) fn wrap_proof(
+        &self,
+        inner_proof: ProofWithPublicInputs<F, C, D>,
+    ) -> Result<ProofWithPublicInputs<F, C, D>> {
+        self.0.wrap_proof(inner_proof, None)
+    }
+
+    // Helper function that returns a pointer to the circuit data of the circuit for the last
+    // wrap step
+    pub(crate) fn final_proof_circuit_data(&self) -> &CircuitData<F, C, D> {
+        self.0.circuit_data.last().unwrap()
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod test {
+    use plonky2::gates::noop::NoopGate;
+    use plonky2::plonk::config::PoseidonGoldilocksConfig;
+    use plonky2::field::types::Sample;
+    use rstest::rstest;
+
+    use super::*;
+    use crate::recursion::test_circuits::{check_panic, logger, MulBaseCircuit};
+
+    pub(crate) fn mutable_final_proof_circuit_data<
+        F: RichField + Extendable<D>,
+        C: GenericConfig<D, F = F>,
+        const D: usize,
+    >(
+        circuit: &mut WrapCircuitForBaseProofs<F, C, D>,
+    ) -> &mut CircuitData<F, C, D> {
+        circuit.0.circuit_data.last_mut().unwrap()
+    }
+
+    #[rstest]
+    fn test_wrap_circuit_keys(_logger: ()) {
+        const D: usize = 2;
+        type C = PoseidonGoldilocksConfig;
+        type F = <C as GenericConfig<D>>::F;
+
+        let config = CircuitConfig::standard_recursion_config();
+        const DEGREE: usize = 14;
+        let mul_circuit = MulBaseCircuit::<F, C, D>::build_base_circuit(&config, DEGREE, false);
+
+        let proof = mul_circuit.generate_base_proof(F::rand()).unwrap();
+
+        let wrap_circuit = WrapCircuitForBaseProofs::<F, C, D>::build_wrap_circuit(
+            &mul_circuit.get_circuit_data().verifier_only,
+            &mul_circuit.get_circuit_data().common,
+            &config,
+        );
+
+        let mul_circuit_swap = MulBaseCircuit::<F, C, D>::build_base_circuit(&config, DEGREE, true);
+
+        let proof_swap = mul_circuit_swap.generate_base_proof(F::rand()).unwrap();
+
+        assert_eq!(
+            mul_circuit_swap.get_circuit_data().common.degree_bits(),
+            DEGREE
+        );
+
+        // generate random circuit digest
+        let circuit_set_digest = CircuitSetDigest::default();
+
+        let wrap_proof = wrap_circuit
+            .wrap_proof(proof, circuit_set_digest.clone())
+            .unwrap();
+
+        wrap_circuit
+            .final_proof_circuit_data()
+            .verify(wrap_proof)
+            .unwrap();
+
+        let wrap_circuit_mul_swap = WrapCircuitForBaseProofs::<F, C, D>::build_wrap_circuit(
+            &mul_circuit_swap.get_circuit_data().verifier_only,
+            &mul_circuit_swap.get_circuit_data().common,
+            &config,
+        );
+
+        let wrap_proof_swap = wrap_circuit_mul_swap
+            .wrap_proof(proof_swap.clone(), circuit_set_digest.clone())
+            .unwrap();
+
+        wrap_circuit_mul_swap
+            .final_proof_circuit_data()
+            .verify(wrap_proof_swap)
+            .unwrap();
+
+        assert_ne!(
+            mul_circuit.get_circuit_data().verifier_only,
+            mul_circuit_swap.get_circuit_data().verifier_only
+        );
+
+        assert_ne!(
+            wrap_circuit.final_proof_circuit_data().verifier_only,
+            wrap_circuit_mul_swap
+                .final_proof_circuit_data()
+                .verifier_only
+        );
+
+        // check that wrapping a proof with the wrong wrapping circuit does not work
+        check_panic!(
+            || wrap_circuit
+                .wrap_proof(proof_swap, circuit_set_digest,)
+                .unwrap(),
+            "wrapping proof with wrong circuit did not panic"
+        );
+    }
+
+    #[rstest]
+    fn test_wrapping_base_circuit_with_domain_separator(_logger: ()) {
+        const D: usize = 2;
+        type C = PoseidonGoldilocksConfig;
+        type F = <C as GenericConfig<D>>::F;
+
+        let config = CircuitConfig::standard_recursion_config();
+
+        let mut builder = CircuitBuilder::<F, D>::new(config.clone());
+        for _ in 0..=(1 << 12) {
+            builder.add_gate(NoopGate, vec![]);
+        }
+        builder.set_domain_separator(vec![F::rand()]);
+        let pi_t = builder.add_virtual_public_input();
+
+        let data = builder.build::<C>();
+
+        assert_eq!(data.common.degree_bits(), 13);
+
+        let wrap_circuit = WrapCircuitForBaseProofs::build_wrap_circuit(
+            &data.verifier_only,
+            &data.common,
+            &config,
+        );
+
+        let mut pw = PartialWitness::new();
+        let public_input = F::rand();
+        pw.set_target(pi_t, public_input);
+
+        let proof = data.prove(pw).unwrap();
+
+        let wrapped_proof = wrap_circuit
+            .wrap_proof(proof, CircuitSetDigest::default())
+            .unwrap();
+
+        assert_eq!(wrapped_proof.public_inputs[0], public_input);
+
+        wrap_circuit
+            .final_proof_circuit_data()
+            .verify(wrapped_proof)
+            .unwrap()
+    }
+}

--- a/generic_recursion/tests/integration.rs
+++ b/generic_recursion/tests/integration.rs
@@ -1,0 +1,350 @@
+#![feature(generic_const_exprs)]
+
+use std::iter::once;
+use generic_recursion::public_input_aggregation::PublicInputAggregation;
+use plonky2::iop::target::Target;
+use generic_recursion::public_input_aggregation::shared_state::{SharedStatePublicInput, State};
+use plonky2::hash::hash_types::RichField;
+use plonky2::iop::witness::{PartialWitness, WitnessWrite};
+use plonky2::plonk::circuit_builder::CircuitBuilder;
+use plonky2::plonk::circuit_data::{CircuitConfig, CircuitData, VerifierCircuitData};
+use plonky2::plonk::config::{AlgebraicHasher, GenericConfig, Hasher, PoseidonGoldilocksConfig};
+use plonky2::plonk::proof::ProofWithPublicInputs;
+use plonky2::field::extension::Extendable;
+use anyhow::{Error, Result};
+use rand::{Rng, thread_rng};
+use generic_recursion::recursion::{BaseCircuitInfo, build_verifier_circuit_data, PreparedProof, RecursionCircuit, prepare_base_circuit_for_circuit_set};
+use generic_recursion::{AggregationScheme, PreparedProofForAggregation};
+use plonky2::plonk::plonk_common::reduce_with_powers_circuit;
+use plonky2::field::types::Sample;
+use plonky2_u32::gadgets::arithmetic_u32::{CircuitBuilderU32, U32Target};
+use plonky2_u32::gadgets::range_check::range_check_u32_circuit;
+use plonky2_u32::witness::WitnessU32;
+
+ /*
+    Implement a public input aggregation scheme for a shared state where the state is a set of
+    `NUM_EL` targets
+ */
+// underlying type representing the state
+struct VectorState<const NUM_EL: usize>([Target; NUM_EL]);
+
+impl<const NUM_EL: usize> FromIterator<Target> for VectorState<NUM_EL> {
+    fn from_iter<T: IntoIterator<Item=Target>>(iter: T) -> Self {
+        let state = iter.into_iter().take(NUM_EL).collect::<Vec<_>>();
+        VectorState(
+            state.try_into().unwrap()
+        )
+    }
+}
+
+impl<const NUM_EL: usize> TryFrom<&[Target]> for VectorState<NUM_EL> {
+    type Error = Error;
+
+    fn try_from(targets: &[Target]) -> std::result::Result<Self, Self::Error> {
+        if targets.len() != Self::num_targets() {
+            Err(anyhow::Error::msg(format!("expected {} targets to build VectorState, found {}", Self::num_targets(), targets.len())))
+        } else {
+            let targets_array = targets.try_into()?;
+            Ok(Self(targets_array))
+        }
+    }
+}
+
+impl<const NUM_EL: usize> State for VectorState<NUM_EL> {
+    fn num_targets() -> usize {
+        NUM_EL
+    }
+
+    fn to_vec(&self) -> Vec<Target> {
+        self.0.to_vec()
+    }
+}
+
+type VectorStatePublicInput<const NUM_EL: usize> = SharedStatePublicInput<VectorState<NUM_EL>>;
+
+// Data structure for a base circuit employing a state as a public input given by `STATE_LEN`
+// field elements
+const STATE_LEN: usize = 4;
+struct BaseCircuit<
+F: RichField + Extendable<D>,
+C: GenericConfig<D, F = F>,
+const D: usize,
+> {
+    public_input: VectorStatePublicInput<STATE_LEN>,
+    private_input: [Target; STATE_LEN],
+    circuit_data: CircuitData<F,C,D>
+}
+
+impl<
+F: RichField + Extendable<D>,
+C: GenericConfig<D, F = F>,
+const D: usize,
+> BaseCircuit<F,C,D> {
+    fn build_base_circuit(config: CircuitConfig) -> Self
+        where
+            C::Hasher: AlgebraicHasher<F>,
+    {
+        let mut builder = CircuitBuilder::<F, D>::new(config.clone());
+
+        let mut input_state_targets = builder.add_virtual_targets(STATE_LEN);
+
+        let mut intermediate_state_targets = builder.add_virtual_targets(STATE_LEN);
+
+        let private_input_targets = builder.add_virtual_targets(STATE_LEN);
+
+        for (&input_t, &intermediate_t) in input_state_targets.iter().zip(intermediate_state_targets.iter()) {
+            builder.generate_copy(input_t, intermediate_t);
+            builder.connect(input_t, intermediate_t);
+        }
+
+        const NUM_ROUNDS: usize = 1 << 10;
+
+        for i in 0..NUM_ROUNDS {
+            intermediate_state_targets = intermediate_state_targets.iter().zip(private_input_targets.iter()).map(|(&intermediate_t, &input_t)| {
+                if i % 2 == 0 {
+                    builder.exp(intermediate_t, input_t, F::BITS)
+                } else {
+                    builder.mul(intermediate_t, input_t)
+                }
+            }).collect::<Vec<_>>();
+            intermediate_state_targets = builder.hash_n_to_m_no_pad::<C::Hasher>(intermediate_state_targets, STATE_LEN);
+        }
+
+        input_state_targets.extend_from_slice(intermediate_state_targets.as_slice());
+
+        let public_input_targets = VectorStatePublicInput::try_from_public_input_targets(input_state_targets.as_slice()).unwrap();
+
+        public_input_targets.register_public_inputs(&mut builder);
+
+        let data = builder.build::<C>();
+
+        Self {
+            public_input: public_input_targets,
+            private_input: private_input_targets.try_into().unwrap(),
+            circuit_data: data,
+        }
+    }
+
+    fn generate_base_proof(&self, init_state: [F; STATE_LEN])
+        -> Result<ProofWithPublicInputs<F,C,D>> {
+        let mut pw = PartialWitness::<F>::new();
+
+        for (&target, &value) in self.public_input.get_targets().iter().take(STATE_LEN).zip(init_state.iter()) {
+            pw.set_target(target, value);
+        }
+
+        for target in self.private_input {
+            pw.set_target(target, F::rand());
+        }
+
+        self.circuit_data.prove(pw)
+    }
+}
+
+// Data structure for a second base circuit, which employs `STATE_LEN` `U32Target`s as the public
+// input shared state
+struct BaseCircuitU32 <
+    F: RichField + Extendable<D>,
+    C: GenericConfig<D, F = F>,
+    const D: usize,
+> {
+    public_input: VectorStatePublicInput<STATE_LEN>,
+    private_input: [U32Target; STATE_LEN],
+    circuit_data: CircuitData<F,C,D>
+}
+
+impl<
+    F: RichField + Extendable<D>,
+    C: GenericConfig<D, F = F>,
+    const D: usize,
+> BaseCircuitU32<F,C,D> {
+
+    // Utility function that computes a target out of the 32 least significant bits of the input
+    // target
+    fn truncate_target_to_u32(builder: &mut CircuitBuilder<F,D>, target: Target) -> Target {
+        const B_BITS: usize = 2;
+        const B: usize = 1 << B_BITS;
+        let least_significant_limbs = &builder.split_le_base::<B>(target, (64+B_BITS-1)/B_BITS)[..(32+B_BITS-1)/B_BITS];
+        let four = builder.constant(F::from_canonical_u64(B as u64));
+        reduce_with_powers_circuit(builder, least_significant_limbs, four)
+    }
+
+    fn build_base_circuit(config: CircuitConfig) -> Self
+        where
+            C::Hasher: AlgebraicHasher<F>,
+    {
+        let mut builder = CircuitBuilder::<F, D>::new(config.clone());
+
+        let mut input_state_targets = builder.add_virtual_targets(STATE_LEN);
+
+        let private_input_targets = builder.add_virtual_u32_targets(STATE_LEN);
+
+        range_check_u32_circuit(&mut builder, private_input_targets.clone());
+        
+        let mut intermediate_state_targets = input_state_targets.iter().map(|&input_t| {
+            let target = Self::truncate_target_to_u32(&mut builder, input_t);
+            range_check_u32_circuit(&mut builder, vec![U32Target(target)]);
+            target
+        }).collect::<Vec<_>>();
+
+        const NUM_ROUNDS: usize = 1 << 9;
+
+        for i in 0..NUM_ROUNDS {
+            intermediate_state_targets = intermediate_state_targets.iter().zip(private_input_targets.iter()).map(|(&intermediate_t, &input_t)| {
+                if i % 2 == 0 {
+                    builder.add_u32(U32Target(intermediate_t), input_t).0
+                } else {
+                    builder.mul_u32(U32Target(intermediate_t), input_t).0
+                }.0
+            }).collect::<Vec<_>>();
+            intermediate_state_targets =
+                builder.hash_n_to_m_no_pad::<C::Hasher>(intermediate_state_targets, STATE_LEN).iter().map(|&target|
+                Self::truncate_target_to_u32(&mut builder, target)
+                ).collect();
+        }
+
+        input_state_targets.extend_from_slice(intermediate_state_targets.as_slice());
+
+        let public_input_targets = VectorStatePublicInput::try_from_public_input_targets(input_state_targets.as_slice()).unwrap();
+
+        public_input_targets.register_public_inputs(&mut builder);
+
+        let data = builder.build::<C>();
+
+        Self {
+            public_input: public_input_targets,
+            private_input: private_input_targets.try_into().unwrap(),
+            circuit_data: data,
+        }
+    }
+
+    fn generate_base_proof(&self, init_state: [F; STATE_LEN])
+                           -> Result<ProofWithPublicInputs<F,C,D>> {
+        let mut pw = PartialWitness::<F>::new();
+
+        for (&target, &value) in self.public_input.get_targets().iter().take(STATE_LEN).zip(init_state.iter()) {
+            pw.set_target(target, value);
+        }
+
+        for target in self.private_input {
+            pw.set_u32_target(target, thread_rng().gen());
+        }
+
+        self.circuit_data.prove(pw)
+    }
+}
+
+// Implement `BaseCircuitInfo` trait for `BaseCircuit` to allow aggregation of proofs of this
+// circuit with the recursive aggregation circuit
+impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
+BaseCircuitInfo<F, C, D> for &BaseCircuit<F,C,D> {
+    type PIScheme = VectorStatePublicInput<STATE_LEN>;
+
+    fn get_verifier_circuit_data(&self) -> VerifierCircuitData<F, C, D> {
+        build_verifier_circuit_data(&self.circuit_data)
+    }
+}
+// Implement `BaseCircuitInfo` trait for `BaseCircuitU32` to allow aggregation of proofs of this
+// circuit with the recursive aggregation circuit
+impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
+BaseCircuitInfo<F, C, D> for &BaseCircuitU32<F,C,D> {
+    type PIScheme = VectorStatePublicInput<STATE_LEN>;
+
+    fn get_verifier_circuit_data(&self) -> VerifierCircuitData<F, C, D> {
+        build_verifier_circuit_data(&self.circuit_data)
+    }
+}
+
+// multiple checks to ensure the validity of an aggregated proof for a
+// `SharedStatePublicInput` aggregation scheme employing `ST` as state representation
+fn check_aggregated_proof<
+    F: RichField + Extendable<D>,
+    C: GenericConfig<D, F = F> + 'static,
+    const D: usize,
+    ST: State,
+>(
+    aggregated_proof: &PreparedProofForAggregation<F, C, D>,
+    aggregation_scheme: &AggregationScheme<F, C, D, SharedStatePublicInput<ST>>,
+    init: Vec<F>,
+    final_state: Vec<F>,
+) where
+    C::Hasher: AlgebraicHasher<F>,
+    [(); C::Hasher::HASH_SIZE]:,
+{
+    aggregation_scheme
+        .verify_aggregated_proof(aggregated_proof.clone())
+        .unwrap();
+    let aggregated_proof = aggregated_proof.get_proof();
+
+    assert_eq!(aggregated_proof.public_inputs[..ST::num_targets()], init);
+    assert_eq!(
+        aggregated_proof.public_inputs
+            [ST::num_targets()..SharedStatePublicInput::<ST>::num_public_inputs()],
+        final_state
+    );
+}
+
+#[test]
+fn test_recursive_aggregation() {
+    const D: usize = 2;
+    type PC = PoseidonGoldilocksConfig;
+    type F = <PC as GenericConfig<D>>::F;
+    env_logger::init();
+
+    let config = CircuitConfig::standard_recursion_config();
+
+    let mut rng = thread_rng();
+
+    let base_circuit = BaseCircuit::<F,PC,D>::build_base_circuit(config.clone());
+    log::info!("base circuit size: {}", base_circuit.circuit_data.common.degree_bits());
+    let base_circuit_u32 = BaseCircuitU32::<F,PC,D>::build_base_circuit(config.clone());
+    log::info!("base circuit u32 size: {}", base_circuit.circuit_data.common.degree_bits());
+    let base_vd = (&base_circuit).get_verifier_circuit_data();
+    let base_u32_vd = (&base_circuit_u32).get_verifier_circuit_data();
+
+    let init_state = (0..STATE_LEN).map(|_| F::rand()).collect::<Vec<_>>().try_into().unwrap();
+
+    const NUM_PROOFS: usize = 8;
+    let mut state = init_state;
+    let base_proofs = (0..NUM_PROOFS).map(|i| {
+        let (proof, vd) = if rng.gen() {
+            (
+                base_circuit.generate_base_proof(state).unwrap(),
+                &base_vd
+            )
+        } else {
+            (
+                base_circuit_u32.generate_base_proof(state).unwrap(),
+                &base_u32_vd,
+            )
+        };
+        log::info!("generated {}-th base proof", i + 1);
+        state = proof.public_inputs[STATE_LEN..].to_vec().try_into().unwrap();
+        vd.verify(proof.clone()).unwrap();
+        (proof, vd)
+    }).collect::<Vec<_>>();
+
+    let circuit_set
+    = vec![prepare_base_circuit_for_circuit_set(&base_circuit),
+           prepare_base_circuit_for_circuit_set(&base_circuit_u32)];
+
+    let mut aggregation_scheme = AggregationScheme::build_circuit(
+        circuit_set.into_iter()
+    ).unwrap();
+
+    for (proof, vd) in base_proofs {
+        let prepared_proof = aggregation_scheme.prepare_proof_for_aggregation(proof, vd).unwrap();
+        aggregation_scheme = aggregation_scheme.add_proofs_for_aggregation(once(prepared_proof));
+    }
+
+    let (aggregation_scheme, aggregated_proof) = aggregation_scheme.aggregate_proofs().unwrap();
+
+
+    check_aggregated_proof::<_, _, D, VectorState<STATE_LEN>>(
+        &aggregated_proof,
+        &aggregation_scheme,
+        init_state.to_vec(),
+        state.to_vec(),
+    );
+
+}


### PR DESCRIPTION
This PR introduces a crate that provides interfaces and data structures to aggregate an unlimited number of Plonky2 proofs in a single proof, which can be verified with the same verifier data independently from the number of proofs being aggregated.
In order to setup the recursive aggregation, it is only necessary to specify a set of circuits with the same format of public inputs: the available aggregation scheme  will be then capable of aggregating proofs generated with a circuit belonging to the specified set. 
The crate provides also a trait, called `PublicInputAggregation`, that allows to specify the format of the public inputs of the proofs being aggregated, which is necessary in order to properly combine the public inputs of the aggregated proofs in a set of public inputs for the final aggregated proof.

The recursive aggregation provided in this crate has the following features:                                                               
- There is no need to write an ad-hoc recursive circuit for each set of circuits whose proofs needs to be aggregated: the user just needs to specify the set of circuits and how to aggregate their public inputs, then the crate will build the necessary recursive circuits to aggregate an arbitrary number of proofs
- Proofs are aggregated in a tree-like fashion rather than sequentially, which can be more efficient if there are multiple provers that can aggregate simultaneously different chunks of the proof tree  

This crate can be conceived as an additional recursion strategy available in Plonky2, possibly extending the usability and versatility of Plonky2 to a broader set of use cases.

**Note that due to [this bug](https://github.com/rust-lang/rust/issues/104815) in the Rust compiler, the tests can be run only with the following nightly build: `rustc 1.67.0-nightly (e0098a5cc 2022-11-29)`**