### PR TITLE
Implement out of gas exception

### DIFF
--- a/evm/src/cpu/kernel/asm/core/exception.asm
+++ b/evm/src/cpu/kernel/asm/core/exception.asm
@@ -24,8 +24,31 @@ global exception_jumptable:
 
 
 global exc_out_of_gas:
-    // TODO
-    %jump(fault_exception)
+    // stack: trap_info
+    %ctx_gas_limit
+    // stack: gas_limit, trap_info
+    DUP2 %shr_const(192)
+    // stack: gas_used, gas_limit, trap_info
+    DUP2 DUP2
+    // stack: gas_used, gas_limit, gas_used, gas_limit, trap_info
+    // If gas_used is already over the limit, panic. The exception should have
+    // been raised earlier.
+    GT %jumpi(panic)
+    // stack: gas_used, gas_limit, trap_info
+    DUP3 %opcode_from_exp_trap_info
+    // stack: opcode, gas_used, gas_limit, trap_info
+    %add_const(gas_cost_for_opcode)
+    %mload_kernel_code
+    // stack: gas_cost, gas_used, gas_limit, trap_info
+    ADD
+    // stack: new_gas_used, gas_limit, trap_info
+    GT
+    // stack: is_oog, trap_info
+    SWAP1 POP
+    // stack: is_oog
+    %jumpi(fault_exception)
+    // If we didn't jump, we shouldn't have raised the exception.
+    PANIC
 
 
 global exc_invalid_opcode:
@@ -297,3 +320,110 @@ min_stack_len_for_opcode:
     BYTES 2  // 0xfd, REVERT
     BYTES 0  // 0xfe, invalid
     BYTES 1  // 0xff, SELFDESTRUCT
+
+// A zero indicates either that the opcode is kernel-only,
+// or that it's handled with a syscall.
+gas_cost_for_opcode:
+    BYTES 0  // 0x00, STOP
+    BYTES 3  // 0x01, ADD
+    BYTES 5  // 0x02, MUL
+    BYTES 3  // 0x03, SUB
+    BYTES 5  // 0x04, DIV
+    BYTES 5  // 0x05, SDIV
+    BYTES 5  // 0x06, MOD
+    BYTES 5  // 0x07, SMOD
+    BYTES 8  // 0x08, ADDMOD
+    BYTES 8  // 0x09, MULMOD
+    BYTES 0  // 0x0a, EXP
+    BYTES 0  // 0x0b, SIGNEXTEND
+    %rep 4  // 0x0c-0x0f, invalid
+        BYTES 0
+    %endrep
+
+    BYTES 3  // 0x10, LT
+    BYTES 3  // 0x11, GT
+    BYTES 3  // 0x12, SLT
+    BYTES 3  // 0x13, SGT
+    BYTES 3  // 0x14, EQ
+    BYTES 3  // 0x15, ISZERO
+    BYTES 3  // 0x16, AND
+    BYTES 3  // 0x17, OR
+    BYTES 3  // 0x18, XOR
+    BYTES 3  // 0x19, NOT
+    BYTES 3  // 0x1a, BYTE
+    BYTES 3  // 0x1b, SHL
+    BYTES 3  // 0x1c, SHR
+    BYTES 3  // 0x1d, SAR
+    BYTES 0  // 0x1e, invalid
+    BYTES 0  // 0x1f, invalid
+
+    BYTES 0  // 0x20, KECCAK256
+    %rep 15 // 0x21-0x2f, invalid
+        BYTES 0
+    %endrep
+
+    %rep 25 //0x30-0x48, only syscalls
+    BYTES 0  
+    %endrep
+
+    %rep 7  // 0x49-0x4f, invalid
+        BYTES 0
+    %endrep
+
+    BYTES 2  // 0x50, POP
+    BYTES 0  // 0x51, MLOAD
+    BYTES 0  // 0x52, MSTORE
+    BYTES 0  // 0x53, MSTORE8
+    BYTES 0  // 0x54, SLOAD
+    BYTES 0  // 0x55, SSTORE
+    BYTES 8  // 0x56, JUMP
+    BYTES 10  // 0x57, JUMPI
+    BYTES 2  // 0x58, PC
+    BYTES 0  // 0x59, MSIZE
+    BYTES 0  // 0x5a, GAS
+    BYTES 1  // 0x5b, JUMPDEST
+    %rep 3  // 0x5c-0x5e, invalid
+        BYTES 0
+    %endrep
+
+    BYTES 2 // 0x5f, PUSH0
+    %rep 32 // 0x60-0x7f, PUSH1-PUSH32
+        BYTES 3
+    %endrep
+
+    %rep 16 // 0x80-0x8f, DUP1-DUP16
+        BYTES 3
+    %endrep
+
+    %rep 16 // 0x90-0x9f, SWAP1-SWAP16
+        BYTES 3
+    %endrep
+
+    BYTES 0  // 0xa0, LOG0
+    BYTES 0  // 0xa1, LOG1
+    BYTES 0  // 0xa2, LOG2
+    BYTES 0  // 0xa3, LOG3
+    BYTES 0  // 0xa4, LOG4
+    %rep 11 // 0xa5-0xaf, invalid
+        BYTES 0
+    %endrep
+
+    %rep 64 // 0xb0-0xef, invalid
+        BYTES 0
+    %endrep
+
+    BYTES 0  // 0xf0, CREATE
+    BYTES 0  // 0xf1, CALL
+    BYTES 0  // 0xf2, CALLCODE
+    BYTES 0  // 0xf3, RETURN
+    BYTES 0  // 0xf4, DELEGATECALL
+    BYTES 0  // 0xf5, CREATE2
+    %rep 4  // 0xf6-0xf9, invalid
+        BYTES 0
+    %endrep
+    BYTES 0  // 0xfa, STATICCALL
+    BYTES 0  // 0xfb, invalid
+    BYTES 0  // 0xfc, invalid
+    BYTES 0  // 0xfd, REVERT
+    BYTES 0  // 0xfe, invalid
+    BYTES 0  // 0xff, SELFDESTRUCT

