### PR TITLE
Remove extra SHL/SHR CTL.

### DIFF
--- a/evm/src/all_stark.rs
+++ b/evm/src/all_stark.rs
@@ -104,10 +104,7 @@ pub(crate) fn all_cross_table_lookups<F: Field>() -> Vec<CrossTableLookup<F>> {
 
 fn ctl_arithmetic<F: Field>() -> CrossTableLookup<F> {
     CrossTableLookup::new(
-        vec![
-            cpu_stark::ctl_arithmetic_base_rows(),
-            cpu_stark::ctl_arithmetic_shift_rows(),
-        ],
+        vec![cpu_stark::ctl_arithmetic_base_rows()],
         arithmetic_stark::ctl_arithmetic_rows(),
     )
 }

--- a/evm/src/arithmetic/arithmetic_stark.rs
+++ b/evm/src/arithmetic/arithmetic_stark.rs
@@ -12,6 +12,7 @@ use plonky2::util::transpose;
 use static_assertions::const_assert;
 
 use super::columns::NUM_ARITH_COLUMNS;
+use super::shift;
 use crate::all_stark::Table;
 use crate::arithmetic::columns::{RANGE_COUNTER, RC_FREQUENCIES, SHARED_COLS};
 use crate::arithmetic::{addcy, byte, columns, divmod, modular, mul, Operation};
@@ -208,6 +209,7 @@ impl<F: RichField + Extendable<D>, const D: usize> Stark<F, D> for ArithmeticSta
         divmod::eval_packed(lv, nv, yield_constr);
         modular::eval_packed(lv, nv, yield_constr);
         byte::eval_packed(lv, yield_constr);
+        shift::eval_packed_generic(lv, nv, yield_constr);
     }
 
     fn eval_ext_circuit(
@@ -237,6 +239,7 @@ impl<F: RichField + Extendable<D>, const D: usize> Stark<F, D> for ArithmeticSta
         divmod::eval_ext_circuit(builder, lv, nv, yield_constr);
         modular::eval_ext_circuit(builder, lv, nv, yield_constr);
         byte::eval_ext_circuit(builder, lv, yield_constr);
+        shift::eval_ext_circuit(builder, lv, nv, yield_constr);
     }
 
     fn constraint_degree(&self) -> usize {

--- a/evm/src/arithmetic/columns.rs
+++ b/evm/src/arithmetic/columns.rs
@@ -101,7 +101,7 @@ pub(crate) const MODULAR_OUT_AUX_RED: Range<usize> = AUX_REGISTER_0;
 pub(crate) const MODULAR_MOD_IS_ZERO: usize = AUX_REGISTER_1.start;
 pub(crate) const MODULAR_AUX_INPUT_LO: Range<usize> = AUX_REGISTER_1.start + 1..AUX_REGISTER_1.end;
 pub(crate) const MODULAR_AUX_INPUT_HI: Range<usize> = AUX_REGISTER_2;
-// Must be set to MOD_IS_ZERO for DIV operation i.e. MOD_IS_ZERO * lv[IS_DIV]
+// Must be set to MOD_IS_ZERO for DIV and SHR operations i.e. MOD_IS_ZERO * (lv[IS_DIV] + lv[IS_SHR]).
 pub(crate) const MODULAR_DIV_DENOM_IS_ZERO: usize = AUX_REGISTER_2.end;
 
 /// The counter column (used for the range check) starts from 0 and increments.

--- a/evm/src/arithmetic/divmod.rs
+++ b/evm/src/arithmetic/divmod.rs
@@ -57,7 +57,7 @@ pub(crate) fn generate_divmod<F: PrimeField64>(
             );
             lv[AUX_INPUT_REGISTER_0].copy_from_slice(&quo_input[..N_LIMBS]);
         }
-        _ => panic!("expected filter to be IS_DIV or IS_MOD but it was {filter}"),
+        _ => panic!("expected filter to be IS_DIV, IS_SHR or IS_MOD but it was {filter}"),
     };
 }
 /// Generate the output and auxiliary values for modular operations.
