### PR TITLE
Fix failed receipt.

### DIFF
--- a/evm/src/cpu/kernel/asm/core/create_receipt.asm
+++ b/evm/src/cpu/kernel/asm/core/create_receipt.asm
@@ -228,6 +228,7 @@ failed_receipt:
     // It is the receipt of a failed transaction, so set num_logs to 0. This will also lead to Bloom filter = 0.
     PUSH 0
     %mstore_global_metadata(@GLOBAL_METADATA_LOGS_LEN)
+    PUSH 0 %mstore_global_metadata(@GLOBAL_METADATA_LOGS_PAYLOAD_LEN)
     // stack: status, new_cum_gas, num_nibbles, txn_nb
     %jump(process_receipt_after_status)
 


### PR DESCRIPTION
We noticed a few evm-tests failing (such as Create2OOGFromCallRefunds_{16, 17}) when the logs are non-empty and the status of the transaction is 0. This is because we set the length of the logs to 0 but not their payload's length, which is later used for encoding the receipts. This PR fixes this by setting the logs' payload length to 0 when the status is 0.