### PR TITLE
Add try_build_with_options

### DIFF
--- a/plonky2/src/plonk/circuit_builder.rs
+++ b/plonky2/src/plonk/circuit_builder.rs
@@ -915,6 +915,7 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
         }
     }
 
+    /// Builds a "full circuit", with both prover and verifier data.
     pub fn build_with_options<C: GenericConfig<D, F = F>>(
         self,
         commit_to_sigma: bool,
@@ -926,7 +927,6 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
         circuit_data
     }
 
-    /// Builds a "full circuit", with both prover and verifier data.
     pub fn try_build_with_options<C: GenericConfig<D, F = F>>(
         mut self,
         commit_to_sigma: bool,


### PR DESCRIPTION
When using cyclic recursion, `CircuitBuilder::build_with_options` currently checks that the resulting common data matches the data that was passed into `CircuitBuilder::conditionally_verify_cyclic_proof`, and panics if it's different. This PR adds a `try_build_with_options` function that always returns the data along with a boolean of whether it succeeded or not. This way, it's possible to get the correct common_data and pass it into `conditionally_verify_cyclic_proof`. The behavior of `build_with_options` is the same.