### PR TITLE
restore `no-std` support

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -29,6 +29,7 @@ jobs:
           profile: minimal
           toolchain: nightly
           target: ${{ matrix.target }}
+          default: true
           override: true
 
       - name: rust-cache

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -10,11 +10,14 @@ on:
     branches:
       - "**"
 
-jobs:  
+jobs:
   test:
     name: Test Suite
     runs-on: ubuntu-latest
     if: "! contains(toJSON(github.event.commits.*.message), '[skip-ci]')"
+    strategy:
+      matrix:
+        target: [x86_64-unknown-linux-gnu, wasm32-unknown-unknown]
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
@@ -25,6 +28,7 @@ jobs:
         with:
           profile: minimal
           toolchain: nightly
+          target: ${{ matrix.target }}
           override: true
 
       - name: rust-cache

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -66,7 +66,7 @@ jobs:
           RUST_BACKTRACE: 1
 
       - name: Check in evm subdirectory
-        if: ${{ matrix.target != wasm32-unknown-unknown }}
+        if: ${{ matrix.target != "wasm32-unknown-unknown" }}
         uses: actions-rs/cargo@v1
         with:
           command: check
@@ -78,6 +78,7 @@ jobs:
           RUST_BACKTRACE: 1
 
       - name: Run cargo test
+        if: ${{ matrix.target != "wasm32-unknown-unknown" }}
         uses: actions-rs/cargo@v1
         with:
           command: test

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -15,9 +15,6 @@ jobs:
     name: Test Suite
     runs-on: ubuntu-latest
     if: "! contains(toJSON(github.event.commits.*.message), '[skip-ci]')"
-    strategy:
-      matrix:
-        target: [x86_64-unknown-linux-gnu, wasm32-unknown-unknown]
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
@@ -28,8 +25,6 @@ jobs:
         with:
           profile: minimal
           toolchain: nightly
-          target: ${{ matrix.target }}
-          default: true
           override: true
 
       - name: rust-cache
@@ -47,7 +42,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: check
-          args: --manifest-path plonky2/Cargo.toml --target ${{ matrix.target }}
+          args: --manifest-path plonky2/Cargo.toml
         env:
           RUSTFLAGS: -Copt-level=3 -Cdebug-assertions -Coverflow-checks=y -Cdebuginfo=0
           RUST_LOG: 1
@@ -58,7 +53,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: check
-          args: --manifest-path starky/Cargo.toml --target ${{ matrix.target }}
+          args: --manifest-path starky/Cargo.toml
         env:
           RUSTFLAGS: -Copt-level=3 -Cdebug-assertions -Coverflow-checks=y -Cdebuginfo=0
           RUST_LOG: 1
@@ -66,7 +61,6 @@ jobs:
           RUST_BACKTRACE: 1
 
       - name: Check in evm subdirectory
-        if: ${{ matrix.target != 'wasm32-unknown-unknown' }}
         uses: actions-rs/cargo@v1
         with:
           command: check
@@ -78,11 +72,59 @@ jobs:
           RUST_BACKTRACE: 1
 
       - name: Run cargo test
-        if: ${{ matrix.target != 'wasm32-unknown-unknown' }}
         uses: actions-rs/cargo@v1
         with:
           command: test
           args: --workspace
+        env:
+          RUSTFLAGS: -Copt-level=3 -Cdebug-assertions -Coverflow-checks=y -Cdebuginfo=0
+          RUST_LOG: 1
+          CARGO_INCREMENTAL: 1
+          RUST_BACKTRACE: 1
+
+  wasm32:
+    name: wasm32 compatibility
+    runs-on: ubuntu-latest
+    if: "! contains(toJSON(github.event.commits.*.message), '[skip-ci]')"
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+      - name: Install nightly wasm32 toolchain
+        id: rustc-toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly
+          target: wasm32-unknown-unknown
+          default: true
+          override: true
+      - name: rust-cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: rustc-wasm32-${{ steps.rustc-toolchain.outputs.rustc_hash }}-cargo-${{ hashFiles('**/Cargo.toml') }}
+
+      - name: Check in plonky2 subdirectory
+        uses: actions-rs/cargo@v1
+        with:
+          command: check
+          args: --manifest-path plonky2/Cargo.toml --target wasm32-unknown-unknown
+        env:
+          RUSTFLAGS: -Copt-level=3 -Cdebug-assertions -Coverflow-checks=y -Cdebuginfo=0
+          RUST_LOG: 1
+          CARGO_INCREMENTAL: 1
+          RUST_BACKTRACE: 1
+
+      - name: Check in starky subdirectory
+        uses: actions-rs/cargo@v1
+        with:
+          command: check
+          args: --manifest-path starky/Cargo.toml --target wasm32-unknown-unknown
         env:
           RUSTFLAGS: -Copt-level=3 -Cdebug-assertions -Coverflow-checks=y -Cdebuginfo=0
           RUST_LOG: 1

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -66,7 +66,7 @@ jobs:
           RUST_BACKTRACE: 1
 
       - name: Check in evm subdirectory
