### PR TITLE
Check gas in sys_stop

### DIFF
--- a/evm/src/cpu/kernel/asm/core/terminate.asm
+++ b/evm/src/cpu/kernel/asm/core/terminate.asm
@@ -6,6 +6,10 @@ global sys_stop:
     // Set the parent context's return data size to 0.
     %mstore_parent_context_metadata(@CTX_METADATA_RETURNDATA_SIZE, 0)
 
+    // This makes sure the gas used hasn't overflowed the gaslimit.
+    // This could happen when executing a native instruction (i.e. not a syscall).
+    %charge_gas_const(0)
+
     %leftover_gas
     // stack: leftover_gas
     PUSH 1 // success


### PR DESCRIPTION
Implements @hratoanina's suggestion in #1106 to handle gas overflowing the gaslimit caused by native instructions.

closes #1106