### PR TITLE
Fix kernel codehash discrepancy

### DIFF
--- a/evm/src/cpu/kernel/asm/mpt/hex_prefix.asm
+++ b/evm/src/cpu/kernel/asm/mpt/hex_prefix.asm
@@ -56,7 +56,7 @@ first_byte:
     SWAP1
     JUMP
     
-remaining_bytes:
+global remaining_bytes:
     // stack: rlp_pos, num_nibbles, packed_nibbles, retdest
     SWAP2
     PUSH @U256_MAX
@@ -86,7 +86,7 @@ remaining_bytes:
     JUMP
 
 
-rlp_header_medium:
+global rlp_header_medium:
     // stack: hp_len, rlp_pos, num_nibbles, packed_nibbles, terminated, retdest
     %add_const(0x80) // value = 0x80 + hp_len
     DUP2 // offset = rlp_pos
@@ -95,13 +95,17 @@ rlp_header_medium:
     // rlp_pos += 1
     %increment
 
-    %stack
-        (rlp_pos, num_nibbles, packed_nibbles, terminated) ->
-        (rlp_pos, num_nibbles, packed_nibbles, terminated, remaining_bytes, num_nibbles, packed_nibbles)
+    // stack: rlp_pos, num_nibbles, packed_nibbles, terminated, retdest
+    SWAP3 DUP3 DUP3
+    // stack: num_nibbles, packed_nibbles, terminated, num_nibbles, packed_nibbles, rlp_pos, retdest
+    PUSH remaining_bytes
+    // stack: remaining_bytes, num_nibbles, packed_nibbles, terminated, num_nibbles, packed_nibbles, rlp_pos, retdest
+    SWAP4 SWAP5 SWAP6
+    // stack: rlp_pos, num_nibbles, packed_nibbles, terminated, remaining_bytes, num_nibbles, packed_nibbles, retdest
 
     %jump(first_byte)
 
-rlp_header_large:
+global rlp_header_large:
     // stack: hp_len, rlp_pos, num_nibbles, packed_nibbles, terminated, retdest
     // In practice hex-prefix length will never exceed 256, so the length of the
     // length will always be 1 byte in this case.
@@ -118,9 +122,12 @@ rlp_header_large:
     // rlp_pos += 2
     %add_const(2)
 
-    %stack
-        (rlp_pos, num_nibbles, packed_nibbles, terminated) ->
-        (rlp_pos, num_nibbles, packed_nibbles, terminated, remaining_bytes, num_nibbles, packed_nibbles)
+    // stack: rlp_pos, num_nibbles, packed_nibbles, terminated, retdest
+    SWAP3 DUP3 DUP3
+    // stack: num_nibbles, packed_nibbles, terminated, num_nibbles, packed_nibbles, rlp_pos, retdest
+    PUSH remaining_bytes
+    // stack: remaining_bytes, num_nibbles, packed_nibbles, terminated, num_nibbles, packed_nibbles, rlp_pos, retdest
+    SWAP4 SWAP5 SWAP6
+    // stack: rlp_pos, num_nibbles, packed_nibbles, terminated, remaining_bytes, num_nibbles, packed_nibbles, retdest
 
     %jump(first_byte)
-

--- a/evm/src/cpu/kernel/asm/mpt/hex_prefix.asm
+++ b/evm/src/cpu/kernel/asm/mpt/hex_prefix.asm
@@ -56,7 +56,7 @@ first_byte:
     SWAP1
     JUMP
     
-global remaining_bytes:
+remaining_bytes:
     // stack: rlp_pos, num_nibbles, packed_nibbles, retdest
     SWAP2
     PUSH @U256_MAX
@@ -86,7 +86,7 @@ global remaining_bytes:
     JUMP
 
 
-global rlp_header_medium:
+rlp_header_medium:
     // stack: hp_len, rlp_pos, num_nibbles, packed_nibbles, terminated, retdest
     %add_const(0x80) // value = 0x80 + hp_len
     DUP2 // offset = rlp_pos
@@ -105,7 +105,7 @@ global rlp_header_medium:
 
     %jump(first_byte)
 
-global rlp_header_large:
+rlp_header_large:
     // stack: hp_len, rlp_pos, num_nibbles, packed_nibbles, terminated, retdest
     // In practice hex-prefix length will never exceed 256, so the length of the
     // length will always be 1 byte in this case.

--- a/evm/src/cpu/kernel/asm/mpt/hex_prefix.asm
+++ b/evm/src/cpu/kernel/asm/mpt/hex_prefix.asm
@@ -67,20 +67,20 @@ remaining_bytes:
     SWAP1 SUB DUP1
     // stack: num_nibbles - parity, num_nibbles - parity, U256_MAX, packed_nibbles, rlp_pos, ret_dest
     %div_const(2)
-    // stack: remaining_bytes, num_nibbles - parity, U256_MAX, packed_nibbles, rlp_pos, ret_dest
+    // stack: rem_bytes, num_nibbles - parity, U256_MAX, packed_nibbles, rlp_pos, ret_dest
     SWAP2 SWAP1
-    // stack: num_nibbles - parity, U256_MAX, remaining_bytes, packed_nibbles, rlp_pos, ret_dest
+    // stack: num_nibbles - parity, U256_MAX, rem_bytes, packed_nibbles, rlp_pos, ret_dest
     %mul_const(4)