-        if: ${{ matrix.target != "wasm32-unknown-unknown" }}
+        if: ${{ matrix.target != 'wasm32-unknown-unknown' }}
         uses: actions-rs/cargo@v1
         with:
           command: check
@@ -78,7 +78,7 @@ jobs:
           RUST_BACKTRACE: 1
 
       - name: Run cargo test
-        if: ${{ matrix.target != "wasm32-unknown-unknown" }}
+        if: ${{ matrix.target != 'wasm32-unknown-unknown' }}
         uses: actions-rs/cargo@v1
         with:
           command: test

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -89,6 +89,7 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
+
       - name: Install nightly wasm32 toolchain
         id: rustc-toolchain
         uses: actions-rs/toolchain@v1
@@ -98,6 +99,7 @@ jobs:
           target: wasm32-unknown-unknown
           default: true
           override: true
+
       - name: rust-cache
         uses: actions/cache@v3
         with:
@@ -113,7 +115,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: check
-          args: --manifest-path plonky2/Cargo.toml --target wasm32-unknown-unknown
+          args: --manifest-path plonky2/Cargo.toml --target wasm32-unknown-unknown --no-default-features
         env:
           RUSTFLAGS: -Copt-level=3 -Cdebug-assertions -Coverflow-checks=y -Cdebuginfo=0
           RUST_LOG: 1
@@ -124,7 +126,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: check
-          args: --manifest-path starky/Cargo.toml --target wasm32-unknown-unknown
+          args: --manifest-path starky/Cargo.toml --target wasm32-unknown-unknown --no-default-features
         env:
           RUSTFLAGS: -Copt-level=3 -Cdebug-assertions -Coverflow-checks=y -Cdebuginfo=0
           RUST_LOG: 1

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -47,7 +47,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: check
-          args: --manifest-path plonky2/Cargo.toml
+          args: --manifest-path plonky2/Cargo.toml --target ${{ matrix.target }}
         env:
           RUSTFLAGS: -Copt-level=3 -Cdebug-assertions -Coverflow-checks=y -Cdebuginfo=0
           RUST_LOG: 1
@@ -58,7 +58,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: check
-          args: --manifest-path starky/Cargo.toml
+          args: --manifest-path starky/Cargo.toml --target ${{ matrix.target }}
         env:
           RUSTFLAGS: -Copt-level=3 -Cdebug-assertions -Coverflow-checks=y -Cdebuginfo=0
           RUST_LOG: 1

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -65,6 +65,7 @@ jobs:
           RUST_BACKTRACE: 1
 
       - name: Check in evm subdirectory
+        if: ${{ matrix.target != wasm32-unknown-unknown }}
         uses: actions-rs/cargo@v1
         with:
           command: check

--- a/plonky2/src/gadgets/arithmetic.rs
+++ b/plonky2/src/gadgets/arithmetic.rs
@@ -1,3 +1,4 @@
+use alloc::string::{String, ToString};
 use alloc::vec;
 use alloc::vec::Vec;
 use core::borrow::Borrow;

--- a/plonky2/src/gadgets/arithmetic_extension.rs
+++ b/plonky2/src/gadgets/arithmetic_extension.rs
@@ -1,3 +1,4 @@
+use alloc::string::{String, ToString};
 use alloc::vec;
 use alloc::vec::Vec;
 use core::borrow::Borrow;

--- a/plonky2/src/gadgets/lookup.rs
+++ b/plonky2/src/gadgets/lookup.rs
@@ -1,3 +1,6 @@
+use alloc::borrow::ToOwned;
+use alloc::vec;
+
 use crate::field::extension::Extendable;
 use crate::gates::lookup::LookupGate;
 use crate::gates::lookup_table::{LookupTable, LookupTableGate};

