### PR TITLE
Fix `wcopy` and `extcodecopy` for ranges over code limit

### DIFF
--- a/evm/src/cpu/kernel/asm/memory/memset.asm
+++ b/evm/src/cpu/kernel/asm/memory/memset.asm
@@ -2,8 +2,10 @@
 //     DST = (dst_ctx, dst_segment, dst_addr).
 // This tuple definition is used for brevity in the stack comments below.
 global memset:
+    // stack: DST, count, retdest
+
     // Handle empty case
-    DUP7
+    DUP4
     // stack: count, DST, count, retdest
     ISZERO
     // stack: count == 0, DST, count, retdest
@@ -33,9 +35,9 @@ global memset:
     %add_const(0x20)
     SWAP2
     // Decrement count.
-    SWAP4
+    SWAP3
     %sub_const(0x20)
-    SWAP4
+    SWAP3
 
     // Continue the loop.
     %jump(memset)


### PR DESCRIPTION
This fixes `RETURNDATACOPY`, `CODECOPY`, `CALLDATACOPY` and `EXTCODECOPY` for copies going over the code/data range by correctly copying the overlapping range, and then filling with zeroes the destination for the remaining length.

While fixing `EXTCODECOPY` I also switched it to use `memcpy` for simplicity and to amortize CPU cycles.

fixes the current failing CI on `main`.
@wborgeaud It doesn't look super clean to me, I'd like to do some more refactoring/cleanup but at least this is a working version.

I haven't run the entire test suite but I got only successes on related ones, cf below:

