### PR TITLE
Use `memcpy_bytes` whenever possible

### DIFF
--- a/evm/src/cpu/kernel/asm/core/call.asm
+++ b/evm/src/cpu/kernel/asm/core/call.asm
@@ -388,7 +388,7 @@ call_too_deep:
             args_size, %%after,                     // count, retdest
             new_ctx, args_size
         )
-    %jump(memcpy)
+    %jump(memcpy_bytes)
 %%after:
     %stack (new_ctx, args_size) ->
         (new_ctx, @SEGMENT_CONTEXT_METADATA, @CTX_METADATA_CALLDATA_SIZE, args_size)
@@ -410,7 +410,7 @@ call_too_deep:
             n, %%after,                     // count, retdest
             kexit_info, success
         )
-    %jump(memcpy)
+    %jump(memcpy_bytes)
 %%after:
 %endmacro
 

--- a/evm/src/cpu/kernel/asm/core/create.asm
+++ b/evm/src/cpu/kernel/asm/core/create.asm
@@ -104,7 +104,7 @@ global create_common:
             code_len,
             run_constructor,
             new_ctx, value, address)
-    %jump(memcpy)
+    %jump(memcpy_bytes)
 
 run_constructor:
     // stack: new_ctx, value, address, kexit_info

--- a/evm/src/cpu/kernel/asm/core/create_receipt.asm
+++ b/evm/src/cpu/kernel/asm/core/create_receipt.asm
@@ -82,7 +82,7 @@ process_receipt_after_type:
     PUSH 0 PUSH @SEGMENT_TXN_BLOOM PUSH 0 // Bloom memory address.
     %get_trie_data_size PUSH @SEGMENT_TRIE_DATA PUSH 0 // MPT dest address.
     // stack: DST, SRC, 256, receipt_ptr, txn_nb, new_cum_gas, txn_nb, num_nibbles, retdest
-    %memcpy
+    %memcpy_bytes
     // stack: receipt_ptr, txn_nb, new_cum_gas, txn_nb, num_nibbles, retdest
     // Update trie data size.
     %get_trie_data_size

--- a/evm/src/cpu/kernel/asm/core/precompiles/id.asm
+++ b/evm/src/cpu/kernel/asm/core/precompiles/id.asm
@@ -32,7 +32,7 @@ global precompile_id:
         ctx, @SEGMENT_CALLDATA, 0,  // SRC
         size, id_contd              // count, retdest
         )
-    %jump(memcpy)
+    %jump(memcpy_bytes)
 
 id_contd:
     // stack: kexit_info

--- a/evm/src/cpu/kernel/asm/core/precompiles/main.asm
+++ b/evm/src/cpu/kernel/asm/core/precompiles/main.asm
@@ -59,7 +59,7 @@ global handle_precompiles_from_eoa:
     %stack (calldata_size, new_ctx) -> (calldata_size, new_ctx, calldata_size)
     %set_new_ctx_calldata_size
     %stack (new_ctx, calldata_size) -> (new_ctx, @SEGMENT_CALLDATA, 0, 0, @SEGMENT_TXN_DATA, 0, calldata_size, handle_precompiles_from_eoa_finish, new_ctx)
-    %jump(memcpy)
+    %jump(memcpy_bytes)
 
 handle_precompiles_from_eoa_finish:
     %stack (new_ctx, addr, retdest) -> (addr, new_ctx, retdest)

--- a/evm/src/cpu/kernel/asm/core/precompiles/rip160.asm
+++ b/evm/src/cpu/kernel/asm/core/precompiles/rip160.asm
@@ -47,7 +47,7 @@ global precompile_rip160:
     PUSH @SEGMENT_KERNEL_GENERAL
     DUP3
 
-    %jump(memcpy)
+    %jump(memcpy_bytes)
 
 rip160_contd:
     // stack: hash, kexit_info

--- a/evm/src/cpu/kernel/asm/core/precompiles/sha256.asm
+++ b/evm/src/cpu/kernel/asm/core/precompiles/sha256.asm
@@ -49,7 +49,7 @@ global precompile_sha256:
     PUSH @SEGMENT_KERNEL_GENERAL
     DUP3
 
-    %jump(memcpy)
+    %jump(memcpy_bytes)
 
 sha256_contd:
     // stack: hash, kexit_info

--- a/evm/src/cpu/kernel/asm/core/process_txn.asm
+++ b/evm/src/cpu/kernel/asm/core/process_txn.asm
@@ -163,7 +163,7 @@ global process_contract_creation_txn:
     PUSH 0 // DST.offset
     PUSH @SEGMENT_CODE // DST.segment
     DUP8 // DST.context = new_ctx
-    %jump(memcpy)
+    %jump(memcpy_bytes)
 
 global process_contract_creation_txn_after_code_loaded:
     // stack: new_ctx, address, retdest
@@ -294,7 +294,7 @@ global process_message_txn_code_loaded:
     %stack (calldata_size, new_ctx, retdest) -> (calldata_size, new_ctx, calldata_size, retdest)
     %set_new_ctx_calldata_size
     %stack (new_ctx, calldata_size, retdest) -> (new_ctx, @SEGMENT_CALLDATA, 0, 0, @SEGMENT_TXN_DATA, 0, calldata_size, process_message_txn_code_loaded_finish, new_ctx, retdest)
-    %jump(memcpy)
+    %jump(memcpy_bytes)
 
 process_message_txn_code_loaded_finish:
     %enter_new_ctx

--- a/evm/src/cpu/kernel/asm/core/terminate.asm
+++ b/evm/src/cpu/kernel/asm/core/terminate.asm
@@ -45,7 +45,7 @@ return_after_gas:
         ctx, @SEGMENT_MAIN_MEMORY, offset,  // SRC
         size, sys_return_finish, kexit_info // count, retdest, ...
         )