--- a/plonky2/src/gadgets/range_check.rs
+++ b/plonky2/src/gadgets/range_check.rs
@@ -1,3 +1,4 @@
+use alloc::string::{String, ToString};
 use alloc::vec;
 use alloc::vec::Vec;
 

--- a/plonky2/src/gadgets/split_base.rs
+++ b/plonky2/src/gadgets/split_base.rs
@@ -1,3 +1,4 @@
+use alloc::string::{String, ToString};
 use alloc::vec;
 use alloc::vec::Vec;
 use core::borrow::Borrow;

--- a/plonky2/src/gadgets/split_join.rs
+++ b/plonky2/src/gadgets/split_join.rs
@@ -1,3 +1,4 @@
+use alloc::string::{String, ToString};
 use alloc::vec;
 use alloc::vec::Vec;
 

--- a/plonky2/src/gates/arithmetic_base.rs
+++ b/plonky2/src/gates/arithmetic_base.rs
@@ -1,5 +1,5 @@
 use alloc::format;
-use alloc::string::String;
+use alloc::string::{String, ToString};
 use alloc::vec::Vec;
 
 use crate::field::extension::Extendable;

--- a/plonky2/src/gates/arithmetic_extension.rs
+++ b/plonky2/src/gates/arithmetic_extension.rs
@@ -1,5 +1,5 @@
 use alloc::format;
-use alloc::string::String;
+use alloc::string::{String, ToString};
 use alloc::vec::Vec;
 use core::ops::Range;
 

--- a/plonky2/src/gates/base_sum.rs
+++ b/plonky2/src/gates/base_sum.rs
@@ -1,4 +1,4 @@
-use alloc::string::String;
+use alloc::string::{String, ToString};
 use alloc::vec::Vec;
 use alloc::{format, vec};
 use core::ops::Range;

--- a/plonky2/src/gates/coset_interpolation.rs
+++ b/plonky2/src/gates/coset_interpolation.rs
@@ -1,4 +1,4 @@
-use alloc::string::String;
+use alloc::string::{String, ToString};
 use alloc::vec::Vec;
 use alloc::{format, vec};
 use core::marker::PhantomData;
