### PR TITLE
Add PROVER_INPUT stack constraints.

### DIFF
--- a/evm/src/cpu/stack.rs
+++ b/evm/src/cpu/stack.rs
@@ -78,7 +78,11 @@ const STACK_BEHAVIORS: OpsColumnsView<Option<StackBehavior>> = OpsColumnsView {
         pushes: true,
         disable_other_channels: true,
     }),
-    prover_input: None, // TODO
+    prover_input: Some(StackBehavior {
+        num_pops: 0,
+        pushes: true,
+        disable_other_channels: true,
+    }),
     pop: Some(StackBehavior {
         num_pops: 1,
         pushes: false,


### PR DESCRIPTION
This PR adds missing stack constraints for `PROVER_INPUT` by adding a `StackBehavior` with no pop, pushes and other channels disabled.