-    %jump(memcpy)
+    %jump(memcpy_bytes)
 
 sys_return_finish:
     // stack: kexit_info
@@ -145,7 +145,7 @@ revert_after_gas:
         ctx, @SEGMENT_MAIN_MEMORY, offset,  // SRC
         size, sys_revert_finish, kexit_info // count, retdest, ...
         )
-    %jump(memcpy)
+    %jump(memcpy_bytes)
 
 sys_revert_finish:
     %leftover_gas

--- a/evm/src/cpu/kernel/asm/rlp/encode_rlp_string.asm
+++ b/evm/src/cpu/kernel/asm/rlp/encode_rlp_string.asm
@@ -33,7 +33,7 @@ global encode_rlp_string_small:
     // stack: pos'', pos', ADDR: 3, len, retdest
     %stack (pos2, pos1, ADDR: 3, len, retdest)
         -> (0, @SEGMENT_RLP_RAW, pos1, ADDR, len, retdest, pos2)
-    %jump(memcpy)
+    %jump(memcpy_bytes)
 
 global encode_rlp_string_small_single_byte:
     // stack: pos, ADDR: 3, len, retdest
@@ -71,7 +71,7 @@ global encode_rlp_string_large_after_writing_len:
     // stack: pos''', pos'', ADDR: 3, len, retdest
     %stack (pos3, pos2, ADDR: 3, len, retdest)
         -> (0, @SEGMENT_RLP_RAW, pos2, ADDR, len, retdest, pos3)
-    %jump(memcpy)
+    %jump(memcpy_bytes)
 
 %macro encode_rlp_string
     %stack (pos, ADDR: 3, len) -> (pos, ADDR, len, %%after)

--- a/evm/src/cpu/kernel/asm/transactions/common_decoding.asm
+++ b/evm/src/cpu/kernel/asm/transactions/common_decoding.asm
@@ -115,7 +115,7 @@
     PUSH @SEGMENT_TXN_DATA
     GET_CONTEXT
     // stack: DST, SRC, data_len, %%after, new_pos
-    %jump(memcpy)
+    %jump(memcpy_bytes)
 
 %%after:
     // stack: new_pos

--- a/evm/src/cpu/kernel/asm/transactions/type_1.asm
+++ b/evm/src/cpu/kernel/asm/transactions/type_1.asm
@@ -94,7 +94,7 @@ after_serializing_txn_data:
             al_len,
             after_serializing_access_list,
             rlp_pos, rlp_start, retdest)
-    %jump(memcpy)
+    %jump(memcpy_bytes)
 after_serializing_access_list:
     // stack: rlp_pos, rlp_start, retdest
     %mload_global_metadata(@GLOBAL_METADATA_ACCESS_LIST_RLP_LEN) ADD

--- a/evm/src/cpu/kernel/asm/transactions/type_2.asm
+++ b/evm/src/cpu/kernel/asm/transactions/type_2.asm
@@ -101,7 +101,7 @@ after_serializing_txn_data:
             al_len,
             after_serializing_access_list,
             rlp_pos, rlp_start, retdest)
-    %jump(memcpy)
+    %jump(memcpy_bytes)
 after_serializing_access_list:
     // stack: rlp_pos, rlp_start, retdest
     %mload_global_metadata(@GLOBAL_METADATA_ACCESS_LIST_RLP_LEN) ADD


### PR DESCRIPTION
Follow up from #1304, it seems that actually almost all calls to `memcpy` are dealing with bytes, for which we can then replace the macro call to `memcpy_bytes`.
Below are a few results before/after this change:

```asm
simple_transfer: (CPU -> 17.2% reduction)
Trace lengths (before padding): { arithmetic_len: 11629, byte_packing_len: 1863, cpu_len: 78144, keccak_len: 12072, keccak_sponge_len: 503, logic_len: 3549, memory_len: 300598 }
Trace lengths (before padding): { arithmetic_len: 10149, byte_packing_len: 2895, cpu_len: 64732, keccak_len: 12072, keccak_sponge_len: 503, logic_len: 3549, memory_len: 264874 }

add11_yml: (CPU -> 13.9% reduction)
{ arithmetic_len: 13856, byte_packing_len: 2491, cpu_len: 95679, keccak_len: 12384, keccak_sponge_len: 516, logic_len: 3772, memory_len: 346087 }
{ arithmetic_len: 12389, byte_packing_len: 3515, cpu_len: 82360, keccak_len: 12384, keccak_sponge_len: 516, logic_len: 3772, memory_len: 310595 }

log_opcode: (CPU -> 23.7% reduction)
{ arithmetic_len: 16647, byte_packing_len: 2814, cpu_len: 119949, keccak_len: 12504, keccak_sponge_len: 521, logic_len: 3796, memory_len: 412588 }
{ arithmetic_len: 13515, byte_packing_len: 5000, cpu_len: 91523, keccak_len: 12504, keccak_sponge_len: 521, logic_len: 3796, memory_len: 336846 }
```

The gains are even greater for specific scenarios like Ripemd / SHA256 precompiles. For instance for this pathological case below, this reduces the number of CPU cycles by 96% and memory by 93%.
```asm
CALLCODESha256_5_d0g0v0_Shanghai: (CPU -> 96% reduction)
{ arithmetic_len: 3013259, byte_packing_len: 2421, cpu_len: 27091042, keccak_len: 12504, keccak_sponge_len: 521, logic_len: 3719, memory_len: 74334498 }
{ arithmetic_len: 136794, byte_packing_len: 2003445, cpu_len: 1015171, keccak_len: 12480, keccak_sponge_len: 520, logic_len: 3714, memory_len: 4861092 }
```