@@ -631,8 +631,6 @@ fn partial_interpolate_ext_algebra_target<F: RichField + Extendable<D>, const D:
 
 #[cfg(test)]
 mod tests {
-    use core::iter::repeat_with;
-
     use anyhow::Result;
     use plonky2_field::polynomial::PolynomialValues;
     use plonky2_util::log2_strict;
@@ -832,7 +830,7 @@ mod tests {
 
         // Get a working row for InterpolationGate.
         let shift = F::rand();
-        let values = PolynomialValues::new(repeat_with(FF::rand).take(4).collect());
+        let values = PolynomialValues::new(core::iter::repeat_with(FF::rand).take(4).collect());
         let eval_point = FF::rand();
         let gate = CosetInterpolationGate::<F, D>::with_max_degree(2, 3);
         let vars = EvaluationVars {

--- a/plonky2/src/gates/exponentiation.rs
+++ b/plonky2/src/gates/exponentiation.rs
@@ -1,4 +1,4 @@
-use alloc::string::String;
+use alloc::string::{String, ToString};
 use alloc::vec::Vec;
 use alloc::{format, vec};
 use core::marker::PhantomData;

--- a/plonky2/src/gates/lookup.rs
+++ b/plonky2/src/gates/lookup.rs
@@ -1,6 +1,6 @@
-use alloc::format;
-use alloc::string::String;
+use alloc::string::{String, ToString};
 use alloc::vec::Vec;
+use alloc::{format, vec};
 use core::usize;
 
 use itertools::Itertools;

--- a/plonky2/src/gates/lookup_table.rs
+++ b/plonky2/src/gates/lookup_table.rs
@@ -1,7 +1,7 @@
-use alloc::format;
-use alloc::string::String;
+use alloc::string::{String, ToString};
 use alloc::sync::Arc;
 use alloc::vec::Vec;
+use alloc::{format, vec};
 use core::usize;
 
 use itertools::Itertools;

--- a/plonky2/src/gates/multiplication_extension.rs
+++ b/plonky2/src/gates/multiplication_extension.rs
@@ -1,5 +1,5 @@
 use alloc::format;
-use alloc::string::String;
+use alloc::string::{String, ToString};
 use alloc::vec::Vec;
 use core::ops::Range;
 

--- a/plonky2/src/gates/poseidon.rs
+++ b/plonky2/src/gates/poseidon.rs
@@ -1,4 +1,4 @@
-use alloc::string::String;
+use alloc::string::{String, ToString};
 use alloc::vec::Vec;
 use alloc::{format, vec};
 use core::marker::PhantomData;

--- a/plonky2/src/gates/poseidon_mds.rs
+++ b/plonky2/src/gates/poseidon_mds.rs
@@ -1,4 +1,4 @@
-use alloc::string::String;
+use alloc::string::{String, ToString};
 use alloc::vec::Vec;
 use alloc::{format, vec};
 use core::marker::PhantomData;

--- a/plonky2/src/gates/random_access.rs
+++ b/plonky2/src/gates/random_access.rs
@@ -1,4 +1,4 @@
-use alloc::string::String;
+use alloc::string::{String, ToString};
 use alloc::vec::Vec;
 use alloc::{format, vec};
 use core::marker::PhantomData;

--- a/plonky2/src/gates/reducing.rs
+++ b/plonky2/src/gates/reducing.rs
@@ -1,4 +1,4 @@
-use alloc::string::String;
+use alloc::string::{String, ToString};
 use alloc::vec::Vec;
 use alloc::{format, vec};
 use core::ops::Range;

--- a/plonky2/src/gates/reducing_extension.rs
+++ b/plonky2/src/gates/reducing_extension.rs
@@ -1,4 +1,4 @@
-use alloc::string::String;
+use alloc::string::{String, ToString};
 use alloc::vec::Vec;
 use alloc::{format, vec};
 use core::ops::Range;

--- a/plonky2/src/hash/hashing.rs
+++ b/plonky2/src/hash/hashing.rs
@@ -2,7 +2,6 @@
 
 use alloc::vec::Vec;
 use core::fmt::Debug;
-use std::iter::repeat;
 
 use crate::field::extension::Extendable;
 use crate::field::types::Field;
@@ -34,7 +33,7 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
         num_outputs: usize,
     ) -> Vec<Target> {
         let zero = self.zero();
-        let mut state = H::AlgebraicPermutation::new(std::iter::repeat(zero));
+        let mut state = H::AlgebraicPermutation::new(core::iter::repeat(zero));
 
         // Absorb all input chunks.
         for input_chunk in inputs.chunks(H::AlgebraicPermutation::RATE) {
@@ -71,7 +70,7 @@ pub trait PlonkyPermutation<T: Copy + Default>:
     /// received; remaining state (if any) initialised with
     /// `T::default()`. To initialise remaining elements with a
     /// different value, instead of your original `iter` pass
-    /// `iter.chain(std::iter::repeat(F::from_canonical_u64(12345)))`
+    /// `iter.chain(core::iter::repeat(F::from_canonical_u64(12345)))`
     /// or similar.
     fn new<I: IntoIterator<Item = T>>(iter: I) -> Self;
 
@@ -103,7 +102,7 @@ pub fn compress<F: Field, P: PlonkyPermutation<F>>(x: HashOut<F>, y: HashOut<F>)
     debug_assert_eq!(y.elements.len(), NUM_HASH_OUT_ELTS);
     debug_assert!(P::RATE >= NUM_HASH_OUT_ELTS);
 
-    let mut perm = P::new(repeat(F::ZERO));
+    let mut perm = P::new(core::iter::repeat(F::ZERO));
     perm.set_from_slice(&x.elements, 0);
     perm.set_from_slice(&y.elements, NUM_HASH_OUT_ELTS);
 
@@ -120,7 +119,7 @@ pub fn hash_n_to_m_no_pad<F: RichField, P: PlonkyPermutation<F>>(
     inputs: &[F],
     num_outputs: usize,
 ) -> Vec<F> {
-    let mut perm = P::new(repeat(F::ZERO));
+    let mut perm = P::new(core::iter::repeat(F::ZERO));
 
     // Absorb all input chunks.
     for input_chunk in inputs.chunks(P::RATE) {

--- a/plonky2/src/hash/keccak.rs
+++ b/plonky2/src/hash/keccak.rs
@@ -1,6 +1,5 @@
 use alloc::vec;
 use alloc::vec::Vec;
-use core::iter;
 use core::mem::size_of;
 
 use itertools::Itertools;
@@ -68,7 +67,7 @@ impl<F: RichField> PlonkyPermutation<F> for KeccakPermutation<F> {
                 .copy_from_slice(&self.state[i].to_canonical_u64().to_le_bytes());
         }
 
-        let hash_onion = iter::repeat_with(|| {
+        let hash_onion = core::iter::repeat_with(|| {
             let output = keccak(state_bytes.clone()).to_fixed_bytes();
             state_bytes = output.to_vec();
             output

--- a/plonky2/src/hash/merkle_proofs.rs
+++ b/plonky2/src/hash/merkle_proofs.rs
@@ -132,7 +132,7 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
             perm_inputs.set_from_slice(&state.elements, 0);
             perm_inputs.set_from_slice(&sibling.elements, NUM_HASH_OUT_ELTS);
             // Ensure the rest of the state, if any, is zero:
-            perm_inputs.set_from_iter(std::iter::repeat(zero), 2 * NUM_HASH_OUT_ELTS);
+            perm_inputs.set_from_iter(core::iter::repeat(zero), 2 * NUM_HASH_OUT_ELTS);
             let perm_outs = self.permute_swapped::<H>(perm_inputs, bit);
             let hash_outs = perm_outs.squeeze()[0..NUM_HASH_OUT_ELTS]
                 .try_into()

--- a/plonky2/src/hash/poseidon.rs
+++ b/plonky2/src/hash/poseidon.rs
@@ -3,7 +3,7 @@
 
 use alloc::vec;
 use alloc::vec::Vec;
-use std::fmt::Debug;
+use core::fmt::Debug;
 
 use unroll::unroll_for_loops;
 

--- a/plonky2/src/iop/challenger.rs
+++ b/plonky2/src/iop/challenger.rs
@@ -30,7 +30,7 @@ pub struct Challenger<F: RichField, H: Hasher<F>> {
 impl<F: RichField, H: Hasher<F>> Challenger<F, H> {
     pub fn new() -> Challenger<F, H> {
         Challenger {
-            sponge_state: H::Permutation::new(std::iter::repeat(F::ZERO)),
+            sponge_state: H::Permutation::new(core::iter::repeat(F::ZERO)),
             input_buffer: Vec::with_capacity(H::Permutation::RATE),
             output_buffer: Vec::with_capacity(H::Permutation::RATE),
         }
@@ -175,7 +175,7 @@ impl<F: RichField + Extendable<D>, H: AlgebraicHasher<F>, const D: usize>
     pub fn new(builder: &mut CircuitBuilder<F, D>) -> Self {
         let zero = builder.zero();
         Self {
-            sponge_state: H::AlgebraicPermutation::new(std::iter::repeat(zero)),
+            sponge_state: H::AlgebraicPermutation::new(core::iter::repeat(zero)),
             input_buffer: Vec::new(),
             output_buffer: Vec::new(),
             __: PhantomData,

--- a/plonky2/src/iop/generator.rs
+++ b/plonky2/src/iop/generator.rs
@@ -1,3 +1,5 @@
+use alloc::boxed::Box;
+use alloc::string::{String, ToString};
 use alloc::vec;
 use alloc::vec::Vec;
 use core::fmt::Debug;

--- a/plonky2/src/lib.rs
+++ b/plonky2/src/lib.rs
@@ -2,7 +2,7 @@
 #![allow(clippy::needless_range_loop)]
 #![cfg_attr(not(feature = "std"), no_std)]
 
-extern crate alloc;
+pub extern crate alloc;
 
 #[doc(inline)]
 pub use plonky2_field as field;

--- a/plonky2/src/recursion/cyclic_recursion.rs
+++ b/plonky2/src/recursion/cyclic_recursion.rs
@@ -1,5 +1,7 @@
 #![allow(clippy::int_plus_one)] // Makes more sense for some inequalities below.
 
+use alloc::vec::Vec;
+
 use anyhow::{ensure, Result};
 
 use crate::field::extension::Extendable;

--- a/plonky2/src/recursion/dummy_circuit.rs
+++ b/plonky2/src/recursion/dummy_circuit.rs
@@ -1,3 +1,4 @@
+use alloc::string::{String, ToString};
 use alloc::vec;
 use alloc::vec::Vec;
 

--- a/plonky2/src/util/serialization/gate_serialization.rs
+++ b/plonky2/src/util/serialization/gate_serialization.rs
@@ -76,7 +76,7 @@ macro_rules! impl_gate_serializer {
 
         fn write_gate(
             &self,
-            buf: &mut Vec<u8>,
+            buf: &mut $crate::alloc::vec::Vec<u8>,
             gate: &$crate::gates::gate::GateRef<F, D>,
             common: &$crate::plonk::circuit_data::CommonCircuitData<F, D>,
         ) -> $crate::util::serialization::IoResult<()> {

--- a/plonky2/src/util/serialization/gate_serialization.rs
+++ b/plonky2/src/util/serialization/gate_serialization.rs
@@ -1,3 +1,7 @@
+//! A module to help with GateRef serialization
+
+use alloc::vec::Vec;
+
 use plonky2_field::extension::Extendable;
 
 use crate::gates::gate::GateRef;
@@ -44,7 +48,11 @@ macro_rules! get_gate_tag_impl {
             Ok(tag)
         } else)*
         {
-            log::log!(log::Level::Error, "attempted to serialize gate with id `{}` which is unsupported by this gate serializer", $gate.0.id());
+            log::log!(
+                log::Level::Error,
+                "attempted to serialize gate with id `{}` which is unsupported by this gate serializer",
+                $gate.0.id()
+            );
             Err($crate::util::serialization::IoError)
         }
     }};

--- a/plonky2/src/util/serialization/generator_serialization.rs
+++ b/plonky2/src/util/serialization/generator_serialization.rs
@@ -1,5 +1,7 @@
 //! A module to help with WitnessGeneratorRef serialization
 
+use alloc::vec::Vec;
+
 use plonky2_field::extension::Extendable;
 
 use crate::hash::hash_types::RichField;
@@ -50,7 +52,11 @@ macro_rules! get_generator_tag_impl {
             Ok(tag)
         } else)*
         {
-            log::log!(log::Level::Error, "attempted to serialize generator with id {} which is unsupported by this generator serializer", $generator.0.id());
+            log::log!(
+                log::Level::Error,
+                "attempted to serialize generator with id {} which is unsupported by this generator serializer",
+                $generator.0.id()
+            );
             Err($crate::util::serialization::IoError)
         }
     }};

--- a/plonky2/src/util/serialization/generator_serialization.rs
+++ b/plonky2/src/util/serialization/generator_serialization.rs
@@ -80,7 +80,7 @@ macro_rules! impl_generator_serializer {
 
         fn write_generator(
             &self,
-            buf: &mut Vec<u8>,
+            buf: &mut $crate::alloc::vec::Vec<u8>,
             generator: &$crate::iop::generator::WitnessGeneratorRef<F, D>,
             common: &$crate::plonk::circuit_data::CommonCircuitData<F, D>,
         ) -> $crate::util::serialization::IoResult<()> {

--- a/plonky2/src/util/serialization/mod.rs
+++ b/plonky2/src/util/serialization/mod.rs
@@ -134,7 +134,7 @@ pub trait Read {
     /// Reads a `usize` value from `self`.
     #[inline]
     fn read_usize(&mut self) -> IoResult<usize> {
-        let mut buf = [0; std::mem::size_of::<u64>()];
+        let mut buf = [0; core::mem::size_of::<u64>()];
         self.read_exact(&mut buf)?;
         Ok(u64::from_le_bytes(buf) as usize)
     }

--- a/starky/src/recursive_verifier.rs
+++ b/starky/src/recursive_verifier.rs
@@ -1,3 +1,4 @@
+use alloc::vec::Vec;
 use core::iter::once;
 
 use anyhow::{ensure, Result};


### PR DESCRIPTION
`no-std` support for `plonky2` and `starky` was added by #806, but nobody noticed some breaking changes later on.
This PR restores `no-std` support, and introduces `wasm32-unknown-unknown` as an additional target for tests, to avoid making the same mistake again.

https://github.com/0xPolygonZero/plonky2/pull/907#issuecomment-1462939316 