### PR TITLE
Move empty check inside final iteration

### DIFF
--- a/evm/src/cpu/kernel/asm/memory/memcpy.asm
+++ b/evm/src/cpu/kernel/asm/memory/memcpy.asm
@@ -52,15 +52,6 @@ global memcpy:
 global memcpy_bytes:
     // stack: DST, SRC, count, retdest
 
-    // Handle empty case
-    DUP7
-    // stack: count, DST, SRC, count, retdest
-    ISZERO
-    // stack: count == 0, DST, SRC, count, retdest
-    %jumpi(memcpy_finish)
-
-    // stack: DST, SRC, count, retdest
-
     // Handle small case
     DUP7
     // stack: count, DST, SRC, count, retdest
@@ -102,6 +93,15 @@ global memcpy_bytes:
     %jump(memcpy_bytes)
 
 memcpy_bytes_finish:
+    // stack: DST, SRC, count, retdest
+
+    // Handle empty case
+    DUP7
+    // stack: count, DST, SRC, count, retdest
+    ISZERO
+    // stack: count == 0, DST, SRC, count, retdest
+    %jumpi(memcpy_finish)
+
     // stack: DST, SRC, count, retdest
 
     // Copy the last chunk of `count` bytes.


### PR DESCRIPTION
There are currently 2 checks on each loop iteration of `memcpy_bytes`:
- check whether the sequence is empty (needed as `BytePackingStark` expects non-empty sequences)
- check whether the sequence is smaller than 32 bytes (to do a final packing/unpacking combo and exit)

The latter can contain the former case, so that we don't need to check twice on every iteration.