### PR TITLE
Speed-up memset and fix it to write 0 values

### DIFF
--- a/evm/src/cpu/kernel/asm/account_code.asm
+++ b/evm/src/cpu/kernel/asm/account_code.asm
@@ -190,7 +190,7 @@ extcodecopy_large_offset:
     // offset is larger than the code size. So we just have to write zeros.
     // stack: code_size, size, offset, dest_offset, retdest
     GET_CONTEXT
-    %stack (context, code_size, size, offset, dest_offset, retdest) -> (context, @SEGMENT_MAIN_MEMORY, dest_offset, 0, size, retdest)
+    %stack (context, code_size, size, offset, dest_offset, retdest) -> (context, @SEGMENT_MAIN_MEMORY, dest_offset, size, retdest)
     %jump(memset)
 
 // Loads the code at `address` into memory, at the given context and segment, starting at offset 0.

--- a/evm/src/cpu/kernel/asm/bignum/util.asm
+++ b/evm/src/cpu/kernel/asm/bignum/util.asm
@@ -9,7 +9,7 @@
 %macro clear_current_general
     // stack: dst, len
     GET_CONTEXT
-    %stack (context, dst, len) -> (context, @SEGMENT_KERNEL_GENERAL, dst, 0, len, %%after)
+    %stack (context, dst, len) -> (context, @SEGMENT_KERNEL_GENERAL, dst, len, %%after)
     %jump(memset)
 %%after:
 %endmacro

--- a/evm/src/cpu/kernel/asm/memory/memset.asm
+++ b/evm/src/cpu/kernel/asm/memory/memset.asm
@@ -9,8 +9,6 @@ global memset:
     // stack: count < 32, DST, count, retdest
     %jumpi(memset_finish)
     // stack: DST, count, retdest
-    
-    // stack: DST, count, retdest
     PUSH 32
     PUSH 0
     DUP5

--- a/evm/src/cpu/kernel/asm/memory/memset.asm
+++ b/evm/src/cpu/kernel/asm/memory/memset.asm
@@ -1,38 +1,47 @@
-// Sets `count` values to `value` at
+// Sets `count` values to 0 at
 //     DST = (dst_ctx, dst_segment, dst_addr).
 // This tuple definition is used for brevity in the stack comments below.
 global memset:
-    // stack: DST, value, count, retdest
-    DUP5
-    // stack: count, DST, value, count, retdest
-    ISZERO
-    // stack: count == 0, DST, value, count, retdest
+    // stack: DST, count, retdest
+    DUP4
+    // stack: count, DST, count, retdest
+    %lt_const(0x20)
+    // stack: count < 32, DST, count, retdest
     %jumpi(memset_finish)
-    // stack: DST, value, count, retdest
+    // stack: DST, count, retdest
     
-    DUP4
-    // stack: value, DST, value, count, retdest
-    DUP4
-    DUP4
-    DUP4
-    // stack: DST, value, DST, value, count, retdest
-    MSTORE_GENERAL
-    // stack: DST, value, count, retdest
+    // stack: DST, count, retdest
+    PUSH 32
+    PUSH 0
+    DUP5
+    DUP5
+    DUP5
+    // stack: DST, 0, 32, DST, count, retdest
+    MSTORE_32BYTES
+    // stack: DST, count, retdest
 
     // Increment dst_addr.
     SWAP2
-    %increment
+    %add_const(0x20)
     SWAP2
     // Decrement count.
     SWAP4
-    %decrement
+    %sub_const(0x20)
     SWAP4
 
     // Continue the loop.
     %jump(memset)
 
 memset_finish:
-    // stack: DST, value, count, retdest
-    %pop5
+    // stack: DST, final_count, retdest
+    DUP4
+    PUSH 0
+    DUP5
+    DUP5
+    DUP5
+    // stack: DST, 0, final_count, DST, final_count, retdest
+    MSTORE_32BYTES
+    // stack: DST, final_count, retdest
+    %pop4
     // stack: retdest
     JUMP

--- a/evm/src/cpu/kernel/asm/memory/syscalls.asm
+++ b/evm/src/cpu/kernel/asm/memory/syscalls.asm
@@ -109,7 +109,7 @@ wcopy_large_offset:
     // stack: kexit_info, dest_offset, offset, size
     GET_CONTEXT
     %stack (context, kexit_info, dest_offset, offset, size) ->
-        (context, @SEGMENT_MAIN_MEMORY, dest_offset, 0, size, wcopy_after, kexit_info)
+        (context, @SEGMENT_MAIN_MEMORY, dest_offset, size, wcopy_after, kexit_info)
     %jump(memset)
 
 wcopy_after:


### PR DESCRIPTION
I realized in #1304 that a similar logic could be done with `memset`.
As it is always used to write zeroes, I just replaced the original label to be effective everywhere.

An example on `stPreCompiledContracts/modexp_d0g0v0_Shanghai` test:

before: `{ arithmetic_len: 141396, byte_packing_len: 3644, cpu_len: 899924, keccak_len: 12600, keccak_sponge_len: 525, logic_len: 3782, memory_len: 2447097 }`

after: `{ arithmetic_len: 125741, byte_packing_len: 11724, cpu_len: 740850, keccak_len: 12600, keccak_sponge_len: 525, logic_len: 3782, memory_len: 2028462 }`

i.e. 17.7% reduction in CPU / 17.1% reduction in Memory, pre padding.