### PR TITLE
Pad according to RATE rather than WIDTH

### DIFF
--- a/plonky2/src/plonk/config.rs
+++ b/plonky2/src/plonk/config.rs
@@ -43,7 +43,7 @@ pub trait Hasher<F: RichField>: Sized + Copy + Debug + Eq + PartialEq {
     fn hash_pad(input: &[F]) -> Self::Hash {
         let mut padded_input = input.to_vec();
         padded_input.push(F::ONE);
-        while (padded_input.len() + 1) % Self::Permutation::WIDTH != 0 {
+        while (padded_input.len() + 1) % Self::Permutation::RATE != 0 {
             padded_input.push(F::ZERO);
         }
         padded_input.push(F::ONE);


### PR DESCRIPTION
I noticed that when padding a hash, we pad to a multiple of `WIDTH` instead of `RATE`. I believe this is a mistake that this PR fixes. @dlubarov  Would you mind letting me know whether I'm missing something?