### PR TITLE
Fix sys_blockhash

### DIFF
--- a/evm/src/cpu/kernel/asm/memory/metadata.asm
+++ b/evm/src/cpu/kernel/asm/memory/metadata.asm
@@ -241,6 +241,8 @@ global sys_blockhash:
     SWAP1
     // stack: block_number, kexit_info
     %blockhash
+    // stack: blockhash, kexit_info
+    SWAP1
     EXIT_KERNEL
 
 global blockhash:
@@ -262,7 +264,6 @@ global blockhash:
     // stack: block_hash_number, retdest
     %mload_kernel(@SEGMENT_BLOCK_HASHES)
     SWAP1 JUMP
-    JUMP
 
 %macro blockhash
     // stack: block_number


### PR DESCRIPTION
Wrong stack at the end of `sys_blockhash`. Fixes (at least) one `stEIP150singleCodeGasPrices/gasCostBerlin` test.