### PR TITLE
Derive clone for txn RLP structs

### DIFF
--- a/evm/src/generation/mpt.rs
+++ b/evm/src/generation/mpt.rs
@@ -33,88 +33,6 @@ impl Default for AccountRlp {
     }
 }
 
-pub mod transaction_testing {
-    use super::*;
-
-    #[derive(RlpEncodable, RlpDecodable, Debug, Clone)]
-    pub struct AccessListItemRlp {
-        pub address: Address,
-        pub storage_keys: Vec<U256>,
-    }
-
-    #[derive(Debug, Clone)]
-    pub struct AddressOption(pub Option<Address>);
-
-    impl Encodable for AddressOption {
-        fn rlp_append(&self, s: &mut RlpStream) {
-            match self.0 {
-                None => {
-                    s.append_empty_data();
-                }
-                Some(value) => {
-                    s.encoder().encode_value(&value.to_fixed_bytes());
-                }
-            }
-        }
-    }
-
-    impl Decodable for AddressOption {
-        fn decode(rlp: &Rlp) -> Result<Self, DecoderError> {
-            if rlp.is_int() && rlp.is_empty() {
-                return Ok(AddressOption(None));
-            }
-            if rlp.is_data() && rlp.size() == 20 {
-                return Ok(AddressOption(Some(Address::decode(rlp)?)));
-            }
-            Err(DecoderError::RlpExpectedToBeData)
-        }
-    }
-
-    #[derive(RlpEncodable, RlpDecodable, Debug, Clone)]
-    pub struct LegacyTransactionRlp {
-        pub nonce: U256,
-        pub gas_price: U256,
-        pub gas: U256,
-        pub to: AddressOption,
-        pub value: U256,
-        pub data: Bytes,
-        pub v: U256,
-        pub r: U256,
-        pub s: U256,
-    }
-
-    #[derive(RlpEncodable, RlpDecodable, Debug, Clone)]
-    pub struct AccessListTransactionRlp {
-        pub chain_id: u64,
-        pub nonce: U256,
-        pub gas_price: U256,
-        pub gas: U256,
-        pub to: AddressOption,
-        pub value: U256,
-        pub data: Bytes,
-        pub access_list: Vec<AccessListItemRlp>,
-        pub y_parity: U256,
-        pub r: U256,
-        pub s: U256,
-    }
-
-    #[derive(RlpEncodable, RlpDecodable, Debug, Clone)]
-    pub struct FeeMarketTransactionRlp {
-        pub chain_id: u64,
-        pub nonce: U256,
-        pub max_priority_fee_per_gas: U256,
-        pub max_fee_per_gas: U256,
-        pub gas: U256,
-        pub to: AddressOption,
-        pub value: U256,
-        pub data: Bytes,
-        pub access_list: Vec<AccessListItemRlp>,
-        pub y_parity: U256,
-        pub r: U256,
-        pub s: U256,
-    }
-}
-
 #[derive(RlpEncodable, RlpDecodable, Debug, Clone)]
 pub struct LogRlp {
     pub address: Address,
@@ -358,5 +276,87 @@ fn empty_nibbles() -> Nibbles {
     Nibbles {
         count: 0,
         packed: U512::zero(),
+    }
+}
+
+pub mod transaction_testing {
+    use super::*;
+
+    #[derive(RlpEncodable, RlpDecodable, Debug, Clone)]
+    pub struct AccessListItemRlp {
+        pub address: Address,
+        pub storage_keys: Vec<U256>,
+    }
+
+    #[derive(Debug, Clone)]
+    pub struct AddressOption(pub Option<Address>);
+
+    impl Encodable for AddressOption {
+        fn rlp_append(&self, s: &mut RlpStream) {
+            match self.0 {
+                None => {
+                    s.append_empty_data();
+                }
+                Some(value) => {
+                    s.encoder().encode_value(&value.to_fixed_bytes());
+                }
+            }
+        }
+    }
+
+    impl Decodable for AddressOption {
+        fn decode(rlp: &Rlp) -> Result<Self, DecoderError> {
+            if rlp.is_int() && rlp.is_empty() {
+                return Ok(AddressOption(None));
+            }
+            if rlp.is_data() && rlp.size() == 20 {
+                return Ok(AddressOption(Some(Address::decode(rlp)?)));
+            }
+            Err(DecoderError::RlpExpectedToBeData)
+        }
+    }
+
+    #[derive(RlpEncodable, RlpDecodable, Debug, Clone)]
+    pub struct LegacyTransactionRlp {
+        pub nonce: U256,
+        pub gas_price: U256,
+        pub gas: U256,
+        pub to: AddressOption,
+        pub value: U256,
+        pub data: Bytes,
+        pub v: U256,
+        pub r: U256,
+        pub s: U256,
+    }
+
+    #[derive(RlpEncodable, RlpDecodable, Debug, Clone)]
+    pub struct AccessListTransactionRlp {
+        pub chain_id: u64,
+        pub nonce: U256,
+        pub gas_price: U256,
+        pub gas: U256,
+        pub to: AddressOption,
+        pub value: U256,
+        pub data: Bytes,
+        pub access_list: Vec<AccessListItemRlp>,
+        pub y_parity: U256,
+        pub r: U256,
+        pub s: U256,
+    }
+
+    #[derive(RlpEncodable, RlpDecodable, Debug, Clone)]
+    pub struct FeeMarketTransactionRlp {
+        pub chain_id: u64,
+        pub nonce: U256,
+        pub max_priority_fee_per_gas: U256,
+        pub max_fee_per_gas: U256,
+        pub gas: U256,
+        pub to: AddressOption,
+        pub value: U256,
+        pub data: Bytes,
+        pub access_list: Vec<AccessListItemRlp>,
+        pub y_parity: U256,
+        pub r: U256,
+        pub s: U256,
     }
 }

--- a/evm/src/generation/mpt.rs
+++ b/evm/src/generation/mpt.rs
@@ -33,13 +33,13 @@ impl Default for AccountRlp {
     }
 }
 
