### PR TITLE
Make sure success is 0 in contract failure

### DIFF
--- a/evm/src/cpu/kernel/asm/core/process_txn.asm
+++ b/evm/src/cpu/kernel/asm/core/process_txn.asm
@@ -420,7 +420,7 @@ contract_creation_fault_3:
     // stack: leftover_gas', retdest, success
     %delete_all_touched_addresses
     %delete_all_selfdestructed_addresses
-    %stack (leftover_gas, retdest, success) -> (retdest, success, leftover_gas)
+    %stack (leftover_gas, retdest, success) -> (retdest, 0, leftover_gas)
     JUMP
 
 contract_creation_fault_3_zero_leftover:
@@ -432,7 +432,7 @@ contract_creation_fault_3_zero_leftover:
     %pay_coinbase_and_refund_sender
     %delete_all_touched_addresses
     %delete_all_selfdestructed_addresses
-    %stack (leftover_gas, retdest, success) -> (retdest, success, leftover_gas)
+    %stack (leftover_gas, retdest, success) -> (retdest, 0, leftover_gas)
     JUMP
 
 contract_creation_fault_4:
@@ -444,7 +444,7 @@ contract_creation_fault_4:
     %pay_coinbase_and_refund_sender
     %delete_all_touched_addresses
     %delete_all_selfdestructed_addresses
-    %stack (leftover_gas, retdest, success) -> (retdest, success, leftover_gas)
+    %stack (leftover_gas, retdest, success) -> (retdest, 0, leftover_gas)
     JUMP
 
 


### PR DESCRIPTION
`Syscalls` push a default 1 as txn `status` at the end of their execution, prior jumping to `terminate_common`. However the latter may end up in failure, while the `status` stored in the stack is never modified to be changed to 0.

Detected through all the `CREATE_ContractRETURNBigOffset` variants (now passing).
Also fixes `codesizeOOGInvalidSize` variants and most of previously failing `CreateOOGFromEOARefunds` variants.