### PR TITLE
Fix some edge cases with code_copy

### DIFF
--- a/evm/src/cpu/kernel/asm/account_code.asm
+++ b/evm/src/cpu/kernel/asm/account_code.asm
@@ -195,11 +195,11 @@ extcodecopy_end:
     JUMP
 
 extcodecopy_large_offset:
-    // offset is larger than the code size. So we just have to write zeros.
+    // offset is larger than the code size.
+    // The YP specifies we should not do anything outside of the code's bounds. 
     // stack: code_size, size, offset, dest_offset, retdest
-    GET_CONTEXT
-    %stack (context, code_size, size, offset, dest_offset, retdest) -> (context, @SEGMENT_MAIN_MEMORY, dest_offset, size, retdest)
-    %jump(memset)
+    %pop4
+    JUMP
 
 // Loads the code at `address` into memory, at the given context and segment, starting at offset 0.
 // Checks that the hash of the loaded code corresponds to the `codehash` in the state trie.

--- a/evm/src/cpu/kernel/asm/account_code.asm
+++ b/evm/src/cpu/kernel/asm/account_code.asm
@@ -136,14 +136,13 @@ global extcodecopy:
 
 extcodecopy_contd:
     // stack: code_size, size, offset, dest_offset, retdest
-    DUP1 DUP4
-    // stack: offset, code_size, code_size, size, offset, dest_offset, retdest
+    DUP1 DUP4 %add_const(1)
+    // stack: offset + 1, code_size, code_size, size, offset, dest_offset, retdest
     GT %jumpi(extcodecopy_large_offset)
 
     // Do not copy past the length of the SRC segment
-    PUSH 1
-    DUP4 DUP3 SUB SUB
-    // stack: code_size - offset - 1, code_size, size, offset, dest_offset, retdest
+    DUP3 DUP2 SUB
+    // stack: code_size - offset, code_size, size, offset, dest_offset, retdest
     DUP3
     %min
     // stack: max_size, code_size, size, offset, dest_offset, retdest

--- a/evm/src/cpu/kernel/asm/account_code.asm
+++ b/evm/src/cpu/kernel/asm/account_code.asm
@@ -141,8 +141,9 @@ extcodecopy_contd:
     GT %jumpi(extcodecopy_large_offset)
 
     // Do not copy past the length of the SRC segment
-    DUP3 DUP2 SUB
-    // stack: code_size - offset, code_size, size, offset, dest_offset, retdest
+    PUSH 1
+    DUP4 DUP3 SUB SUB
+    // stack: code_size - offset - 1, code_size, size, offset, dest_offset, retdest
     DUP3
     %min
     // stack: max_size, code_size, size, offset, dest_offset, retdest

--- a/evm/src/cpu/kernel/asm/account_code.asm
+++ b/evm/src/cpu/kernel/asm/account_code.asm
@@ -139,6 +139,14 @@ extcodecopy_contd:
     DUP1 DUP4
     // stack: offset, code_size, code_size, size, offset, dest_offset, retdest
     GT %jumpi(extcodecopy_large_offset)
+
+    // Do not copy past the length of the SRC segment
+    DUP3 DUP2 SUB
+    // stack: code_size - offset, code_size, size, offset, dest_offset, retdest
+    DUP3
+    %min
+    // stack: max_size, code_size, size, offset, dest_offset, retdest
+    SWAP2 POP
     // stack: code_size, size, offset, dest_offset, retdest
     SWAP1
     // stack: size, code_size, offset, dest_offset, retdest

--- a/evm/src/cpu/kernel/asm/memory/syscalls.asm
+++ b/evm/src/cpu/kernel/asm/memory/syscalls.asm
@@ -139,7 +139,7 @@ global sys_codecopy:
     // stack: total_size, kexit_info, dest_offset, offset, size
     DUP4
     // stack: offset, total_size, kexit_info, dest_offset, offset, size
-    GT %jumpi(wcopy_large_offset)
+    GT %jumpi(codecopy_exit)
 
     // Do not copy past the length of the SRC segment
     DUP3
