### PR TITLE
Fix hash node case in `mpt_delete_branch`

### DIFF
--- a/evm/src/cpu/kernel/asm/mpt/delete/delete_branch.asm
+++ b/evm/src/cpu/kernel/asm/mpt/delete/delete_branch.asm
@@ -77,14 +77,16 @@ loop_end:
     // stack: i, updated_child_ptr, first_nibble, node_payload_ptr, retdest
     DUP4 ADD %mload_trie_data
     // stack: only_child_ptr, updated_child_ptr, first_nibble, node_payload_ptr, retdest
-    DUP1 %mload_trie_data %eq_const(@MPT_NODE_BRANCH)     %jumpi(maybe_normalize_branch_branch)
+    DUP1 %mload_trie_data %eq_const(@MPT_NODE_BRANCH)     %jumpi(maybe_normalize_branch_branchhash)
+    DUP1 %mload_trie_data %eq_const(@MPT_NODE_HASH)       %jumpi(maybe_normalize_branch_branchhash)
     DUP1 %mload_trie_data %eq_const(@MPT_NODE_EXTENSION)  %jumpi(maybe_normalize_branch_leafext)
     DUP1 %mload_trie_data %eq_const(@MPT_NODE_LEAF)       %jumpi(maybe_normalize_branch_leafext)
     PANIC // This should never happen.
 
-// The only child of the branch node is a branch node.
+// The only child of the branch node is a branch node or a hash node.
 // Transform the branch node into an extension node of length 1.
-maybe_normalize_branch_branch:
+// This assumes that the hash node does not contain a leaf or an extension node (in which case this implementation is incorrect).
+maybe_normalize_branch_branchhash:
     // stack: only_child_ptr, updated_child_ptr, first_nibble, node_payload_ptr, retdest
     %get_trie_data_size // pointer to the extension node we're about to create
     // stack: extension_ptr, only_child_ptr, updated_child_ptr, first_nibble, node_payload_ptr, retdest

--- a/evm/src/cpu/kernel/tests/mpt/delete.rs
+++ b/evm/src/cpu/kernel/tests/mpt/delete.rs
@@ -9,7 +9,6 @@ use crate::cpu::kernel::interpreter::Interpreter;
 use crate::cpu::kernel::tests::mpt::{nibbles_64, test_account_1_rlp, test_account_2};
 use crate::generation::mpt::{all_mpt_prover_inputs_reversed, AccountRlp};
 use crate::generation::TrieInputs;
-use crate::memory::segments::Segment;
 use crate::Node;
 
 #[test]

--- a/evm/src/cpu/kernel/tests/mpt/delete.rs
+++ b/evm/src/cpu/kernel/tests/mpt/delete.rs
@@ -41,7 +41,7 @@ fn mpt_delete_leaf_overlapping_keys() -> Result<()> {
 fn mpt_delete_branch_into_hash() -> Result<()> {
     let hash = Node::Hash(H256::random());
     let state_trie = Node::Extension {
-        nibbles: nibbles_64(0xFFF),
+        nibbles: nibbles_64(0xADF),
         child: hash.into(),
     }
     .into();
@@ -78,8 +78,6 @@ fn test_state_trie(
     interpreter.run()?;
     assert_eq!(interpreter.stack(), vec![]);
 
-    dbg!(&interpreter.generation_state.memory.contexts[0].segments[Segment::TrieData as usize]);
-
     // Next, execute mpt_insert_state_trie.
     interpreter.generation_state.registers.program_counter = mpt_insert_state_trie;
     let trie_data = interpreter.get_trie_data_mut();
@@ -109,8 +107,6 @@ fn test_state_trie(
         interpreter.stack()
     );
 
-    dbg!(&interpreter.generation_state.memory.contexts[0].segments[Segment::TrieData as usize]);
-
     // Next, execute mpt_delete, deleting the account we just inserted.
     let state_trie_ptr = interpreter.get_global_metadata_field(GlobalMetadata::StateTrieRoot);
     interpreter.generation_state.registers.program_counter = mpt_delete;
@@ -121,8 +117,6 @@ fn test_state_trie(
     interpreter.run()?;
     let state_trie_ptr = interpreter.pop();
     interpreter.set_global_metadata_field(GlobalMetadata::StateTrieRoot, state_trie_ptr);
-
-    dbg!(&interpreter.generation_state.memory.contexts[0].segments[Segment::TrieData as usize]);
 
     // Now, execute mpt_hash_state_trie.
     interpreter.generation_state.registers.program_counter = mpt_hash_state_trie;


### PR DESCRIPTION
Add the assumption that whenever we have
``` 
  B
 / \
H   N
```
and want to delete `N`, the hash node `H` does not contain an extension or leaf node. The result is then just
```
E
|
H
```
This assumption should be satisfied in the EVM if the partial tries are correctly computed.

Closes #1275.