### PR TITLE
Handle empty case for `memcpy_bytes`

### DIFF
--- a/evm/src/cpu/kernel/asm/memory/memcpy.asm
+++ b/evm/src/cpu/kernel/asm/memory/memcpy.asm
@@ -131,7 +131,7 @@ memcpy_bytes_finish:
     JUMP
 
 memcpy_bytes_empty:
-    // stack: DST, SRC, count, retdest
+    // stack: DST, SRC, 0, retdest
     %pop7
     // stack: retdest
     JUMP

--- a/evm/src/cpu/kernel/asm/memory/memcpy.asm
+++ b/evm/src/cpu/kernel/asm/memory/memcpy.asm
@@ -57,6 +57,17 @@ memcpy_finish:
 // Similar logic to memcpy, but optimized for copying sequences of bytes.
 global memcpy_bytes:
     // stack: DST, SRC, count, retdest
+
+    // Handle empty case
+    DUP7
+    // stack: count, DST, SRC, count, retdest
+    ISZERO
+    // stack: count == 0, DST, SRC, count, retdest
+    %jumpi(memcpy_bytes_empty)
+
+    // stack: DST, SRC, count, retdest
+
+    // Handle small case
     DUP7
     // stack: count, DST, SRC, count, retdest
     %lt_const(0x20)
@@ -115,6 +126,12 @@ memcpy_bytes_finish:
     MSTORE_32BYTES
     // stack: DST, SRC, count, retdest
 
+    %pop7
+    // stack: retdest
+    JUMP
+
+memcpy_bytes_empty:
+    // stack: DST, SRC, count, retdest
     %pop7
     // stack: retdest
     JUMP

--- a/evm/src/cpu/kernel/asm/memory/memset.asm
+++ b/evm/src/cpu/kernel/asm/memory/memset.asm
@@ -2,12 +2,22 @@
 //     DST = (dst_ctx, dst_segment, dst_addr).
 // This tuple definition is used for brevity in the stack comments below.
 global memset:
+    // Handle empty case
+    DUP7
+    // stack: count, DST, count, retdest
+    ISZERO
+    // stack: count == 0, DST, count, retdest
+    %jumpi(memset_bytes_empty)
+
     // stack: DST, count, retdest
+
+    // Handle small case
     DUP4
     // stack: count, DST, count, retdest
     %lt_const(0x20)
     // stack: count < 32, DST, count, retdest
     %jumpi(memset_finish)
+
     // stack: DST, count, retdest
     PUSH 32
     PUSH 0
@@ -40,6 +50,12 @@ memset_finish:
     // stack: DST, 0, final_count, DST, final_count, retdest
     MSTORE_32BYTES
     // stack: DST, final_count, retdest
+    %pop4
+    // stack: retdest
+    JUMP
+
+memset_bytes_empty:
+    // stack: DST, 0, retdest
     %pop4
     // stack: retdest
     JUMP


### PR DESCRIPTION
An oversight from #1304 (that isn't part of the last comment there), but copying empty sequences (either through a dumb call to one of the syscalls, or if the sequence length is a multiple of 32 bytes), would result in CTL failure as the byte_packing table isn't supposed to have empty sequences.

example: `codecopy_d3g0v0_Shanghai.json`