@@ -157,6 +157,12 @@ global sys_codecopy:
     %stack (context, kexit_info, dest_offset, offset, size) ->
         (context, @SEGMENT_MAIN_MEMORY, dest_offset, context, @SEGMENT_CODE, offset, size, wcopy_after, kexit_info)
     %jump(memcpy_bytes)
+
+codecopy_exit:
+    // offset is larger than the code size.
+    // The YP specifies we should not do anything outside of the code's bounds.
+    %stack (kexit_info, dest_offset, offset, size) -> (kexit_info)
+    EXIT_KERNEL
 
 // Same as %wcopy but with overflow checks.
 global sys_returndatacopy:

--- a/evm/src/cpu/kernel/asm/memory/syscalls.asm
+++ b/evm/src/cpu/kernel/asm/memory/syscalls.asm
@@ -137,17 +137,16 @@ global sys_codecopy:
 
     %mload_context_metadata(@CTX_METADATA_CODE_SIZE)
     // stack: total_size, kexit_info, dest_offset, offset, size
-    DUP4
-    // stack: offset, total_size, kexit_info, dest_offset, offset, size
+    DUP4 %add_const(1)
+    // stack: offset + 1, total_size, kexit_info, dest_offset, offset, size
     GT %jumpi(codecopy_exit)
 
     // Do not copy past the length of the SRC segment
-    PUSH 1
-    DUP4
+    DUP3
     %mload_context_metadata(@CTX_METADATA_CODE_SIZE)
-    // stack: total_size, offset, 1, kexit_info, dest_offset, offset, size
-    SUB SUB
-    // stack: total_size - offset - 1, kexit_info, dest_offset, offset, size
+    // stack: total_size, offset, kexit_info, dest_offset, offset, size
+    SUB
+    // stack: total_size - offset, kexit_info, dest_offset, offset, size
     DUP5
     %min
     // stack: max_size, kexit_info, dest_offset, offset, size

--- a/evm/src/cpu/kernel/asm/memory/syscalls.asm
+++ b/evm/src/cpu/kernel/asm/memory/syscalls.asm
@@ -142,20 +142,19 @@ global sys_codecopy:
     GT %jumpi(codecopy_exit)
 
     // Do not copy past the length of the SRC segment
-    DUP3
+    PUSH 1
+    DUP4
     %mload_context_metadata(@CTX_METADATA_CODE_SIZE)
-    // stack: total_size, kexit_info, dest_offset, offset, size
-    SUB
-    // stack: total_size - offset, kexit_info, dest_offset, offset, size
+    // stack: total_size, offset, 1, kexit_info, dest_offset, offset, size
+    SUB SUB
+    // stack: total_size - offset - 1, kexit_info, dest_offset, offset, size
     DUP5
     %min
     // stack: max_size, kexit_info, dest_offset, offset, size
-    SWAP4 POP
-    // stack: kexit_info, dest_offset, offset, max_size
 
     GET_CONTEXT
-    %stack (context, kexit_info, dest_offset, offset, size) ->
-        (context, @SEGMENT_MAIN_MEMORY, dest_offset, context, @SEGMENT_CODE, offset, size, wcopy_after, kexit_info)
+    %stack (context, max_size, kexit_info, dest_offset, offset, size) ->
+        (context, @SEGMENT_MAIN_MEMORY, dest_offset, context, @SEGMENT_CODE, offset, max_size, wcopy_after, kexit_info)
     %jump(memcpy_bytes)
 
 codecopy_exit:

