### PR TITLE
Fix run_syscall in interpreter.

### DIFF
--- a/evm/src/cpu/kernel/interpreter.rs
+++ b/evm/src/cpu/kernel/interpreter.rs
@@ -1038,7 +1038,7 @@ impl<'a> Interpreter<'a> {
         let new_program_counter =
             u256_to_usize(handler_addr).map_err(|_| anyhow!("The program counter is too large"))?;
 
-        let syscall_info = U256::from(self.generation_state.registers.program_counter + 1)
+        let syscall_info = U256::from(self.generation_state.registers.program_counter)
             + U256::from((self.generation_state.registers.is_kernel as usize) << 32)
             + (U256::from(self.generation_state.registers.gas_used) << 192);
         self.generation_state.registers.program_counter = new_program_counter;
@@ -1048,7 +1048,6 @@ impl<'a> Interpreter<'a> {
         self.generation_state.registers.gas_used = 0;
         self.push(syscall_info);
 
-        self.run().map_err(|_| anyhow!("Syscall failed"))?;
         Ok(())
     }
 

--- a/evm/src/cpu/kernel/tests/account_code.rs
+++ b/evm/src/cpu/kernel/tests/account_code.rs
@@ -322,7 +322,7 @@ fn sload() -> Result<()> {
     let addr_nibbles = Nibbles::from_bytes_be(addr_hashed.as_bytes()).unwrap();
 
     // This code is similar to the one in add11_yml's contract, but we pop the added value
-    // and carry out an SLOAD instead of an SSTORE.
+    // and carry out an SLOAD instead of an SSTORE. We also add a PUSH at the end.
     let code = [
         0x60, 0x01, 0x60, 0x01, 0x01, 0x50, 0x60, 0x00, 0x54, 0x60, 0x03, 0x00,
     ];

--- a/evm/src/cpu/kernel/tests/account_code.rs
+++ b/evm/src/cpu/kernel/tests/account_code.rs
@@ -353,21 +353,12 @@ fn sload() -> Result<()> {
 
     interpreter.run()?;
 
-    assert_eq!(interpreter.stack().len(), 2, "Stack length should be 2");
-
-    // The last step in the provided code pushes the value 3.
-    let pushed_val = interpreter.pop();
-    assert_eq!(
-        pushed_val,
-        3.into(),
-        "The last pushed values is 3, but we the stack contains {:?}",
-        pushed_val
-    );
-
-    // We check that no value was found in the storage trie.
-    let value = interpreter.pop();
-    assert_eq!(value, 0.into());
-
+    // The SLOAD in the provided code should return 0, since
+    // the storage trie is empty. The last step in the code
+    // pushes the value 3.
+    assert_eq!(interpreter.stack(), vec![0x0.into(), 0x3.into()]);
+    interpreter.pop();
+    interpreter.pop();
     // Now, execute mpt_hash_state_trie. We check that the state trie has not changed.
     let mpt_hash_state_trie = KERNEL.global_labels["mpt_hash_state_trie"];
     interpreter.generation_state.registers.program_counter = mpt_hash_state_trie;


### PR DESCRIPTION
We noticed that in the interpreter, the program counter that is stored corresponds to `program_counter + 1` outside of the interpreter, so we fix this in `run_syscall` on the interpreter side. We also remove the unnecessary `self.run` in `run_syscall`. We update the `sload` test to catch this error.