--- a/evm/src/cpu/kernel/asm/core/exception.asm
+++ b/evm/src/cpu/kernel/asm/core/exception.asm
@@ -325,35 +325,35 @@ min_stack_len_for_opcode:
 // or that it's handled with a syscall.
 gas_cost_for_opcode:
     BYTES 0  // 0x00, STOP
-    BYTES 3  // 0x01, ADD
-    BYTES 5  // 0x02, MUL
-    BYTES 3  // 0x03, SUB
-    BYTES 5  // 0x04, DIV
-    BYTES 5  // 0x05, SDIV
-    BYTES 5  // 0x06, MOD
-    BYTES 5  // 0x07, SMOD
-    BYTES 8  // 0x08, ADDMOD
-    BYTES 8  // 0x09, MULMOD
+    BYTES @GAS_VERYLOW  // 0x01, ADD
+    BYTES @GAS_LOW  // 0x02, MUL
+    BYTES @GAS_VERYLOW  // 0x03, SUB
+    BYTES @GAS_LOW  // 0x04, DIV
+    BYTES @GAS_LOW  // 0x05, SDIV
+    BYTES @GAS_LOW  // 0x06, MOD
+    BYTES @GAS_LOW  // 0x07, SMOD
+    BYTES @GAS_MID  // 0x08, ADDMOD
+    BYTES @GAS_MID  // 0x09, MULMOD
     BYTES 0  // 0x0a, EXP
     BYTES 0  // 0x0b, SIGNEXTEND
     %rep 4  // 0x0c-0x0f, invalid
         BYTES 0
     %endrep
 
-    BYTES 3  // 0x10, LT
-    BYTES 3  // 0x11, GT
-    BYTES 3  // 0x12, SLT
-    BYTES 3  // 0x13, SGT
-    BYTES 3  // 0x14, EQ
-    BYTES 3  // 0x15, ISZERO
-    BYTES 3  // 0x16, AND
-    BYTES 3  // 0x17, OR
-    BYTES 3  // 0x18, XOR
-    BYTES 3  // 0x19, NOT
-    BYTES 3  // 0x1a, BYTE
-    BYTES 3  // 0x1b, SHL
-    BYTES 3  // 0x1c, SHR
-    BYTES 3  // 0x1d, SAR
+    BYTES @GAS_VERYLOW  // 0x10, LT
+    BYTES @GAS_VERYLOW  // 0x11, GT
+    BYTES @GAS_VERYLOW  // 0x12, SLT
+    BYTES @GAS_VERYLOW  // 0x13, SGT
+    BYTES @GAS_VERYLOW  // 0x14, EQ
+    BYTES @GAS_VERYLOW  // 0x15, ISZERO
+    BYTES @GAS_VERYLOW  // 0x16, AND
+    BYTES @GAS_VERYLOW  // 0x17, OR
+    BYTES @GAS_VERYLOW  // 0x18, XOR
+    BYTES @GAS_VERYLOW  // 0x19, NOT
+    BYTES @GAS_VERYLOW  // 0x1a, BYTE
+    BYTES @GAS_VERYLOW  // 0x1b, SHL
+    BYTES @GAS_VERYLOW  // 0x1c, SHR
+    BYTES @GAS_VERYLOW  // 0x1d, SAR
     BYTES 0  // 0x1e, invalid
     BYTES 0  // 0x1f, invalid
 