--- a/evm/src/cpu/kernel/tests/account_code.rs
+++ b/evm/src/cpu/kernel/tests/account_code.rs
@@ -175,7 +175,7 @@ fn test_extcodecopy() -> Result<()> {
         let copied_code_length = if offset >= code.len() {
             0
         } else {
-            core::cmp::min(size, code.len() - offset - 1)
+            core::cmp::min(size, code.len() - offset)
         };
         let memory_untouched_after_code = interpreter.generation_state.memory.contexts
             [interpreter.context]

--- a/evm/src/cpu/kernel/tests/account_code.rs
+++ b/evm/src/cpu/kernel/tests/account_code.rs
@@ -174,12 +174,6 @@ fn test_extcodecopy() -> Result<()> {
     interpreter.run()?;
 
     assert!(interpreter.stack().is_empty());
-    println!(
-        "Code len: {:?}, size: {:?}, offset: {:?}",
-        code.len(),
-        size,
-        offset
-    );
 
     // extcodecopy doesn't do anything if offset >= code.len()
     if offset < code.len() {

--- a/evm/src/cpu/kernel/tests/account_code.rs
+++ b/evm/src/cpu/kernel/tests/account_code.rs
@@ -174,15 +174,26 @@ fn test_extcodecopy() -> Result<()> {
     interpreter.run()?;
 
     assert!(interpreter.stack().is_empty());
-    // Check that the code was correctly copied to memory.
-    for i in 0..size {
-        let memory = interpreter.generation_state.memory.contexts[interpreter.context].segments
-            [Segment::MainMemory as usize]
-            .get(dest_offset + i);
-        assert_eq!(
-            memory,
-            code.get(offset + i).copied().unwrap_or_default().into()
-        );
+    println!(
+        "Code len: {:?}, size: {:?}, offset: {:?}",
+        code.len(),
+        size,
+        offset
+    );
+
+    // extcodecopy doesn't do anything if offset >= code.len()
+    if offset < code.len() {
+        // Check that the code was correctly copied to memory.
+        // we stopped copying at the end of the code
+        for i in 0..core::cmp::min(size, offset - code.len()) {
+            let memory = interpreter.generation_state.memory.contexts[interpreter.context].segments
+                [Segment::MainMemory as usize]
+                .get(dest_offset + i);
+            assert_eq!(
+                memory,
+                code.get(offset + i).copied().unwrap_or_default().into()
+            );
+        }
     }
 
     Ok(())

--- a/evm/src/cpu/kernel/tests/account_code.rs
+++ b/evm/src/cpu/kernel/tests/account_code.rs
@@ -177,15 +177,22 @@ fn test_extcodecopy() -> Result<()> {
 
     // extcodecopy doesn't do anything if offset >= code.len()
     if offset < code.len() {
+        println!(
+            "code of size: {:?}, copying {:?} from {:?}",
+            code.len(),
+            size,
+            offset
+        );
         // Check that the code was correctly copied to memory.
         // we stopped copying at the end of the code
-        for i in 0..core::cmp::min(size, offset - code.len()) {
+        for i in 0..core::cmp::min(size, offset - code.len() - 1) {
             let memory = interpreter.generation_state.memory.contexts[interpreter.context].segments
                 [Segment::MainMemory as usize]
                 .get(dest_offset + i);
             assert_eq!(
                 memory,
-                code.get(offset + i).copied().unwrap_or_default().into()
+                code.get(offset + i).copied().unwrap_or_default().into(),
+                "failed at idx {i} to access {offset} + {i}",
             );
         }
     }

--- a/evm/src/cpu/kernel/tests/account_code.rs
+++ b/evm/src/cpu/kernel/tests/account_code.rs
@@ -209,7 +209,6 @@ fn test_extcodecopy() -> Result<()> {
                 assert_eq!(
                     memory,
                     code.get(offset + i).copied().unwrap_or_default().into(),
-                    "failed at idx {i} to access {offset} + {i}",
                 );
             }
 


### PR DESCRIPTION
More detailed comment in [here](https://github.com/0xPolygonZero/plonky2/pull/1304#issuecomment-1776137373).

The YP specifies that we should stop copying for CODECOPY / EXTCODECOPY (while we currently pad with zeroes using memset when the offset is too large, and we don't check that offset + copy_size can go over the codesize, which can fail if we copy non-byte elements). The current failure on `main` is dues to the `test_extcodecopy` which generates a random code and random offsets / sizes to copy to. I think it would need a rewrite, to handle those specific edge cases manually and have deterministic failure.

@wborgeaud Was there a particular rationale for always padding with zeroes? This should be unrelated to the test failing so I could remove it, though it feels wasteful and it wasn't clear why we would need it. We do need padding with zeroes for CALLDATACOPY and RETURNDATACOPY though, which isn't implemented yet.