### PR TITLE
Fix encoding for empty recipient

### DIFF
--- a/evm/src/generation/mpt.rs
+++ b/evm/src/generation/mpt.rs
@@ -282,21 +282,19 @@ fn empty_nibbles() -> Nibbles {
 pub mod transaction_testing {
     use super::*;
 
-    #[derive(RlpEncodable, RlpDecodable, Debug, Clone)]
+    #[derive(RlpEncodable, RlpDecodable, Debug, Clone, PartialEq, Eq)]
     pub struct AccessListItemRlp {
         pub address: Address,
         pub storage_keys: Vec<U256>,
     }
 
-    #[derive(Debug, Clone)]
+    #[derive(Debug, Clone, PartialEq, Eq)]
     pub struct AddressOption(pub Option<Address>);
 
     impl Encodable for AddressOption {
         fn rlp_append(&self, s: &mut RlpStream) {
             match self.0 {
-                None => {
-                    s.append_empty_data();
-                }
+                None => s.encoder().encode_value(&[]),
                 Some(value) => {
                     s.encoder().encode_value(&value.to_fixed_bytes());
                 }
@@ -316,7 +314,7 @@ pub mod transaction_testing {
         }
     }
 
-    #[derive(RlpEncodable, RlpDecodable, Debug, Clone)]
+    #[derive(RlpEncodable, RlpDecodable, Debug, Clone, PartialEq, Eq)]
     pub struct LegacyTransactionRlp {
         pub nonce: U256,
         pub gas_price: U256,
@@ -329,7 +327,7 @@ pub mod transaction_testing {
         pub s: U256,
     }
 
-    #[derive(RlpEncodable, RlpDecodable, Debug, Clone)]
+    #[derive(RlpEncodable, RlpDecodable, Debug, Clone, PartialEq, Eq)]
     pub struct AccessListTransactionRlp {
         pub chain_id: u64,
         pub nonce: U256,
@@ -344,7 +342,7 @@ pub mod transaction_testing {
         pub s: U256,
     }
 
-    #[derive(RlpEncodable, RlpDecodable, Debug, Clone)]
+    #[derive(RlpEncodable, RlpDecodable, Debug, Clone, PartialEq, Eq)]
     pub struct FeeMarketTransactionRlp {
         pub chain_id: u64,
         pub nonce: U256,


### PR DESCRIPTION
The current custom encoding for empty `to` fields is erroneous, as it will attempt to end early the RLP processing, leading the final RLP string to miss the length of the final element (the `s` field of the signature) in the prefix computation.
This can be tested for instance by getting an arbitrary transaction, replace the `to` field with `AddressOption(None)` encode it, and try to decode it with an online tool like https://toolkit.abdk.consulting/ethereum#rlp.