-#[derive(RlpEncodable, RlpDecodable, Debug)]
+#[derive(RlpEncodable, RlpDecodable, Debug, Clone)]
 pub struct AccessListItemRlp {
     pub address: Address,
     pub storage_keys: Vec<U256>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct AddressOption(pub Option<Address>);
 
 impl Encodable for AddressOption {
@@ -67,7 +67,7 @@ impl Decodable for AddressOption {
     }
 }
 
-#[derive(RlpEncodable, RlpDecodable, Debug)]
+#[derive(RlpEncodable, RlpDecodable, Debug, Clone)]
 pub struct LegacyTransactionRlp {
     pub nonce: U256,
     pub gas_price: U256,
@@ -80,7 +80,7 @@ pub struct LegacyTransactionRlp {
     pub s: U256,
 }
 
-#[derive(RlpEncodable, RlpDecodable, Debug)]
+#[derive(RlpEncodable, RlpDecodable, Debug, Clone)]
 pub struct AccessListTransactionRlp {
     pub chain_id: u64,
     pub nonce: U256,
@@ -95,7 +95,7 @@ pub struct AccessListTransactionRlp {
     pub s: U256,
 }
 
-#[derive(RlpEncodable, RlpDecodable, Debug)]
+#[derive(RlpEncodable, RlpDecodable, Debug, Clone)]
 pub struct FeeMarketTransactionRlp {
     pub chain_id: u64,
     pub nonce: U256,
@@ -111,14 +111,14 @@ pub struct FeeMarketTransactionRlp {
     pub s: U256,
 }
 
-#[derive(RlpEncodable, RlpDecodable, Debug)]
+#[derive(RlpEncodable, RlpDecodable, Debug, Clone)]
 pub struct LogRlp {
     pub address: Address,
     pub topics: Vec<H256>,
     pub data: Bytes,
 }
 
-#[derive(RlpEncodable, RlpDecodable, Debug)]
+#[derive(RlpEncodable, RlpDecodable, Debug, Clone)]
 pub struct LegacyReceiptRlp {
     pub status: bool,
     pub cum_gas_used: U256,

--- a/evm/src/generation/mpt.rs
+++ b/evm/src/generation/mpt.rs
@@ -33,82 +33,86 @@ impl Default for AccountRlp {
     }
 }
 
-#[derive(RlpEncodable, RlpDecodable, Debug, Clone)]
-pub struct AccessListItemRlp {
-    pub address: Address,
-    pub storage_keys: Vec<U256>,
-}
+pub mod transaction_testing {
+    use super::*;
 
-#[derive(Debug, Clone)]
-pub struct AddressOption(pub Option<Address>);
+    #[derive(RlpEncodable, RlpDecodable, Debug, Clone)]
+    pub struct AccessListItemRlp {
+        pub address: Address,
+        pub storage_keys: Vec<U256>,
+    }
 
-impl Encodable for AddressOption {
-    fn rlp_append(&self, s: &mut RlpStream) {
-        match self.0 {
-            None => {
-                s.append_empty_data();
-            }
-            Some(value) => {
-                s.encoder().encode_value(&value.to_fixed_bytes());
+    #[derive(Debug, Clone)]
+    pub struct AddressOption(pub Option<Address>);
+
+    impl Encodable for AddressOption {
+        fn rlp_append(&self, s: &mut RlpStream) {
+            match self.0 {
+                None => {
+                    s.append_empty_data();
+                }
+                Some(value) => {
+                    s.encoder().encode_value(&value.to_fixed_bytes());
+                }
             }
         }
     }
-}
 
-impl Decodable for AddressOption {
-    fn decode(rlp: &Rlp) -> Result<Self, DecoderError> {
-        if rlp.is_int() && rlp.is_empty() {
-            return Ok(AddressOption(None));
+    impl Decodable for AddressOption {
+        fn decode(rlp: &Rlp) -> Result<Self, DecoderError> {
+            if rlp.is_int() && rlp.is_empty() {
+                return Ok(AddressOption(None));
+            }
+            if rlp.is_data() && rlp.size() == 20 {
+                return Ok(AddressOption(Some(Address::decode(rlp)?)));
+            }
+            Err(DecoderError::RlpExpectedToBeData)
         }
-        if rlp.is_data() && rlp.size() == 20 {
-            return Ok(AddressOption(Some(Address::decode(rlp)?)));
-        }
-        Err(DecoderError::RlpExpectedToBeData)
     }
-}
 
-#[derive(RlpEncodable, RlpDecodable, Debug, Clone)]
-pub struct LegacyTransactionRlp {
-    pub nonce: U256,
-    pub gas_price: U256,
-    pub gas: U256,
-    pub to: AddressOption,
-    pub value: U256,
-    pub data: Bytes,
-    pub v: U256,
-    pub r: U256,
-    pub s: U256,
-}
+    #[derive(RlpEncodable, RlpDecodable, Debug, Clone)]
+    pub struct LegacyTransactionRlp {
+        pub nonce: U256,
+        pub gas_price: U256,
+        pub gas: U256,
+        pub to: AddressOption,
+        pub value: U256,
+        pub data: Bytes,
+        pub v: U256,
+        pub r: U256,
+        pub s: U256,
+    }
 
-#[derive(RlpEncodable, RlpDecodable, Debug, Clone)]
-pub struct AccessListTransactionRlp {
-    pub chain_id: u64,
-    pub nonce: U256,
-    pub gas_price: U256,
-    pub gas: U256,
-    pub to: AddressOption,
-    pub value: U256,
-    pub data: Bytes,
-    pub access_list: Vec<AccessListItemRlp>,
-    pub y_parity: U256,
-    pub r: U256,
-    pub s: U256,
-}
+    #[derive(RlpEncodable, RlpDecodable, Debug, Clone)]
+    pub struct AccessListTransactionRlp {
+        pub chain_id: u64,
+        pub nonce: U256,
+        pub gas_price: U256,
+        pub gas: U256,
+        pub to: AddressOption,
+        pub value: U256,
+        pub data: Bytes,
+        pub access_list: Vec<AccessListItemRlp>,
+        pub y_parity: U256,
+        pub r: U256,
+        pub s: U256,
+    }
 
-#[derive(RlpEncodable, RlpDecodable, Debug, Clone)]
-pub struct FeeMarketTransactionRlp {
-    pub chain_id: u64,
-    pub nonce: U256,
-    pub max_priority_fee_per_gas: U256,
-    pub max_fee_per_gas: U256,
-    pub gas: U256,
-    pub to: AddressOption,
-    pub value: U256,
-    pub data: Bytes,
-    pub access_list: Vec<AccessListItemRlp>,
-    pub y_parity: U256,
-    pub r: U256,
-    pub s: U256,
+    #[derive(RlpEncodable, RlpDecodable, Debug, Clone)]
+    pub struct FeeMarketTransactionRlp {
+        pub chain_id: u64,
+        pub nonce: U256,
+        pub max_priority_fee_per_gas: U256,
+        pub max_fee_per_gas: U256,
+        pub gas: U256,
+        pub to: AddressOption,
+        pub value: U256,
+        pub data: Bytes,
+        pub access_list: Vec<AccessListItemRlp>,
+        pub y_parity: U256,
+        pub r: U256,
+        pub s: U256,
+    }
 }
 
 #[derive(RlpEncodable, RlpDecodable, Debug, Clone)]

--- a/evm/tests/log_opcode.rs
+++ b/evm/tests/log_opcode.rs
@@ -17,9 +17,8 @@ use plonky2::util::timing::TimingTree;
 use plonky2_evm::all_stark::AllStark;
 use plonky2_evm::config::StarkConfig;
 use plonky2_evm::fixed_recursive_verifier::AllRecursiveCircuits;
-use plonky2_evm::generation::mpt::{
-    AccountRlp, AddressOption, LegacyReceiptRlp, LegacyTransactionRlp, LogRlp,
-};
+use plonky2_evm::generation::mpt::transaction_testing::{AddressOption, LegacyTransactionRlp};
+use plonky2_evm::generation::mpt::{AccountRlp, LegacyReceiptRlp, LogRlp};
 use plonky2_evm::generation::{GenerationInputs, TrieInputs};
 use plonky2_evm::proof::{BlockHashes, BlockMetadata, ExtraBlockData, PublicValues, TrieRoots};
 use plonky2_evm::prover::prove;


### PR DESCRIPTION
Also move them behind a transaction_testing module for clarity on their expected usage.
@wborgeaud Would you mind having another look?