### PR TITLE
Add macro for copying sequences of bytes

### DIFF
--- a/evm/src/cpu/kernel/asm/memory/memcpy.asm
+++ b/evm/src/cpu/kernel/asm/memory/memcpy.asm
@@ -54,7 +54,7 @@ memcpy_finish:
 %%after:
 %endmacro
 
-// Similar logic than memcpy, but optimized for copying sequences of bytes.
+// Similar logic to memcpy, but optimized for copying sequences of bytes.
 global memcpy_bytes:
     // stack: DST, SRC, count, retdest
     DUP7

--- a/evm/src/cpu/kernel/asm/memory/memcpy.asm
+++ b/evm/src/cpu/kernel/asm/memory/memcpy.asm
@@ -53,3 +53,74 @@ memcpy_finish:
     %jump(memcpy)
 %%after:
 %endmacro
+
+// Similar logic than memcpy, but optimized for copying sequences of bytes.
+global memcpy_bytes:
+    // stack: DST, SRC, count, retdest
+    DUP7
+    // stack: count, DST, SRC, count, retdest
+    %lt_const(0x20)
+    // stack: count < 32, DST, SRC, count, retdest
+    %jumpi(memcpy_bytes_finish)
+    
+    // We will pack 32 bytes into a U256 from the source, and then unpack it at the destination.
+    // Copy the next chunk of bytes.
+    PUSH 32
+    DUP1
+    DUP8
+    DUP8
+    DUP8
+    // stack: SRC, 32, 32, DST, SRC, count, retdest
+    MLOAD_32BYTES
+    // stack: value, 32, DST, SRC, count, retdest
+    DUP5
+    DUP5
+    DUP5
+    // stack: DST, value, 32, DST, SRC, count, retdest
+    MSTORE_32BYTES
+    // stack: DST, SRC, count, retdest
+
+    // Increment dst_addr by 32.
+    SWAP2
+    %add_const(0x20)
+    SWAP2
+    // Increment src_addr by 32.
+    SWAP5
+    %add_const(0x20)
+    SWAP5
+    // Decrement count by 32.
+    SWAP6
+    %sub_const(0x20)
+    SWAP6
+
+    // Continue the loop.
+    %jump(memcpy_bytes)
+
+memcpy_bytes_finish:
+    // stack: DST, SRC, count, retdest
+
+    // Copy the last chunk of `count` bytes.
+    DUP7
+    DUP1
+    DUP8
+    DUP8
+    DUP8
+    // stack: SRC, count, count, DST, SRC, count, retdest
+    MLOAD_32BYTES
+    // stack: value, count, DST, SRC, count, retdest
+    DUP5
+    DUP5
+    DUP5
+    // stack: DST, value, count, DST, SRC, count, retdest
+    MSTORE_32BYTES
+    // stack: DST, SRC, count, retdest
+
+    %pop7
+    // stack: retdest
+    JUMP
+
+%macro memcpy_bytes
+    %stack (dst: 3, src: 3, count) -> (dst, src, count, %%after)
+    %jump(memcpy_bytes)
+%%after:
+%endmacro

--- a/evm/src/cpu/kernel/asm/memory/syscalls.asm
+++ b/evm/src/cpu/kernel/asm/memory/syscalls.asm
@@ -152,7 +152,7 @@ global sys_returndatacopy:
     GET_CONTEXT
     %stack (context, kexit_info, dest_offset, offset, size) ->
         (context, @SEGMENT_MAIN_MEMORY, dest_offset, context, @SEGMENT_RETURNDATA, offset, size, wcopy_after, kexit_info)
-    %jump(memcpy_bytes)
+    %jump(memcpy)
 
 returndatacopy_empty:
     %stack (kexit_info, dest_offset, offset, size) -> (kexit_info)

--- a/evm/src/cpu/kernel/asm/memory/syscalls.asm
+++ b/evm/src/cpu/kernel/asm/memory/syscalls.asm
@@ -95,7 +95,7 @@ calldataload_large_offset:
     GET_CONTEXT
     %stack (context, kexit_info, dest_offset, offset, size) ->
         (context, @SEGMENT_MAIN_MEMORY, dest_offset, context, $segment, offset, size, wcopy_after, kexit_info)
-    %jump(memcpy)
+    %jump(memcpy_bytes)
 %endmacro
 
 wcopy_empty:
@@ -152,7 +152,7 @@ global sys_returndatacopy:
     GET_CONTEXT
     %stack (context, kexit_info, dest_offset, offset, size) ->
         (context, @SEGMENT_MAIN_MEMORY, dest_offset, context, @SEGMENT_RETURNDATA, offset, size, wcopy_after, kexit_info)
-    %jump(memcpy)
+    %jump(memcpy_bytes)
 
 returndatacopy_empty:
     %stack (kexit_info, dest_offset, offset, size) -> (kexit_info)

--- a/evm/src/cpu/kernel/asm/mpt/hash/hash_trie_specific.asm
+++ b/evm/src/cpu/kernel/asm/mpt/hash/hash_trie_specific.asm
@@ -116,7 +116,7 @@ global encode_txn:
         0, @SEGMENT_TRIE_DATA, txn_rlp_ptr, // src addr. Kernel has context 0
         txn_rlp_len, // mcpy len
         txn_rlp_len, rlp_pos)
-    %memcpy
+    %memcpy_bytes
     ADD
     // stack new_rlp_pos, retdest
     SWAP1

--- a/evm/src/cpu/kernel/asm/transactions/router.asm
+++ b/evm/src/cpu/kernel/asm/transactions/router.asm
@@ -57,7 +57,7 @@ global update_txn_trie:
         0, @SEGMENT_RLP_RAW, 0, // src addr. Kernel has context 0
         txn_rlp_len, // mcpy len
         txn_rlp_len, rlp_start, txn_counter, num_nibbles, value_ptr)
-    %memcpy
+    %memcpy_bytes
     ADD
     %set_trie_data_size
     // stack: txn_counter, num_nibbles, value_ptr, retdest


### PR DESCRIPTION
The current `%memcpy` is quite wasteful for sequence of bytes, which is being used twice for transaction encoding.
I suggest having a dedicated macro `memcpy_bytes` for those, which packs the bytes by sequences of length 32 (or smaller for the last chunk), and rely on `MLOAD_32BYTES` / `MSTORE_32BYTES` to amortize the CPU / Memory overhead.

On `add11_yml`, I am getting a mild 4.7% reduction in CPU cycle count, but for larger transactions, the impact is better.
For the more extreme example (`Shanghai/creationTxInitCodeSizeLimit_d0g0v0_Shanghai.json`), this is pruning almost ***30%*** of both CPU and Memory traces, with number of CPU cycles going from 8_758_697 to 6_192_428 and Memory rows going from 23_644_152 to 16_807_024.