### PR TITLE
minor: Move empty check of `memset` inside final iteration

### DIFF
--- a/evm/src/cpu/kernel/asm/memory/memcpy.asm
+++ b/evm/src/cpu/kernel/asm/memory/memcpy.asm
@@ -55,8 +55,8 @@ global memcpy_bytes:
     // Handle small case
     DUP7
     // stack: count, DST, SRC, count, retdest
-    %lt_const(0x20)
-    // stack: count < 32, DST, SRC, count, retdest
+    %lt_const(0x21)
+    // stack: count <= 32, DST, SRC, count, retdest
     %jumpi(memcpy_bytes_finish)
     
     // We will pack 32 bytes into a U256 from the source, and then unpack it at the destination.

--- a/evm/src/cpu/kernel/asm/memory/memset.asm
+++ b/evm/src/cpu/kernel/asm/memory/memset.asm
@@ -4,20 +4,11 @@
 global memset:
     // stack: DST, count, retdest
 
-    // Handle empty case
-    DUP4
-    // stack: count, DST, count, retdest
-    ISZERO
-    // stack: count == 0, DST, count, retdest
-    %jumpi(memset_bytes_empty)
-
-    // stack: DST, count, retdest
-
     // Handle small case
     DUP4
     // stack: count, DST, count, retdest
-    %lt_const(0x20)
-    // stack: count < 32, DST, count, retdest
+    %lt_const(0x21)
+    // stack: count <= 32, DST, count, retdest
     %jumpi(memset_finish)
 
     // stack: DST, count, retdest
@@ -43,6 +34,15 @@ global memset:
     %jump(memset)
 
 memset_finish:
+    // stack: DST, final_count, retdest
+
+    // Handle empty case
+    DUP4
+    // stack: final_count, DST, final_count, retdest
+    ISZERO
+    // stack: final_count == 0, DST, final_count, retdest
+    %jumpi(memset_bytes_empty)
+
     // stack: DST, final_count, retdest
     DUP4
     PUSH 0


### PR DESCRIPTION
Same trick as in `memcpy`.
Additionally, performs `LT` against 33 instead of 32, as otherwise for a chunk of exactly 32 bytes, we'd go through the loop twice.