```asm
ExtCodeCopyTargetRangeLongerThanCodeTests_d0g0v0_Shanghai,Passed,2023-10-24T22:00:55.326626563Z
ExtCodeCopyTests_d0g0v0_Shanghai,Passed,2023-10-24T22:00:59.593494467Z
RawExtCodeCopyGas_d0g0v0_Shanghai,Passed,2023-10-24T22:00:30.622163451Z
RawExtCodeCopyMemoryGas_d0g0v0_Shanghai,Passed,2023-10-24T22:00:34.958435161Z
RevertOpcodeInCallsOnNonEmptyReturnData_d0g0v0_Shanghai,Passed,2023-10-24T22:07:59.615052894Z
RevertOpcodeInCallsOnNonEmptyReturnData_d0g1v0_Shanghai,Passed,2023-10-24T22:08:11.069881411Z
RevertOpcodeInCallsOnNonEmptyReturnData_d1g0v0_Shanghai,Passed,2023-10-24T22:08:22.556520845Z
RevertOpcodeInCallsOnNonEmptyReturnData_d1g1v0_Shanghai,Passed,2023-10-24T22:07:53.626382440Z
RevertOpcodeInCallsOnNonEmptyReturnData_d2g0v0_Shanghai,Passed,2023-10-24T22:08:28.578118067Z
RevertOpcodeInCallsOnNonEmptyReturnData_d2g1v0_Shanghai,Passed,2023-10-24T22:08:34.634186528Z
RevertOpcodeInCallsOnNonEmptyReturnData_d3g0v0_Shanghai,Passed,2023-10-24T22:08:16.544075694Z
RevertOpcodeInCallsOnNonEmptyReturnData_d3g1v0_Shanghai,Passed,2023-10-24T22:08:05.563023490Z
codeCopyOffset_d0g0v0_Shanghai,Passed,2023-10-24T22:00:51.200918833Z
codeCopyZero_d0g0v0_Shanghai,Passed,2023-10-24T22:00:42.619348919Z
codecopyNonConst_d0g0v0_Shanghai,Passed,2023-10-24T22:06:46.982291078Z
codecopyNonConst_d0g0v1_Shanghai,Passed,2023-10-24T22:06:51.116885073Z
codecopy_d0g0v0_Shanghai,Passed,2023-10-24T22:07:24.994522301Z
codecopy_d1g0v0_Shanghai,Passed,2023-10-24T22:07:08.321480588Z
codecopy_d2g0v0_Shanghai,Passed,2023-10-24T22:07:03.925391077Z
codecopy_d3g0v0_Shanghai,Passed,2023-10-24T22:07:14.312324832Z
codecopy_d4g0v0_Shanghai,Passed,2023-10-24T22:07:20.536122744Z
codecopy_dejavu2_d0g0v0_Shanghai,Passed,2023-10-24T22:06:42.872278382Z
codecopy_dejavu_d0g0v0_Shanghai,Passed,2023-10-24T22:06:34.750711793Z
extCodeCopyBounds_d0g0v0_Shanghai,Passed,2023-10-24T22:00:46.954892649Z
extcodecopyNonConst_d0g0v0_Shanghai,Passed,2023-10-24T22:06:59.438402521Z
extcodecopyNonConst_d0g0v1_Shanghai,Passed,2023-10-24T22:06:55.276089057Z
extcodecopy_d0g0v0_Shanghai,Passed,2023-10-24T22:06:30.706417653Z
extcodecopy_dejavu_d0g0v0_Shanghai,Passed,2023-10-24T22:06:38.795196423Z
returndatacopy_afterFailing_create_d0g0v0_Shanghai,Passed,2023-10-24T22:09:33.790507685Z
returndatacopy_after_failing_staticcall_d0g0v0_Shanghai,Passed,2023-10-24T22:08:42.944240391Z
returndatacopy_after_successful_callcode_d0g0v0_Shanghai,Passed,2023-10-24T22:10:02.757906298Z
returndatacopy_after_successful_delegatecall_d0g0v0_Shanghai,Passed,2023-10-24T22:08:55.419481Z
returndatacopy_after_successful_staticcall_d0g0v0_Shanghai,Passed,2023-10-24T22:08:47.119839906Z
returndatacopy_following_call_d0g0v0_Shanghai,Passed,2023-10-24T22:08:38.768020505Z
returndatacopy_following_create_d0g0v0_Shanghai,Passed,2023-10-24T22:09:37.948801372Z
returndatacopy_following_successful_create_d0g0v0_Shanghai,Passed,2023-10-24T22:09:29.635356278Z
returndatacopy_following_too_big_transfer_d0g0v0_Shanghai,Passed,2023-10-24T22:09:25.490296381Z
returndatacopy_initial_256_d0g0v0_Shanghai,Passed,2023-10-24T22:09:58.589356883Z
returndatacopy_initial_256_d1g0v0_Shanghai,Passed,2023-10-24T22:09:50.383021533Z
returndatacopy_initial_256_d2g0v0_Shanghai,Passed,2023-10-24T22:09:54.504269952Z
tooLongReturnDataCopy_d0g0v0_Shanghai,Passed,2023-10-24T22:12:00.133715458Z
tooLongReturnDataCopy_d10g0v0_Shanghai,Passed,2023-10-24T22:11:30.204127908Z
tooLongReturnDataCopy_d11g0v0_Shanghai,Passed,2023-10-24T22:11:47.319722097Z
tooLongReturnDataCopy_d12g0v0_Shanghai,Passed,2023-10-24T22:11:34.500762297Z
tooLongReturnDataCopy_d13g0v0_Shanghai,Passed,2023-10-24T22:10:51.927584218Z
tooLongReturnDataCopy_d14g0v0_Shanghai,Passed,2023-10-24T22:10:43.455593844Z
tooLongReturnDataCopy_d15g0v0_Shanghai,Passed,2023-10-24T22:11:08.946167842Z
tooLongReturnDataCopy_d16g0v0_Shanghai,Passed,2023-10-24T22:11:13.188282234Z
tooLongReturnDataCopy_d17g0v0_Shanghai,Passed,2023-10-24T22:11:25.983184096Z
tooLongReturnDataCopy_d18g0v0_Shanghai,Passed,2023-10-24T22:10:39.180030933Z
tooLongReturnDataCopy_d19g0v0_Shanghai,Passed,2023-10-24T22:10:56.186851549Z
tooLongReturnDataCopy_d1g0v0_Shanghai,Passed,2023-10-24T22:11:38.776257427Z
tooLongReturnDataCopy_d20g0v0_Shanghai,Passed,2023-10-24T22:11:21.691867166Z
tooLongReturnDataCopy_d21g0v0_Shanghai,Passed,2023-10-24T22:11:17.416816767Z
tooLongReturnDataCopy_d22g0v0_Shanghai,Passed,2023-10-24T22:11:04.681337151Z
tooLongReturnDataCopy_d23g0v0_Shanghai,Passed,2023-10-24T22:11:00.428899860Z
tooLongReturnDataCopy_d2g0v0_Shanghai,Passed,2023-10-24T22:11:43.072568725Z
tooLongReturnDataCopy_d3g0v0_Shanghai,Passed,2023-10-24T22:10:47.706960815Z
tooLongReturnDataCopy_d4g0v0_Shanghai,Passed,2023-10-24T22:11:51.585504867Z
tooLongReturnDataCopy_d5g0v0_Shanghai,Passed,2023-10-24T22:12:08.714628562Z
tooLongReturnDataCopy_d6g0v0_Shanghai,Passed,2023-10-24T22:11:55.839366858Z
tooLongReturnDataCopy_d7g0v0_Shanghai,Passed,2023-10-24T22:12:04.415853398Z
tooLongReturnDataCopy_d8g0v0_Shanghai,Passed,2023-10-24T22:12:12.961430459Z
tooLongReturnDataCopy_d9g0v0_Shanghai,Passed,2023-10-24T22:12:17.224086966Z
```