@@ -233,6 +233,8 @@ mod tests {
         for op in MODULAR_OPS {
             lv[op] = F::ZERO;
         }
+        // Since SHR uses the logic for DIV, `IS_SHR` should also be set to 0 here.
+        lv[IS_SHR] = F::ZERO;
 
         let mut constraint_consumer = ConstraintConsumer::new(
             vec![GoldilocksField(2), GoldilocksField(3), GoldilocksField(5)],
@@ -264,6 +266,8 @@ mod tests {
                 for op in MODULAR_OPS {
                     lv[op] = F::ZERO;
                 }
+                // Since SHR uses the logic for DIV, `IS_SHR` should also be set to 0 here.
+                lv[IS_SHR] = F::ZERO;
                 lv[op_filter] = F::ONE;
 
                 let input0 = U256::from(rng.gen::<[u8; 32]>());
@@ -324,6 +328,8 @@ mod tests {
                 for op in MODULAR_OPS {
                     lv[op] = F::ZERO;
                 }
+                // Since SHR uses the logic for DIV, `IS_SHR` should also be set to 0 here.
+                lv[IS_SHR] = F::ZERO;
                 lv[op_filter] = F::ONE;
 
                 let input0 = U256::from(rng.gen::<[u8; 32]>());

--- a/evm/src/arithmetic/divmod.rs
+++ b/evm/src/arithmetic/divmod.rs
@@ -79,7 +79,7 @@ pub(crate) fn generate<F: PrimeField64>(
 }
 
 /// Verify that num = quo * den + rem and 0 <= rem < den.
-pub fn eval_packed_divmod_helper<P: PackedField>(
+pub(crate) fn eval_packed_divmod_helper<P: PackedField>(
     lv: &[P; NUM_ARITH_COLUMNS],
     nv: &[P; NUM_ARITH_COLUMNS],
     yield_constr: &mut ConstraintConsumer<P>,

--- a/evm/src/arithmetic/mod.rs
+++ b/evm/src/arithmetic/mod.rs
@@ -38,14 +38,11 @@ impl BinaryOperator {
             BinaryOperator::Add => input0.overflowing_add(input1).0,
             BinaryOperator::Mul => input0.overflowing_mul(input1).0,
             BinaryOperator::Shl => {
-                // Compute the shifted displacement, so we can turn the left
-                // left into a multiplication.
-                let shifted_input1 = if input1.bits() <= 32 {
-                    U256::one() << input1
+                if input0 < U256::from(256usize) {
+                    input1 << input0
                 } else {
                     U256::zero()
-                };
-                input0.overflowing_mul(shifted_input1).0
+                }
             }
             BinaryOperator::Sub => input0.overflowing_sub(input1).0,
             BinaryOperator::Div => {
@@ -56,17 +53,10 @@ impl BinaryOperator {
                 }
             }
             BinaryOperator::Shr => {
-                // Compute the shifted displacement, so we can turn the
-                // right shift into a multiplication.
-                let shifted_input1 = if input1.bits() <= 32 {
-                    U256::one() << input1
+                if input0 < U256::from(256usize) {
+                    input1 >> input0
                 } else {
                     U256::zero()
-                };
-                if shifted_input1.is_zero() {
-                    U256::zero()
-                } else {
-                    input0 / shifted_input1
                 }
             }
             BinaryOperator::Mod => {

--- a/evm/src/arithmetic/mod.rs
+++ b/evm/src/arithmetic/mod.rs
@@ -9,6 +9,7 @@ mod byte;
 mod divmod;
 mod modular;
 mod mul;
+mod shift;
 mod utils;
 
 pub mod arithmetic_stark;
@@ -35,13 +36,37 @@ impl BinaryOperator {
     pub(crate) fn result(&self, input0: U256, input1: U256) -> U256 {
         match self {
             BinaryOperator::Add => input0.overflowing_add(input1).0,
-            BinaryOperator::Mul | BinaryOperator::Shl => input0.overflowing_mul(input1).0,
+            BinaryOperator::Mul => input0.overflowing_mul(input1).0,
+            BinaryOperator::Shl => {
+                // Compute the shifted displacement, so we can turn the left
+                // left into a multiplication.
+                let shifted_input1 = if input1.bits() <= 32 {
+                    U256::one() << input1
+                } else {
+                    U256::zero()
+                };
+                input0.overflowing_mul(shifted_input1).0
+            }
             BinaryOperator::Sub => input0.overflowing_sub(input1).0,
-            BinaryOperator::Div | BinaryOperator::Shr => {
+            BinaryOperator::Div => {
                 if input1.is_zero() {
                     U256::zero()
                 } else {
                     input0 / input1
+                }
+            }
+            BinaryOperator::Shr => {
+                // Compute the shifted displacement, so we can turn the
+                // right shift into a multiplication.
+                let shifted_input1 = if input1.bits() <= 32 {
+                    U256::one() << input1
+                } else {
+                    U256::zero()
+                };
+                if shifted_input1.is_zero() {
+                    U256::zero()
+                } else {
+                    input0 / shifted_input1
                 }
             }
             BinaryOperator::Mod => {
@@ -238,13 +263,23 @@ fn binary_op_to_rows<F: PrimeField64>(
             addcy::generate(&mut row, op.row_filter(), input0, input1);
             (row, None)
         }
-        BinaryOperator::Mul | BinaryOperator::Shl => {
+        BinaryOperator::Mul => {
             mul::generate(&mut row, input0, input1);
             (row, None)
         }
-        BinaryOperator::Div | BinaryOperator::Mod | BinaryOperator::Shr => {
+        BinaryOperator::Shl => {
+            let mut nv = vec![F::ZERO; columns::NUM_ARITH_COLUMNS];
+            shift::generate(&mut row, &mut nv, true, input0, input1, result);
+            (row, None)
+        }
+        BinaryOperator::Div | BinaryOperator::Mod => {
             let mut nv = vec![F::ZERO; columns::NUM_ARITH_COLUMNS];
             divmod::generate(&mut row, &mut nv, op.row_filter(), input0, input1, result);
+            (row, Some(nv))
+        }
+        BinaryOperator::Shr => {
+            let mut nv = vec![F::ZERO; columns::NUM_ARITH_COLUMNS];
+            shift::generate(&mut row, &mut nv, false, input0, input1, result);
             (row, Some(nv))
         }
         BinaryOperator::AddFp254 | BinaryOperator::MulFp254 | BinaryOperator::SubFp254 => {

--- a/evm/src/arithmetic/mul.rs
+++ b/evm/src/arithmetic/mul.rs
@@ -121,7 +121,7 @@ pub fn eval_packed_generic<P: PackedField>(
 ) {
     let base = P::Scalar::from_canonical_u64(1 << LIMB_BITS);
 
-    let is_mul = lv[IS_MUL] + lv[IS_SHL];
+    let is_mul = lv[IS_MUL];
     let input0_limbs = read_value::<N_LIMBS, _>(lv, INPUT_REGISTER_0);
     let input1_limbs = read_value::<N_LIMBS, _>(lv, INPUT_REGISTER_1);
     let output_limbs = read_value::<N_LIMBS, _>(lv, OUTPUT_REGISTER);
@@ -173,7 +173,7 @@ pub fn eval_ext_circuit<F: RichField + Extendable<D>, const D: usize>(
     lv: &[ExtensionTarget<D>; NUM_ARITH_COLUMNS],
     yield_constr: &mut RecursiveConstraintConsumer<F, D>,
 ) {
-    let is_mul = builder.add_extension(lv[IS_MUL], lv[IS_SHL]);
+    let is_mul = lv[IS_MUL];
     let input0_limbs = read_value::<N_LIMBS, _>(lv, INPUT_REGISTER_0);
     let input1_limbs = read_value::<N_LIMBS, _>(lv, INPUT_REGISTER_1);
     let output_limbs = read_value::<N_LIMBS, _>(lv, OUTPUT_REGISTER);
@@ -229,8 +229,6 @@ mod tests {
         // if `IS_MUL == 0`, then the constraints should be met even
         // if all values are garbage.
         lv[IS_MUL] = F::ZERO;
-        // Deactivate the SHL flag so that a MUL operation is not triggered.
-        lv[IS_SHL] = F::ZERO;
 
         let mut constraint_consumer = ConstraintConsumer::new(
             vec![GoldilocksField(2), GoldilocksField(3), GoldilocksField(5)],

--- a/evm/src/arithmetic/mul.rs
+++ b/evm/src/arithmetic/mul.rs
@@ -68,7 +68,7 @@ use crate::arithmetic::utils::*;
 use crate::constraint_consumer::{ConstraintConsumer, RecursiveConstraintConsumer};
 
 /// Given the two limbs of `left_in` and `right_in`, computes `left_in * right_in`.
-pub fn generate_mul<F: PrimeField64>(lv: &mut [F], left_in: [i64; 16], right_in: [i64; 16]) {
+pub(crate) fn generate_mul<F: PrimeField64>(lv: &mut [F], left_in: [i64; 16], right_in: [i64; 16]) {
     const MASK: i64 = (1i64 << LIMB_BITS) - 1i64;
 
     // Input and output have 16-bit limbs
@@ -120,7 +120,7 @@ pub fn generate<F: PrimeField64>(lv: &mut [F], left_in: U256, right_in: U256) {
     generate_mul(lv, input0, input1);
 }
 
-pub fn eval_packed_generic_mul<P: PackedField>(
+pub(crate) fn eval_packed_generic_mul<P: PackedField>(
     lv: &[P; NUM_ARITH_COLUMNS],
     filter: P,
     left_in_limbs: [P; 16],
@@ -184,7 +184,7 @@ pub fn eval_packed_generic<P: PackedField>(
     eval_packed_generic_mul(lv, is_mul, input0_limbs, input1_limbs, yield_constr);
 }
 
-pub fn eval_ext_mul_circuit<F: RichField + Extendable<D>, const D: usize>(
+pub(crate) fn eval_ext_mul_circuit<F: RichField + Extendable<D>, const D: usize>(
     builder: &mut CircuitBuilder<F, D>,
     lv: &[ExtensionTarget<D>; NUM_ARITH_COLUMNS],
     filter: ExtensionTarget<D>,

--- a/evm/src/arithmetic/mul.rs
+++ b/evm/src/arithmetic/mul.rs
@@ -67,16 +67,8 @@ use crate::arithmetic::columns::*;
 use crate::arithmetic::utils::*;
 use crate::constraint_consumer::{ConstraintConsumer, RecursiveConstraintConsumer};
 
-pub fn generate<F: PrimeField64>(lv: &mut [F], left_in: U256, right_in: U256) {
-    // TODO: It would probably be clearer/cleaner to read the U256
-    // into an [i64;N] and then copy that to the lv table.
-    u256_to_array(&mut lv[INPUT_REGISTER_0], left_in);
-    u256_to_array(&mut lv[INPUT_REGISTER_1], right_in);
-    u256_to_array(&mut lv[INPUT_REGISTER_2], U256::zero());
-
-    let input0 = read_value_i64_limbs(lv, INPUT_REGISTER_0);
-    let input1 = read_value_i64_limbs(lv, INPUT_REGISTER_1);
-
+/// Given the two limbs of `left_in` and `right_in`, computes `left_in * right_in`.
+pub fn generate_mul<F: PrimeField64>(lv: &mut [F], left_in: [i64; 16], right_in: [i64; 16]) {
     const MASK: i64 = (1i64 << LIMB_BITS) - 1i64;
 
     // Input and output have 16-bit limbs
@@ -86,7 +78,7 @@ pub fn generate<F: PrimeField64>(lv: &mut [F], left_in: U256, right_in: U256) {
     // First calculate the coefficients of a(x)*b(x) (in unreduced_prod),
     // then do carry propagation to obtain C = c(β) = a(β)*b(β).
     let mut cy = 0i64;
-    let mut unreduced_prod = pol_mul_lo(input0, input1);
+    let mut unreduced_prod = pol_mul_lo(left_in, right_in);
     for col in 0..N_LIMBS {
         let t = unreduced_prod[col] + cy;
         cy = t >> LIMB_BITS;
@@ -115,16 +107,29 @@ pub fn generate<F: PrimeField64>(lv: &mut [F], left_in: U256, right_in: U256) {
         .copy_from_slice(&aux_limbs.map(|c| F::from_canonical_u16((c >> 16) as u16)));
 }
 
-pub fn eval_packed_generic<P: PackedField>(
+pub fn generate<F: PrimeField64>(lv: &mut [F], left_in: U256, right_in: U256) {
+    // TODO: It would probably be clearer/cleaner to read the U256
+    // into an [i64;N] and then copy that to the lv table.
+    u256_to_array(&mut lv[INPUT_REGISTER_0], left_in);
+    u256_to_array(&mut lv[INPUT_REGISTER_1], right_in);
+    u256_to_array(&mut lv[INPUT_REGISTER_2], U256::zero());
+
+    let input0 = read_value_i64_limbs(lv, INPUT_REGISTER_0);
+    let input1 = read_value_i64_limbs(lv, INPUT_REGISTER_1);
+
+    generate_mul(lv, input0, input1);
+}
+
+pub fn eval_packed_generic_mul<P: PackedField>(
     lv: &[P; NUM_ARITH_COLUMNS],
+    filter: P,
+    left_in_limbs: [P; 16],
+    right_in_limbs: [P; 16],
     yield_constr: &mut ConstraintConsumer<P>,
 ) {
-    let base = P::Scalar::from_canonical_u64(1 << LIMB_BITS);
-
-    let is_mul = lv[IS_MUL];
-    let input0_limbs = read_value::<N_LIMBS, _>(lv, INPUT_REGISTER_0);
-    let input1_limbs = read_value::<N_LIMBS, _>(lv, INPUT_REGISTER_1);
     let output_limbs = read_value::<N_LIMBS, _>(lv, OUTPUT_REGISTER);
+
+    let base = P::Scalar::from_canonical_u64(1 << LIMB_BITS);
 
     let aux_limbs = {
         // MUL_AUX_INPUT was offset by 2^20 in generation, so we undo
@@ -153,7 +158,7 @@ pub fn eval_packed_generic<P: PackedField>(
     //
     //   s(x) = \sum_i aux_limbs[i] * x^i
     //
-    let mut constr_poly = pol_mul_lo(input0_limbs, input1_limbs);
+    let mut constr_poly = pol_mul_lo(left_in_limbs, right_in_limbs);
     pol_sub_assign(&mut constr_poly, &output_limbs);
 
     // This subtracts (x - β) * s(x) from constr_poly.
@@ -164,18 +169,29 @@ pub fn eval_packed_generic<P: PackedField>(
     // multiplication is valid if and only if all of those
     // coefficients are zero.
     for &c in &constr_poly {
-        yield_constr.constraint(is_mul * c);
+        yield_constr.constraint(filter * c);
     }
 }
 
-pub fn eval_ext_circuit<F: RichField + Extendable<D>, const D: usize>(
-    builder: &mut CircuitBuilder<F, D>,
-    lv: &[ExtensionTarget<D>; NUM_ARITH_COLUMNS],
-    yield_constr: &mut RecursiveConstraintConsumer<F, D>,
+pub fn eval_packed_generic<P: PackedField>(
+    lv: &[P; NUM_ARITH_COLUMNS],
+    yield_constr: &mut ConstraintConsumer<P>,
 ) {
     let is_mul = lv[IS_MUL];
     let input0_limbs = read_value::<N_LIMBS, _>(lv, INPUT_REGISTER_0);
     let input1_limbs = read_value::<N_LIMBS, _>(lv, INPUT_REGISTER_1);
+
+    eval_packed_generic_mul(lv, is_mul, input0_limbs, input1_limbs, yield_constr);
+}
+
+pub fn eval_ext_mul_circuit<F: RichField + Extendable<D>, const D: usize>(
+    builder: &mut CircuitBuilder<F, D>,
+    lv: &[ExtensionTarget<D>; NUM_ARITH_COLUMNS],
+    filter: ExtensionTarget<D>,
+    left_in_limbs: [ExtensionTarget<D>; 16],
+    right_in_limbs: [ExtensionTarget<D>; 16],
+    yield_constr: &mut RecursiveConstraintConsumer<F, D>,
+) {
     let output_limbs = read_value::<N_LIMBS, _>(lv, OUTPUT_REGISTER);
 
     let aux_limbs = {
@@ -192,7 +208,7 @@ pub fn eval_ext_circuit<F: RichField + Extendable<D>, const D: usize>(
         aux_limbs
     };
 
-    let mut constr_poly = pol_mul_lo_ext_circuit(builder, input0_limbs, input1_limbs);
+    let mut constr_poly = pol_mul_lo_ext_circuit(builder, left_in_limbs, right_in_limbs);
     pol_sub_assign_ext_circuit(builder, &mut constr_poly, &output_limbs);
 
     let base = builder.constant_extension(F::Extension::from_canonical_u64(1 << LIMB_BITS));
@@ -200,9 +216,28 @@ pub fn eval_ext_circuit<F: RichField + Extendable<D>, const D: usize>(
     pol_sub_assign_ext_circuit(builder, &mut constr_poly, &rhs);
 
     for &c in &constr_poly {
-        let filter = builder.mul_extension(is_mul, c);
+        let filter = builder.mul_extension(filter, c);
         yield_constr.constraint(builder, filter);
     }
+}
+
+pub fn eval_ext_circuit<F: RichField + Extendable<D>, const D: usize>(
+    builder: &mut CircuitBuilder<F, D>,
+    lv: &[ExtensionTarget<D>; NUM_ARITH_COLUMNS],
+    yield_constr: &mut RecursiveConstraintConsumer<F, D>,
+) {
+    let is_mul = lv[IS_MUL];
+    let input0_limbs = read_value::<N_LIMBS, _>(lv, INPUT_REGISTER_0);
+    let input1_limbs = read_value::<N_LIMBS, _>(lv, INPUT_REGISTER_1);
+
+    eval_ext_mul_circuit(
+        builder,
+        lv,
+        is_mul,
+        input0_limbs,
+        input1_limbs,
+        yield_constr,
+    );
 }
 
 #[cfg(test)]

--- a/evm/src/arithmetic/shift.rs
+++ b/evm/src/arithmetic/shift.rs
@@ -23,28 +23,30 @@
 use ethereum_types::U256;
 use plonky2::field::extension::Extendable;
 use plonky2::field::packed::PackedField;
-use plonky2::field::types::{Field, PrimeField64};
+use plonky2::field::types::PrimeField64;
 use plonky2::hash::hash_types::RichField;
 use plonky2::iop::ext_target::ExtensionTarget;
 use plonky2::plonk::circuit_builder::CircuitBuilder;
 
-use super::modular::modular_constr_poly_ext_circuit;
-use crate::arithmetic::columns::{self, *};
-use crate::arithmetic::modular::{generate_modular_op, modular_constr_poly};
+use super::{divmod, mul};
+use crate::arithmetic::columns::*;
 use crate::arithmetic::utils::*;
 use crate::constraint_consumer::{ConstraintConsumer, RecursiveConstraintConsumer};
 
 /// Generates a shift operation (either SHL or SHR).
 /// The inputs are stored in the form `(shift, input, 1 << shift)`.
-/// NB: if `shift > 2^32`, then the third register holds 0.
+/// NB: if `shift >= 256`, then the third register holds 0.
+/// We leverage the functions in mul.rs and divmod.rs to carry out
+/// the computation.
 pub fn generate<F: PrimeField64>(
     lv: &mut [F],
     nv: &mut [F],
     is_shl: bool,
-    input: U256,
     shift: U256,
+    input: U256,
     result: U256,
 ) {
+    // We use the multiplication logic to generate SHL
     // TODO: It would probably be clearer/cleaner to read the U256
     // into an [i64;N] and then copy that to the lv table.
     // The first input is the shift we need to apply.
@@ -52,7 +54,7 @@ pub fn generate<F: PrimeField64>(
     // The second register holds the input which needs shifting.
     u256_to_array(&mut lv[INPUT_REGISTER_1], input);
     u256_to_array(&mut lv[OUTPUT_REGISTER], result);
-    // If `shift > 2^32`, the shifted displacement is set to 0.
+    // If `shift >= 256`, the shifted displacement is set to 0.
     // Compute 1 << shift and store it in the third input register.
     let shifted_displacement = if shift > U256::from(255u64) {
         U256::zero()
@@ -66,123 +68,32 @@ pub fn generate<F: PrimeField64>(
     let input1 = read_value_i64_limbs(lv, INPUT_REGISTER_2); // 1 << shift
 
     if is_shl {
-        // If the operation is SHL, we compute `input * shifted_displacement`.
-        const MASK: i64 = (1i64 << LIMB_BITS) - 1i64;
-
-        // Input and output have 16-bit limbs
-        let mut output_limbs = [0i64; N_LIMBS];
-
-        // Column-wise pen-and-paper long multiplication on 16-bit limbs.
-        // First calculate the coefficients of a(x)*b(x) (in unreduced_prod),
-        // then do carry propagation to obtain C = c(β) = a(β)*b(β).
-        let mut cy = 0i64;
-        let mut unreduced_prod = pol_mul_lo(input0, input1);
-        for col in 0..N_LIMBS {
-            let t = unreduced_prod[col] + cy;
-            cy = t >> LIMB_BITS;
-            output_limbs[col] = t & MASK;
-        }
-        // In principle, the last cy could be dropped because this is
-        // multiplication modulo 2^256. However, we need it below for
-        // aux_limbs to handle the fact that unreduced_prod will
-        // inevitably contain one digit's worth that is > 2^256.
-
-        pol_sub_assign(&mut unreduced_prod, &output_limbs);
-
-        let mut aux_limbs = pol_remove_root_2exp::<LIMB_BITS, _, N_LIMBS>(unreduced_prod);
-        aux_limbs[N_LIMBS - 1] = -cy;
-
-        for c in aux_limbs.iter_mut() {
-            // we store the unsigned offset value c + 2^20
-            *c += AUX_COEFF_ABS_MAX;
-        }
-
-        debug_assert!(aux_limbs.iter().all(|&c| c.abs() <= 2 * AUX_COEFF_ABS_MAX));
-
-        lv[MUL_AUX_INPUT_LO].copy_from_slice(&aux_limbs.map(|c| F::from_canonical_u16(c as u16)));
-        lv[MUL_AUX_INPUT_HI]
-            .copy_from_slice(&aux_limbs.map(|c| F::from_canonical_u16((c >> 16) as u16)));
+        // We generate the multiplication input0 * input1 using mul.rs.
+        mul::generate_mul(lv, input0, input1);
     } else {
         // If the operation is SHR, we compute: `input / shifted_displacement` if `shifted_displacement == 0`
-        // otherwise, the output is 0.
-        let input_limbs = read_value_i64_limbs::<N_LIMBS, _>(lv, INPUT_REGISTER_1);
-        let pol_input = pol_extend(input_limbs);
-        let (out, quo_input) =
-            generate_modular_op(lv, nv, columns::IS_SHL, pol_input, INPUT_REGISTER_2);
-        debug_assert!(
-            &quo_input[N_LIMBS..].iter().all(|&x| x == F::ZERO),
-            "expected top half of quo_input to be zero"
-        );
-
-        // Initialise whole (double) register to zero; the low half will
-        // be overwritten via lv[AUX_INPUT_REGISTER] below.
-        for i in MODULAR_QUO_INPUT {
-            lv[i] = F::ZERO;
-        }
-
-        lv[AUX_INPUT_REGISTER_0].copy_from_slice(&out);
+        // otherwise, the output is 0. We use the logic in divmod.rs to achieve that.
+        divmod::generate_divmod(lv, nv, IS_SHR, INPUT_REGISTER_1, INPUT_REGISTER_2);
     }
 }
 
 /// Evaluates the constraints for an SHL opcode.
-/// The logic is very similar to the one for MUL. The only difference is that
+/// The logic is the same as the one for MUL. The only difference is that
 /// the inputs are in `INPUT_REGISTER_1`  and `INPUT_REGISTER_2` instead of
 /// `INPUT_REGISTER_0` and `INPUT_REGISTER_1`.
 pub fn eval_packed_shl<P: PackedField>(
     lv: &[P; NUM_ARITH_COLUMNS],
     yield_constr: &mut ConstraintConsumer<P>,
 ) {
-    let base = P::Scalar::from_canonical_u64(1 << LIMB_BITS);
-
     let is_shl = lv[IS_SHL];
     let input0_limbs = read_value::<N_LIMBS, _>(lv, INPUT_REGISTER_1);
     let shifted_limbs = read_value::<N_LIMBS, _>(lv, INPUT_REGISTER_2);
-    let output_limbs = read_value::<N_LIMBS, _>(lv, OUTPUT_REGISTER);
 
-    let aux_limbs = {
-        // MUL_AUX_INPUT was offset by 2^20 in generation, so we undo
-        // that here
-        let offset = P::Scalar::from_canonical_u64(AUX_COEFF_ABS_MAX as u64);
-        let mut aux_limbs = read_value::<N_LIMBS, _>(lv, MUL_AUX_INPUT_LO);
-        let aux_limbs_hi = &lv[MUL_AUX_INPUT_HI];
-        for (lo, &hi) in aux_limbs.iter_mut().zip(aux_limbs_hi) {
-            *lo += hi * base - offset;
-        }
-        aux_limbs
-    };
-
-    // Constraint poly holds the coefficients of the polynomial that
-    // must be identically zero for this multiplication to be
-    // verified.
-    //
-    // These two lines set constr_poly to the polynomial a(x)b(x) - c(x),
-    // where a, b and c are the polynomials
-    //
-    //   a(x) = \sum_i input0_limbs[i] * x^i
-    //   b(x) = \sum_i input1_limbs[i] * x^i
-    //   c(x) = \sum_i output_limbs[i] * x^i
-    //
-    // This polynomial should equal (x - β)*s(x) where s is
-    //
-    //   s(x) = \sum_i aux_limbs[i] * x^i
-    //
-    let mut constr_poly = pol_mul_lo(input0_limbs, shifted_limbs);
-    pol_sub_assign(&mut constr_poly, &output_limbs);
-
-    // This subtracts (x - β) * s(x) from constr_poly.
-    pol_sub_assign(&mut constr_poly, &pol_adjoin_root(aux_limbs, base));
-
-    // At this point constr_poly holds the coefficients of the
-    // polynomial a(x)b(x) - c(x) - (x - β)*s(x). The
-    // multiplication is valid if and only if all of those
-    // coefficients are zero.
-    for &c in &constr_poly {
-        yield_constr.constraint(is_shl * c);
-    }
+    mul::eval_packed_generic_mul(lv, is_shl, input0_limbs, shifted_limbs, yield_constr);
 }
 
 /// Evaluates the constraints for an SHR opcode.
-/// The logic is very similar to the one for DIV. The only difference is that
+/// The logic is tha same as the one for DIV. The only difference is that
 /// the inputs are in `INPUT_REGISTER_1`  and `INPUT_REGISTER_2` instead of
 /// `INPUT_REGISTER_0` and `INPUT_REGISTER_1`.
 fn eval_packed_shr<P: PackedField>(
@@ -193,28 +104,17 @@ fn eval_packed_shr<P: PackedField>(
     let quo_range = OUTPUT_REGISTER;
     let rem_range = AUX_INPUT_REGISTER_0;
     let filter = lv[IS_SHR];
-    debug_assert!(quo_range.len() == N_LIMBS);
-    debug_assert!(rem_range.len() == N_LIMBS);
 
-    yield_constr.constraint_last_row(filter);
-
-    let num = &lv[INPUT_REGISTER_1];
-    let den = read_value(lv, INPUT_REGISTER_2);
-    let quo = {
-        let mut quo = [P::ZEROS; 2 * N_LIMBS];
-        quo[..N_LIMBS].copy_from_slice(&lv[quo_range]);
-        quo
-    };
-    let rem = read_value(lv, rem_range);
-
-    let mut constr_poly = modular_constr_poly(lv, nv, yield_constr, filter, rem, den, quo);
-
-    let input = num;
-    pol_sub_assign(&mut constr_poly, input);
-
-    for &c in constr_poly.iter() {
-        yield_constr.constraint_transition(filter * c);
-    }
+    divmod::eval_packed_divmod_helper(
+        lv,
+        nv,
+        yield_constr,
+        filter,
+        INPUT_REGISTER_1,
+        INPUT_REGISTER_2,
+        quo_range,
+        rem_range,
+    );
 }
 
 pub fn eval_packed_generic<P: PackedField>(
@@ -235,33 +135,14 @@ pub fn eval_ext_circuit_shl<F: RichField + Extendable<D>, const D: usize>(
     let input0_limbs = read_value::<N_LIMBS, _>(lv, INPUT_REGISTER_1);
     let shifted_limbs = read_value::<N_LIMBS, _>(lv, INPUT_REGISTER_2);
 
-    let output_limbs = read_value::<N_LIMBS, _>(lv, OUTPUT_REGISTER);
-
-    let aux_limbs = {
-        let base = builder.constant_extension(F::Extension::from_canonical_u64(1 << LIMB_BITS));
-        let offset =
-            builder.constant_extension(F::Extension::from_canonical_u64(AUX_COEFF_ABS_MAX as u64));
-        let mut aux_limbs = read_value::<N_LIMBS, _>(lv, MUL_AUX_INPUT_LO);
-        let aux_limbs_hi = &lv[MUL_AUX_INPUT_HI];
-        for (lo, &hi) in aux_limbs.iter_mut().zip(aux_limbs_hi) {
-            //*lo = lo + hi * base - offset;
-            let t = builder.mul_sub_extension(hi, base, offset);
-            *lo = builder.add_extension(*lo, t);
-        }
-        aux_limbs
-    };
-
-    let mut constr_poly = pol_mul_lo_ext_circuit(builder, input0_limbs, shifted_limbs);
-    pol_sub_assign_ext_circuit(builder, &mut constr_poly, &output_limbs);
-
-    let base = builder.constant_extension(F::Extension::from_canonical_u64(1 << LIMB_BITS));
-    let rhs = pol_adjoin_root_ext_circuit(builder, aux_limbs, base);
-    pol_sub_assign_ext_circuit(builder, &mut constr_poly, &rhs);
-
-    for &c in &constr_poly {
-        let filter = builder.mul_extension(is_shl, c);
-        yield_constr.constraint(builder, filter);
-    }
+    mul::eval_ext_mul_circuit(
+        builder,
+        lv,
+        is_shl,
+        input0_limbs,
+        shifted_limbs,
+        yield_constr,
+    );
 }
 
 pub fn eval_ext_circuit_shr<F: RichField + Extendable<D>, const D: usize>(
@@ -271,30 +152,20 @@ pub fn eval_ext_circuit_shr<F: RichField + Extendable<D>, const D: usize>(
     yield_constr: &mut RecursiveConstraintConsumer<F, D>,
 ) {
     let filter = lv[IS_SHR];
-    yield_constr.constraint_last_row(builder, filter);
-
     let quo_range = OUTPUT_REGISTER;
     let rem_range = AUX_INPUT_REGISTER_0;
-    let num = &lv[INPUT_REGISTER_1];
-    let den = read_value(lv, INPUT_REGISTER_2);
-    let quo = {
-        let zero = builder.zero_extension();
-        let mut quo = [zero; 2 * N_LIMBS];
-        quo[..N_LIMBS].copy_from_slice(&lv[quo_range]);
-        quo
-    };
-    let rem = read_value(lv, rem_range);
 
-    let mut constr_poly =
-        modular_constr_poly_ext_circuit(lv, nv, builder, yield_constr, filter, rem, den, quo);
-
-    let input = num;
-    pol_sub_assign_ext_circuit(builder, &mut constr_poly, input);
-
-    for &c in constr_poly.iter() {
-        let t = builder.mul_extension(filter, c);
-        yield_constr.constraint_transition(builder, t);
-    }
+    divmod::eval_ext_circuit_divmod_helper(
+        builder,
+        lv,
+        nv,
+        yield_constr,
+        filter,
+        INPUT_REGISTER_1,
+        INPUT_REGISTER_2,
+        quo_range,
+        rem_range,
+    );
 }
 
 pub fn eval_ext_circuit<F: RichField + Extendable<D>, const D: usize>(
@@ -322,14 +193,14 @@ mod tests {
 
     // TODO: Should be able to refactor this test to apply to all operations.
     #[test]
-    fn generate_eval_consistency_not_shl() {
+    fn generate_eval_consistency_not_shift() {
         type F = GoldilocksField;
 
         let mut rng = ChaCha8Rng::seed_from_u64(0x6feb51b7ec230f25);
         let mut lv = [F::default(); NUM_ARITH_COLUMNS].map(|_| F::sample(&mut rng));
         let nv = [F::default(); NUM_ARITH_COLUMNS].map(|_| F::sample(&mut rng));
 
-        // if `IS_SHL == 0` and ÌS_SHR == 0`, then the constraints should be met even
+        // if `IS_SHL == 0` and `IS_SHR == 0`, then the constraints should be met even
         // if all values are garbage.
         lv[IS_SHL] = F::ZERO;
         lv[IS_SHR] = F::ZERO;
@@ -346,27 +217,25 @@ mod tests {
         }
     }
 
-    #[test]
-    fn generate_eval_consistency_shl() {
+    fn generate_eval_consistency_shift(is_shl: bool) {
         type F = GoldilocksField;
 
         let mut rng = ChaCha8Rng::seed_from_u64(0x6feb51b7ec230f25);
         let mut lv = [F::default(); NUM_ARITH_COLUMNS].map(|_| F::sample(&mut rng));
         let mut nv = [F::default(); NUM_ARITH_COLUMNS].map(|_| F::sample(&mut rng));
 
-        // set `IS_MUL == 1` and ensure all constraints are satisfied.
-        lv[IS_SHL] = F::ONE;
-        lv[IS_SHR] = F::ZERO;
+        // set `IS_SHL == 1` or `IS_SHR == 1` and ensure all constraints are satisfied.
+        if is_shl {
+            lv[IS_SHL] = F::ONE;
+            lv[IS_SHR] = F::ZERO;
+        } else {
+            lv[IS_SHL] = F::ZERO;
+            lv[IS_SHR] = F::ONE;
+        }
 
         for _i in 0..N_RND_TESTS {
-            let shift = U256::from(rng.gen::<usize>());
-            let shifted = if shift > U256::from(255) {
-                U256::zero()
-            } else {
-                U256::one() << shift
-            };
-            u256_to_array(&mut lv[INPUT_REGISTER_0], shift);
-            u256_to_array(&mut lv[INPUT_REGISTER_2], shifted);
+            let shift = U256::from(rng.gen::<u8>());
+
             let mut full_input = U256::from(0);
             // set inputs to random values
             for ai in INPUT_REGISTER_1 {
@@ -375,20 +244,34 @@ mod tests {
                     U256::from(lv[ai].to_canonical_u64()) + full_input * U256::from(1 << 16);
             }
 
-            let output = full_input * shifted;
+            let output = if is_shl {
+                full_input << shift
+            } else {
+                full_input >> shift
+            };
 
-            generate(&mut lv, &mut nv, true, full_input, shift, output);
+            generate(&mut lv, &mut nv, is_shl, shift, full_input, output);
 
             let mut constraint_consumer = ConstraintConsumer::new(
                 vec![GoldilocksField(2), GoldilocksField(3), GoldilocksField(5)],
                 GoldilocksField::ONE,
                 GoldilocksField::ONE,
-                GoldilocksField::ONE,
+                GoldilocksField::ZERO,
             );
             eval_packed_generic(&lv, &nv, &mut constraint_consumer);
             for &acc in &constraint_consumer.constraint_accs {
                 assert_eq!(acc, GoldilocksField::ZERO);
             }
         }
+    }
+
+    #[test]
+    fn generate_eval_consistency_shl() {
+        generate_eval_consistency_shift(true);
+    }
+
+    #[test]
+    fn generate_eval_consistency_shr() {
+        generate_eval_consistency_shift(false);
     }
 }

--- a/evm/src/arithmetic/shift.rs
+++ b/evm/src/arithmetic/shift.rs
@@ -1,0 +1,394 @@
+//! Support for the EVM SHL and SHR instructions.
+//!
+//! This crate verifies an EVM shift instruction, which takes two
+//! 256-bit inputs S and A, and produces a 256-bit output C satisfying
+//!
+//!    C = A << S (mod 2^256) for SHL or
+//!    C = A >> S (mod 2^256) for SHR.
+//!
+//! The way this computation is carried is by providing a third input
+//!    B = 1 << S (mod 2^256)
+//! and then computing:
+//!    C = A * B (mod 2^256) for SHL or
+//!    C = A / B (mod 2^256) for SHR
+//!
+//! Inputs A, S, and B, and output C, are given as arrays of 16-bit
+//! limbs. For example, if the limbs of A are a[0]...a[15], then
+//!
+//!    A = \sum_{i=0}^15 a[i] β^i,
+//!
+//! where β = 2^16 = 2^LIMB_BITS. To verify that A, S, B and C satisfy
+//! the equations, we proceed similarly to MUL for SHL and to DIV for SHR.
+
+use ethereum_types::U256;
+use plonky2::field::extension::Extendable;
+use plonky2::field::packed::PackedField;
+use plonky2::field::types::{Field, PrimeField64};
+use plonky2::hash::hash_types::RichField;
+use plonky2::iop::ext_target::ExtensionTarget;
+use plonky2::plonk::circuit_builder::CircuitBuilder;
+
+use super::modular::modular_constr_poly_ext_circuit;
+use crate::arithmetic::columns::{self, *};
+use crate::arithmetic::modular::{generate_modular_op, modular_constr_poly};
+use crate::arithmetic::utils::*;
+use crate::constraint_consumer::{ConstraintConsumer, RecursiveConstraintConsumer};
+
+/// Generates a shift operation (either SHL or SHR).
+/// The inputs are stored in the form `(shift, input, 1 << shift)`.
+/// NB: if `shift > 2^32`, then the third register holds 0.
+pub fn generate<F: PrimeField64>(
+    lv: &mut [F],
+    nv: &mut [F],
+    is_shl: bool,
+    input: U256,
+    shift: U256,
+    result: U256,
+) {
+    // TODO: It would probably be clearer/cleaner to read the U256
+    // into an [i64;N] and then copy that to the lv table.
+    // The first input is the shift we need to apply.
+    u256_to_array(&mut lv[INPUT_REGISTER_0], shift);
+    // The second register holds the input which needs shifting.
+    u256_to_array(&mut lv[INPUT_REGISTER_1], input);
+    u256_to_array(&mut lv[OUTPUT_REGISTER], result);
+    // If `shift > 2^32`, the shifted displacement is set to 0.
+    // Compute 1 << shift and store it in the third input register.
+    let shifted_displacement = if shift > U256::from(255u64) {
+        U256::zero()
+    } else {
+        U256::one() << shift
+    };
+
+    u256_to_array(&mut lv[INPUT_REGISTER_2], shifted_displacement);
+
+    let input0 = read_value_i64_limbs(lv, INPUT_REGISTER_1); // input
+    let input1 = read_value_i64_limbs(lv, INPUT_REGISTER_2); // 1 << shift
+
+    if is_shl {
+        // If the operation is SHL, we compute `input * shifted_displacement`.
+        const MASK: i64 = (1i64 << LIMB_BITS) - 1i64;
+
+        // Input and output have 16-bit limbs
+        let mut output_limbs = [0i64; N_LIMBS];
+
+        // Column-wise pen-and-paper long multiplication on 16-bit limbs.
+        // First calculate the coefficients of a(x)*b(x) (in unreduced_prod),
+        // then do carry propagation to obtain C = c(β) = a(β)*b(β).
+        let mut cy = 0i64;
+        let mut unreduced_prod = pol_mul_lo(input0, input1);
+        for col in 0..N_LIMBS {
+            let t = unreduced_prod[col] + cy;
+            cy = t >> LIMB_BITS;
+            output_limbs[col] = t & MASK;
+        }
+        // In principle, the last cy could be dropped because this is
+        // multiplication modulo 2^256. However, we need it below for
+        // aux_limbs to handle the fact that unreduced_prod will
+        // inevitably contain one digit's worth that is > 2^256.
+
+        pol_sub_assign(&mut unreduced_prod, &output_limbs);
+
+        let mut aux_limbs = pol_remove_root_2exp::<LIMB_BITS, _, N_LIMBS>(unreduced_prod);
+        aux_limbs[N_LIMBS - 1] = -cy;
+
+        for c in aux_limbs.iter_mut() {
+            // we store the unsigned offset value c + 2^20
+            *c += AUX_COEFF_ABS_MAX;
+        }
+
+        debug_assert!(aux_limbs.iter().all(|&c| c.abs() <= 2 * AUX_COEFF_ABS_MAX));
+
+        lv[MUL_AUX_INPUT_LO].copy_from_slice(&aux_limbs.map(|c| F::from_canonical_u16(c as u16)));
+        lv[MUL_AUX_INPUT_HI]
+            .copy_from_slice(&aux_limbs.map(|c| F::from_canonical_u16((c >> 16) as u16)));
+    } else {
+        // If the operation is SHR, we compute: `input / shifted_displacement` if `shifted_displacement == 0`
+        // otherwise, the output is 0.
+        let input_limbs = read_value_i64_limbs::<N_LIMBS, _>(lv, INPUT_REGISTER_1);
+        let pol_input = pol_extend(input_limbs);
+        let (out, quo_input) =
+            generate_modular_op(lv, nv, columns::IS_SHL, pol_input, INPUT_REGISTER_2);
+        debug_assert!(
+            &quo_input[N_LIMBS..].iter().all(|&x| x == F::ZERO),
+            "expected top half of quo_input to be zero"
+        );
+
+        // Initialise whole (double) register to zero; the low half will
+        // be overwritten via lv[AUX_INPUT_REGISTER] below.
+        for i in MODULAR_QUO_INPUT {
+            lv[i] = F::ZERO;
+        }
+
+        lv[AUX_INPUT_REGISTER_0].copy_from_slice(&out);
+    }
+}
+
+/// Evaluates the constraints for an SHL opcode.
+/// The logic is very similar to the one for MUL. The only difference is that
+/// the inputs are in `INPUT_REGISTER_1`  and `INPUT_REGISTER_2` instead of
+/// `INPUT_REGISTER_0` and `INPUT_REGISTER_1`.
+pub fn eval_packed_shl<P: PackedField>(
+    lv: &[P; NUM_ARITH_COLUMNS],
+    yield_constr: &mut ConstraintConsumer<P>,
+) {
+    let base = P::Scalar::from_canonical_u64(1 << LIMB_BITS);
+
+    let is_shl = lv[IS_SHL];
+    let input0_limbs = read_value::<N_LIMBS, _>(lv, INPUT_REGISTER_1);
+    let shifted_limbs = read_value::<N_LIMBS, _>(lv, INPUT_REGISTER_2);
+    let output_limbs = read_value::<N_LIMBS, _>(lv, OUTPUT_REGISTER);
+
+    let aux_limbs = {
+        // MUL_AUX_INPUT was offset by 2^20 in generation, so we undo
+        // that here
+        let offset = P::Scalar::from_canonical_u64(AUX_COEFF_ABS_MAX as u64);
+        let mut aux_limbs = read_value::<N_LIMBS, _>(lv, MUL_AUX_INPUT_LO);
+        let aux_limbs_hi = &lv[MUL_AUX_INPUT_HI];
+        for (lo, &hi) in aux_limbs.iter_mut().zip(aux_limbs_hi) {
+            *lo += hi * base - offset;
+        }
+        aux_limbs
+    };
+
+    // Constraint poly holds the coefficients of the polynomial that
+    // must be identically zero for this multiplication to be
+    // verified.
+    //
+    // These two lines set constr_poly to the polynomial a(x)b(x) - c(x),
+    // where a, b and c are the polynomials
+    //
+    //   a(x) = \sum_i input0_limbs[i] * x^i
+    //   b(x) = \sum_i input1_limbs[i] * x^i
+    //   c(x) = \sum_i output_limbs[i] * x^i
+    //
+    // This polynomial should equal (x - β)*s(x) where s is
+    //
+    //   s(x) = \sum_i aux_limbs[i] * x^i
+    //
+    let mut constr_poly = pol_mul_lo(input0_limbs, shifted_limbs);
+    pol_sub_assign(&mut constr_poly, &output_limbs);
+
+    // This subtracts (x - β) * s(x) from constr_poly.
+    pol_sub_assign(&mut constr_poly, &pol_adjoin_root(aux_limbs, base));
+
+    // At this point constr_poly holds the coefficients of the
+    // polynomial a(x)b(x) - c(x) - (x - β)*s(x). The
+    // multiplication is valid if and only if all of those
+    // coefficients are zero.
+    for &c in &constr_poly {
+        yield_constr.constraint(is_shl * c);
+    }
+}
+
+/// Evaluates the constraints for an SHR opcode.
+/// The logic is very similar to the one for DIV. The only difference is that
+/// the inputs are in `INPUT_REGISTER_1`  and `INPUT_REGISTER_2` instead of
+/// `INPUT_REGISTER_0` and `INPUT_REGISTER_1`.
+fn eval_packed_shr<P: PackedField>(
+    lv: &[P; NUM_ARITH_COLUMNS],
+    nv: &[P; NUM_ARITH_COLUMNS],
+    yield_constr: &mut ConstraintConsumer<P>,
+) {
+    let quo_range = OUTPUT_REGISTER;
+    let rem_range = AUX_INPUT_REGISTER_0;
+    let filter = lv[IS_SHR];
+    debug_assert!(quo_range.len() == N_LIMBS);
+    debug_assert!(rem_range.len() == N_LIMBS);
+
+    yield_constr.constraint_last_row(filter);
+
+    let num = &lv[INPUT_REGISTER_1];
+    let den = read_value(lv, INPUT_REGISTER_2);
+    let quo = {
+        let mut quo = [P::ZEROS; 2 * N_LIMBS];
+        quo[..N_LIMBS].copy_from_slice(&lv[quo_range]);
+        quo
+    };
+    let rem = read_value(lv, rem_range);
+
+    let mut constr_poly = modular_constr_poly(lv, nv, yield_constr, filter, rem, den, quo);
+
+    let input = num;
+    pol_sub_assign(&mut constr_poly, input);
+
+    for &c in constr_poly.iter() {
+        yield_constr.constraint_transition(filter * c);
+    }
+}
+
+pub fn eval_packed_generic<P: PackedField>(
+    lv: &[P; NUM_ARITH_COLUMNS],
+    nv: &[P; NUM_ARITH_COLUMNS],
+    yield_constr: &mut ConstraintConsumer<P>,
+) {
+    eval_packed_shl(lv, yield_constr);
+    eval_packed_shr(lv, nv, yield_constr);
+}
+
+pub fn eval_ext_circuit_shl<F: RichField + Extendable<D>, const D: usize>(
+    builder: &mut CircuitBuilder<F, D>,
+    lv: &[ExtensionTarget<D>; NUM_ARITH_COLUMNS],
+    yield_constr: &mut RecursiveConstraintConsumer<F, D>,
+) {
+    let is_shl = lv[IS_SHL];
+    let input0_limbs = read_value::<N_LIMBS, _>(lv, INPUT_REGISTER_1);
+    let shifted_limbs = read_value::<N_LIMBS, _>(lv, INPUT_REGISTER_2);
+
+    let output_limbs = read_value::<N_LIMBS, _>(lv, OUTPUT_REGISTER);
+
+    let aux_limbs = {
+        let base = builder.constant_extension(F::Extension::from_canonical_u64(1 << LIMB_BITS));
+        let offset =
+            builder.constant_extension(F::Extension::from_canonical_u64(AUX_COEFF_ABS_MAX as u64));
+        let mut aux_limbs = read_value::<N_LIMBS, _>(lv, MUL_AUX_INPUT_LO);
+        let aux_limbs_hi = &lv[MUL_AUX_INPUT_HI];
+        for (lo, &hi) in aux_limbs.iter_mut().zip(aux_limbs_hi) {
+            //*lo = lo + hi * base - offset;
+            let t = builder.mul_sub_extension(hi, base, offset);
+            *lo = builder.add_extension(*lo, t);
+        }
+        aux_limbs
+    };
+
+    let mut constr_poly = pol_mul_lo_ext_circuit(builder, input0_limbs, shifted_limbs);
+    pol_sub_assign_ext_circuit(builder, &mut constr_poly, &output_limbs);
+
+    let base = builder.constant_extension(F::Extension::from_canonical_u64(1 << LIMB_BITS));
+    let rhs = pol_adjoin_root_ext_circuit(builder, aux_limbs, base);
+    pol_sub_assign_ext_circuit(builder, &mut constr_poly, &rhs);
+
+    for &c in &constr_poly {
+        let filter = builder.mul_extension(is_shl, c);
+        yield_constr.constraint(builder, filter);
+    }
+}
+
+pub fn eval_ext_circuit_shr<F: RichField + Extendable<D>, const D: usize>(
+    builder: &mut CircuitBuilder<F, D>,
+    lv: &[ExtensionTarget<D>; NUM_ARITH_COLUMNS],
+    nv: &[ExtensionTarget<D>; NUM_ARITH_COLUMNS],
+    yield_constr: &mut RecursiveConstraintConsumer<F, D>,
+) {
+    let filter = lv[IS_SHR];
+    yield_constr.constraint_last_row(builder, filter);
+
+    let quo_range = OUTPUT_REGISTER;
+    let rem_range = AUX_INPUT_REGISTER_0;
+    let num = &lv[INPUT_REGISTER_1];
+    let den = read_value(lv, INPUT_REGISTER_2);
+    let quo = {
+        let zero = builder.zero_extension();
+        let mut quo = [zero; 2 * N_LIMBS];
+        quo[..N_LIMBS].copy_from_slice(&lv[quo_range]);
+        quo
+    };
+    let rem = read_value(lv, rem_range);
+
+    let mut constr_poly =
+        modular_constr_poly_ext_circuit(lv, nv, builder, yield_constr, filter, rem, den, quo);
+
+    let input = num;
+    pol_sub_assign_ext_circuit(builder, &mut constr_poly, input);
+
+    for &c in constr_poly.iter() {
+        let t = builder.mul_extension(filter, c);
+        yield_constr.constraint_transition(builder, t);
+    }
+}
+
+pub fn eval_ext_circuit<F: RichField + Extendable<D>, const D: usize>(
+    builder: &mut CircuitBuilder<F, D>,
+    lv: &[ExtensionTarget<D>; NUM_ARITH_COLUMNS],
+    nv: &[ExtensionTarget<D>; NUM_ARITH_COLUMNS],
+    yield_constr: &mut RecursiveConstraintConsumer<F, D>,
+) {
+    eval_ext_circuit_shl(builder, lv, yield_constr);
+    eval_ext_circuit_shr(builder, lv, nv, yield_constr);
+}
+
+#[cfg(test)]
+mod tests {
+    use plonky2::field::goldilocks_field::GoldilocksField;
+    use plonky2::field::types::{Field, Sample};
+    use rand::{Rng, SeedableRng};
+    use rand_chacha::ChaCha8Rng;
+
+    use super::*;
+    use crate::arithmetic::columns::NUM_ARITH_COLUMNS;
+    use crate::constraint_consumer::ConstraintConsumer;
+
+    const N_RND_TESTS: usize = 1000;
+
+    // TODO: Should be able to refactor this test to apply to all operations.
+    #[test]
+    fn generate_eval_consistency_not_shl() {
+        type F = GoldilocksField;
+
+        let mut rng = ChaCha8Rng::seed_from_u64(0x6feb51b7ec230f25);
+        let mut lv = [F::default(); NUM_ARITH_COLUMNS].map(|_| F::sample(&mut rng));
+        let nv = [F::default(); NUM_ARITH_COLUMNS].map(|_| F::sample(&mut rng));
+
+        // if `IS_SHL == 0` and ÌS_SHR == 0`, then the constraints should be met even
+        // if all values are garbage.
+        lv[IS_SHL] = F::ZERO;
+        lv[IS_SHR] = F::ZERO;
+
+        let mut constraint_consumer = ConstraintConsumer::new(
+            vec![GoldilocksField(2), GoldilocksField(3), GoldilocksField(5)],
+            GoldilocksField::ONE,
+            GoldilocksField::ONE,
+            GoldilocksField::ONE,
+        );
+        eval_packed_generic(&lv, &nv, &mut constraint_consumer);
+        for &acc in &constraint_consumer.constraint_accs {
+            assert_eq!(acc, GoldilocksField::ZERO);
+        }
+    }
+
+    #[test]
+    fn generate_eval_consistency_shl() {
+        type F = GoldilocksField;
+
+        let mut rng = ChaCha8Rng::seed_from_u64(0x6feb51b7ec230f25);
+        let mut lv = [F::default(); NUM_ARITH_COLUMNS].map(|_| F::sample(&mut rng));
+        let mut nv = [F::default(); NUM_ARITH_COLUMNS].map(|_| F::sample(&mut rng));
+
+        // set `IS_MUL == 1` and ensure all constraints are satisfied.
+        lv[IS_SHL] = F::ONE;
+        lv[IS_SHR] = F::ZERO;
+
+        for _i in 0..N_RND_TESTS {
+            let shift = U256::from(rng.gen::<usize>());
+            let shifted = if shift > U256::from(255) {
+                U256::zero()
+            } else {
+                U256::one() << shift
+            };
+            u256_to_array(&mut lv[INPUT_REGISTER_0], shift);
+            u256_to_array(&mut lv[INPUT_REGISTER_2], shifted);
+            let mut full_input = U256::from(0);
+            // set inputs to random values
+            for ai in INPUT_REGISTER_1 {
+                lv[ai] = F::from_canonical_u16(rng.gen());
+                full_input =
+                    U256::from(lv[ai].to_canonical_u64()) + full_input * U256::from(1 << 16);
+            }
+
+            let output = full_input * shifted;
+
+            generate(&mut lv, &mut nv, true, full_input, shift, output);
+
+            let mut constraint_consumer = ConstraintConsumer::new(
+                vec![GoldilocksField(2), GoldilocksField(3), GoldilocksField(5)],
+                GoldilocksField::ONE,
+                GoldilocksField::ONE,
+                GoldilocksField::ONE,
+            );
+            eval_packed_generic(&lv, &nv, &mut constraint_consumer);
+            for &acc in &constraint_consumer.constraint_accs {
+                assert_eq!(acc, GoldilocksField::ZERO);
+            }
+        }
+    }
+}

--- a/evm/src/arithmetic/shift.rs
+++ b/evm/src/arithmetic/shift.rs
@@ -81,7 +81,7 @@ pub fn generate<F: PrimeField64>(
 /// The logic is the same as the one for MUL. The only difference is that
 /// the inputs are in `INPUT_REGISTER_1`  and `INPUT_REGISTER_2` instead of
 /// `INPUT_REGISTER_0` and `INPUT_REGISTER_1`.
-pub fn eval_packed_shl<P: PackedField>(
+fn eval_packed_shl<P: PackedField>(
     lv: &[P; NUM_ARITH_COLUMNS],
     yield_constr: &mut ConstraintConsumer<P>,
 ) {
@@ -126,7 +126,7 @@ pub fn eval_packed_generic<P: PackedField>(
     eval_packed_shr(lv, nv, yield_constr);
 }
 
-pub fn eval_ext_circuit_shl<F: RichField + Extendable<D>, const D: usize>(
+fn eval_ext_circuit_shl<F: RichField + Extendable<D>, const D: usize>(
     builder: &mut CircuitBuilder<F, D>,
     lv: &[ExtensionTarget<D>; NUM_ARITH_COLUMNS],
     yield_constr: &mut RecursiveConstraintConsumer<F, D>,
@@ -145,7 +145,7 @@ pub fn eval_ext_circuit_shl<F: RichField + Extendable<D>, const D: usize>(
     );
 }
 
-pub fn eval_ext_circuit_shr<F: RichField + Extendable<D>, const D: usize>(
+fn eval_ext_circuit_shr<F: RichField + Extendable<D>, const D: usize>(
     builder: &mut CircuitBuilder<F, D>,
     lv: &[ExtensionTarget<D>; NUM_ARITH_COLUMNS],
     nv: &[ExtensionTarget<D>; NUM_ARITH_COLUMNS],

--- a/evm/src/witness/operation.rs
+++ b/evm/src/witness/operation.rs
@@ -499,12 +499,6 @@ fn append_shift<F: Field>(
         channel.addr_virtual = F::from_canonical_usize(lookup_addr.virt);
     }
 
-    // Convert the shift, and log the corresponding arithmetic operation.
-    let input0 = if input0 > U256::from(255u64) {
-        U256::zero()
-    } else {
-        U256::one() << input0
-    };
     let operator = if is_shl {
         BinaryOperator::Shl
     } else {

--- a/evm/src/witness/operation.rs
+++ b/evm/src/witness/operation.rs
@@ -504,7 +504,7 @@ fn append_shift<F: Field>(
     } else {
         BinaryOperator::Shr
     };
-    let operation = arithmetic::Operation::binary(operator, input1, input0);
+    let operation = arithmetic::Operation::binary(operator, input0, input1);
 
     state.traces.push_arithmetic(operation);
     state.traces.push_memory(log_in0);


### PR DESCRIPTION
This PR changes the way SHL and SHR are generated so that all the CPU CTLs looking into `ArithmeticStark` have the same form, and we can save one CTL.

Here, shift operations are generated on the arithmetic side rather on the CPU side. This leads to specific constraints for the shift operations, since now, the first input is `shift` rather than `1 << shift`. 
The three input registers are used in the Arithmetic STARK: the first is `shift`, the second is the input, and the third is `1 << shift`.
This way, we can have the same CTL shape for all arithmetic operations, and it removes the special shift CTL.

@unzvfu Would mind looking at this if you have the time?