@@ -370,33 +370,33 @@ gas_cost_for_opcode:
         BYTES 0
     %endrep
 
-    BYTES 2  // 0x50, POP
+    BYTES @GAS_BASE  // 0x50, POP
     BYTES 0  // 0x51, MLOAD
     BYTES 0  // 0x52, MSTORE
     BYTES 0  // 0x53, MSTORE8
     BYTES 0  // 0x54, SLOAD
     BYTES 0  // 0x55, SSTORE
-    BYTES 8  // 0x56, JUMP
-    BYTES 10  // 0x57, JUMPI
-    BYTES 2  // 0x58, PC
+    BYTES @GAS_MID  // 0x56, JUMP
+    BYTES @GAS_HIGH  // 0x57, JUMPI
+    BYTES @GAS_BASE  // 0x58, PC
     BYTES 0  // 0x59, MSIZE
     BYTES 0  // 0x5a, GAS
-    BYTES 1  // 0x5b, JUMPDEST
+    BYTES @GAS_JUMPDEST  // 0x5b, JUMPDEST
     %rep 3  // 0x5c-0x5e, invalid
         BYTES 0
     %endrep
 
-    BYTES 2 // 0x5f, PUSH0
+    BYTES @GAS_BASE // 0x5f, PUSH0
     %rep 32 // 0x60-0x7f, PUSH1-PUSH32
-        BYTES 3
+        BYTES @GAS_VERYLOW
     %endrep
 
     %rep 16 // 0x80-0x8f, DUP1-DUP16
-        BYTES 3
+        BYTES @GAS_VERYLOW
     %endrep
 
     %rep 16 // 0x90-0x9f, SWAP1-SWAP16
-        BYTES 3
+        BYTES @GAS_VERYLOW
     %endrep
 
     BYTES 0  // 0xa0, LOG0

--- a/evm/src/cpu/kernel/assembler.rs
+++ b/evm/src/cpu/kernel/assembler.rs
@@ -411,10 +411,6 @@ fn assemble_file(
                         BytesTarget::Constant(c) => panic!("Constant wasn't inlined: {c}"),
                     }
                 }
-                // let bytes: Vec<u8> = targets.iter().map(|target| match target {
-                //     BytesTarget::Literal(n) => u256_to_trimmed_be_bytes(&n),
-                //     BytesTarget::Constant(c) => panic!("Constant wasn't inlined: {c}"),
-                // }).collect()
             }
             Item::Jumptable(labels) => {
                 for label in labels {

--- a/evm/src/cpu/kernel/ast.rs
+++ b/evm/src/cpu/kernel/ast.rs
@@ -33,7 +33,7 @@ pub(crate) enum Item {
     /// Any opcode besides a PUSH opcode.
     StandardOp(String),
     /// Literal hex data; should contain an even number of hex chars.
-    Bytes(Vec<u8>),
+    Bytes(Vec<BytesTarget>),
     /// Creates a table of addresses from a list of labels.
     Jumptable(Vec<String>),
 }
@@ -73,5 +73,12 @@ pub(crate) enum PushTarget {
     Label(String),
     MacroLabel(String),
     MacroVar(String),
+    Constant(String),
+}
+
+/// The target of a `BYTES` item.
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
+pub(crate) enum BytesTarget {
+    Literal(u8),
     Constant(String),
 }

--- a/evm/src/cpu/kernel/evm_asm.pest
+++ b/evm/src/cpu/kernel/evm_asm.pest
@@ -34,7 +34,8 @@ local_label_decl = ${ identifier ~ ":" }
 macro_label_decl = ${ "%%" ~ identifier ~ ":" }
 macro_label = ${ "%%" ~ identifier }
 
-bytes_item = { ^"BYTES " ~ literal ~ ("," ~ literal)* }
+bytes_item = { ^"BYTES " ~ bytes_target ~ ("," ~ bytes_target)* }
+bytes_target = { literal | constant }
 jumptable_item = { ^"JUMPTABLE " ~ identifier ~ ("," ~ identifier)* }
 push_instruction = { ^"PUSH " ~ push_target }
 push_target = { literal | identifier | macro_label | variable | constant }


### PR DESCRIPTION
Closes https://github.com/0xPolygonZero/plonky2/issues/1298

It's only been tested with William's (corrected) infinite loop test, but it passes fine.

One issue is the `gas_cost_for_opcode` table in the kernel. It should use the gas constants (`@GAS_VERYLOW` etc.) but apparently the parser doesn't like anything else than literals after the `BYTES` keyword. @wborgeaud Would you happen to know how to get around it? 