### PR TITLE
Optimize reduce_polys_base

### DIFF
--- a/plonky2/src/fri/oracle.rs
+++ b/plonky2/src/fri/oracle.rs
@@ -182,9 +182,12 @@ impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
         // The oracles used in Plonky2 are given in `FRI_ORACLES` in `plonky2/src/plonk/plonk_common.rs`.
         for FriBatchInfo { point, polynomials } in &instance.batches {
             // Collect the coefficients of all the polynomials in `polynomials`.
-            let polys_coeff = polynomials.iter().map(|fri_poly| {
-                &oracles[fri_poly.oracle_index].polynomials[fri_poly.polynomial_index]
-            });
+            let polys_coeff = polynomials
+                .iter()
+                .map(|fri_poly| {
+                    &oracles[fri_poly.oracle_index].polynomials[fri_poly.polynomial_index]
+                })
+                .collect();
             let composition_poly = timed!(
                 timing,
                 &format!("reduce batch of {} polynomials", polynomials.len()),

--- a/plonky2/src/util/reducing.rs
+++ b/plonky2/src/util/reducing.rs
@@ -92,7 +92,7 @@ impl<F: Field> ReducingFactor<F> {
             .zip(polys)
             .collect::<Vec<_>>()
             .par_iter()
-            .map(|(base_power, poly)| poly.mul_extension(base_power.clone()))
+            .map(|(base_power, poly)| poly.mul_extension(*base_power))
             .sum()
     }
 

--- a/plonky2/src/util/reducing.rs
+++ b/plonky2/src/util/reducing.rs
@@ -2,6 +2,8 @@ use alloc::vec;
 use alloc::vec::Vec;
 use core::borrow::Borrow;
 
+use plonky2_maybe_rayon::*;
+
 use crate::field::extension::{Extendable, FieldExtension};
 use crate::field::packed::PackedField;
 use crate::field::polynomial::PolynomialCoeffs;
@@ -82,15 +84,15 @@ impl<F: Field> ReducingFactor<F> {
 
     pub fn reduce_polys_base<BF: Extendable<D, Extension = F>, const D: usize>(
         &mut self,
-        polys: impl IntoIterator<Item = impl Borrow<PolynomialCoeffs<BF>>>,
+        polys: Vec<&PolynomialCoeffs<BF>>,
     ) -> PolynomialCoeffs<F> {
+        self.count += polys.len() as u64;
         self.base
             .powers()
             .zip(polys)
-            .map(|(base_power, poly)| {
-                self.count += 1;
-                poly.borrow().mul_extension(base_power)
-            })
+            .collect::<Vec<_>>()
+            .par_iter()
+            .map(|(base_power, poly)| poly.mul_extension(base_power.clone()))
             .sum()
     }
 


### PR DESCRIPTION
Make `reduce_polys_base` parallel.

Unfortunately I had to use two collect(), not sure if there's a better way to do this.
In all practical cases I analyzed, collect() wasn't an issue as the number of polynomials is relatively small (256, 500, up to 800ish). But parallelization improves significantly the perf.