### PR TITLE
Add journal entry for logs

### DIFF
--- a/evm/src/cpu/kernel/aggregator.rs
+++ b/evm/src/cpu/kernel/aggregator.rs
@@ -148,6 +148,7 @@ pub(crate) fn combined_kernel() -> Kernel {
         include_str!("asm/journal/refund.asm"),
         include_str!("asm/journal/account_created.asm"),
         include_str!("asm/journal/revert.asm"),
+        include_str!("asm/journal/log.asm"),
         include_str!("asm/transactions/common_decoding.asm"),
         include_str!("asm/transactions/router.asm"),
         include_str!("asm/transactions/type_0.asm"),

--- a/evm/src/cpu/kernel/asm/core/log.asm
+++ b/evm/src/cpu/kernel/asm/core/log.asm
@@ -265,22 +265,3 @@ one_byte_data:
     %jump(rlp_data_len)
 %%after:
 %endmacro
-
-%macro journal_add_log
-    %journal_add_2(@JOURNAL_ENTRY_LOG)
-%endmacro
-
-global revert_log:
-    // stack: entry_type, ptr, retdest
-    POP
-    // First, reduce the number of logs.
-    %mload_global_metadata(@GLOBAL_METADATA_LOGS_LEN)
-    %decrement
-    %mstore_global_metadata(@GLOBAL_METADATA_LOGS_LEN)
-    // stack: ptr, retdest
-    // Second, restore payload length.
-    %journal_load_2
-    // stack: prev_logs_data_len, prev_payload_len, retdest
-    %mstore_global_metadata(@GLOBAL_METADATA_LOGS_DATA_LEN)
-    %mstore_global_metadata(@GLOBAL_METADATA_LOGS_PAYLOAD_LEN)
-    JUMP

--- a/evm/src/cpu/kernel/asm/journal/log.asm
+++ b/evm/src/cpu/kernel/asm/journal/log.asm
@@ -1,0 +1,20 @@
+// struct Log {logs_data_len, logs_payload_len}
+
+%macro journal_add_log
+    %journal_add_2(@JOURNAL_ENTRY_LOG)
+%endmacro
+
+global revert_log:
+    // stack: entry_type, ptr, retdest
+    POP
+    // First, reduce the number of logs.
+    %mload_global_metadata(@GLOBAL_METADATA_LOGS_LEN)
+    %decrement
+    %mstore_global_metadata(@GLOBAL_METADATA_LOGS_LEN)
+    // stack: ptr, retdest
+    // Second, restore payload length.
+    %journal_load_2
+    // stack: prev_logs_data_len, prev_payload_len, retdest
+    %mstore_global_metadata(@GLOBAL_METADATA_LOGS_DATA_LEN)
+    %mstore_global_metadata(@GLOBAL_METADATA_LOGS_PAYLOAD_LEN)
+    JUMP

--- a/evm/src/cpu/kernel/asm/journal/log.asm
+++ b/evm/src/cpu/kernel/asm/journal/log.asm
@@ -1,4 +1,4 @@
-// struct Log {logs_data_len, logs_payload_len}
+// struct Log { logs_data_len, logs_payload_len }
 
 %macro journal_add_log
     %journal_add_2(@JOURNAL_ENTRY_LOG)

--- a/evm/src/cpu/kernel/asm/journal/revert.asm
+++ b/evm/src/cpu/kernel/asm/journal/revert.asm
@@ -16,6 +16,7 @@
     DUP1 %eq_const(@JOURNAL_ENTRY_CODE_CHANGE)       %jumpi(revert_code_change)
     DUP1 %eq_const(@JOURNAL_ENTRY_REFUND)            %jumpi(revert_refund)
     DUP1 %eq_const(@JOURNAL_ENTRY_ACCOUNT_CREATED)   %jumpi(revert_account_created)
+    DUP1 %eq_const(@JOURNAL_ENTRY_LOG)               %jumpi(revert_log)
     PANIC // This should never happen.
 %%after:
     // stack: journal_size-1

--- a/evm/src/cpu/kernel/constants/journal_entry.rs
+++ b/evm/src/cpu/kernel/constants/journal_entry.rs
@@ -11,10 +11,11 @@ pub(crate) enum JournalEntry {
     CodeChange = 7,
     Refund = 8,
     AccountCreated = 9,
+    Log = 10,
 }
 
 impl JournalEntry {
-    pub(crate) const COUNT: usize = 10;
+    pub(crate) const COUNT: usize = 11;
 
     pub(crate) fn all() -> [Self; Self::COUNT] {
         [
@@ -28,6 +29,7 @@ impl JournalEntry {
             Self::CodeChange,
             Self::Refund,
             Self::AccountCreated,
+            Self::Log,
         ]
     }
 
@@ -44,6 +46,7 @@ impl JournalEntry {
             Self::CodeChange => "JOURNAL_ENTRY_CODE_CHANGE",
             Self::Refund => "JOURNAL_ENTRY_REFUND",
             Self::AccountCreated => "JOURNAL_ENTRY_ACCOUNT_CREATED",
+            Self::Log => "JOURNAL_ENTRY_LOG",
         }
     }
 }


### PR DESCRIPTION
We noticed a few tests failing, such as `logInOOG_Call` due to logs happening within a CALL, and not reverting. To fix this, this PR adds logs to the journal so they can be reverted when necessary.