-    // stack: 4*(num_nibbles - parity), U256_MAX, remaining_bytes, packed_nibbles, rlp_pos, ret_dest
+    // stack: 4*(num_nibbles - parity), U256_MAX, rem_bytes, packed_nibbles, rlp_pos, ret_dest
     PUSH 256 SUB
-    // stack: 256 - 4*(num_nibbles - parity), U256_MAX, remaining_bytes, packed_nibbles, rlp_pos, ret_dest
+    // stack: 256 - 4*(num_nibbles - parity), U256_MAX, rem_bytes, packed_nibbles, rlp_pos, ret_dest
     SHR
-    // stack: mask, remaining_bytes, packed_nibbles, rlp_pos, ret_dest
+    // stack: mask, rem_bytes, packed_nibbles, rlp_pos, ret_dest
     SWAP1 SWAP2
     AND
     %stack
-        (remaining_nibbles, remaining_bytes, rlp_pos) ->
-        (rlp_pos, remaining_nibbles, remaining_bytes)
+        (remaining_nibbles, rem_bytes, rlp_pos) ->
+        (rlp_pos, remaining_nibbles, rem_bytes)
     %mstore_unpacking_rlp
     SWAP1
     JUMP
@@ -96,8 +96,8 @@ rlp_header_medium:
     %increment
 
     %stack
-        (rlp_pos, num_nibbles, packed_nibbles, terminated, retdest) ->
-        (rlp_pos, num_nibbles, packed_nibbles, terminated, remaining_bytes, num_nibbles, packed_nibbles, retdest)
+        (rlp_pos, num_nibbles, packed_nibbles, terminated) ->
+        (rlp_pos, num_nibbles, packed_nibbles, terminated, remaining_bytes, num_nibbles, packed_nibbles)
 
     %jump(first_byte)
 
@@ -119,8 +119,8 @@ rlp_header_large:
     %add_const(2)
 
     %stack
-        (rlp_pos, num_nibbles, packed_nibbles, terminated, retdest) ->
-        (rlp_pos, num_nibbles, packed_nibbles, terminated, remaining_bytes, num_nibbles, packed_nibbles, retdest)
+        (rlp_pos, num_nibbles, packed_nibbles, terminated) ->
+        (rlp_pos, num_nibbles, packed_nibbles, terminated, remaining_bytes, num_nibbles, packed_nibbles)
 
     %jump(first_byte)
 

--- a/evm/src/cpu/kernel/tests/kernel_consistency.rs
+++ b/evm/src/cpu/kernel/tests/kernel_consistency.rs
@@ -1,0 +1,16 @@
+use anyhow::Result;
+use ethereum_types::U256;
+
+use crate::cpu::kernel::aggregator::{combined_kernel, KERNEL};
+use crate::cpu::kernel::interpreter::Interpreter;
+use crate::memory::segments::Segment;
+
+#[test]
+fn test_kernel_code_hash_consistency() -> Result<()> {
+    for _ in 0..10 {
+        let kernel2 = combined_kernel();
+        assert_eq!(kernel2.code_hash, KERNEL.code_hash);
+    }
+
+    Ok(())
+}

--- a/evm/src/cpu/kernel/tests/mod.rs
+++ b/evm/src/cpu/kernel/tests/mod.rs
@@ -10,6 +10,7 @@ mod core;
 mod ecc;
 mod exp;
 mod hash;
+mod kernel_consistency;
 mod log;
 mod mpt;
 mod packing;

--- a/evm/src/generation/mod.rs
+++ b/evm/src/generation/mod.rs
@@ -191,19 +191,6 @@ fn apply_metadata_and_tries_memops<F: RichField + Extendable<D>, const D: usize>
     state.traces.memory_ops.extend(ops);
 }
 
-fn initialize_kernel_code<F: RichField + Extendable<D>, const D: usize>(
-    state: &mut GenerationState<F>,
-) {
-    for (i, &byte) in enumerate(KERNEL.code.iter()) {
-        let address = MemoryAddress {
-            context: 0,
-            segment: Segment::Code as usize,
-            virt: i,
-        };
-        state.memory.set(address, byte.into());
-    }
-}
-
 pub fn generate_traces<F: RichField + Extendable<D>, const D: usize>(
     all_stark: &AllStark<F, D>,
     inputs: GenerationInputs,
@@ -218,8 +205,6 @@ pub fn generate_traces<F: RichField + Extendable<D>, const D: usize>(
         .map_err(|err| anyhow!("Failed to parse all the initial prover inputs: {:?}", err))?;
 
     apply_metadata_and_tries_memops(&mut state, &inputs);
-
-    initialize_kernel_code(&mut state);
 
     timed!(timing, "simulate CPU", simulate_cpu(&mut state)?);
 


### PR DESCRIPTION
Attempt at fixing the Kernel hash discrepancy across runs.

### How to reproduce it

Print the `KERNEL` code hash in say, `prove_with_outputs()`, and then run:

```bash
for i in {0..10}; do cargo test --release --test simple_transfer; done
```

### Error

Upon inspection of the different code segments per parsed file, it appears that the inconsistency was coming from `hex_prefix.asm`, more particularly on the `%stack` macro which for some reasons seems to not be deterministic. I've replaced them by hardcoding what the optimizer had deduced.

On this branch, I've ran the above command 40 times and got the same hash every time.

### Other changes

I also:
- changed a variable name, that was identical to a `label` and could have messed things up
- removed the duplicate copy of the kernel code in `initialize_kernel_code()` as this is already being done when initializing `GenerationState`

