### PR TITLE
Update stack op cost

### DIFF
--- a/evm/src/cpu/kernel/cost_estimator.rs
+++ b/evm/src/cpu/kernel/cost_estimator.rs
@@ -1,3 +1,4 @@
+use super::opcodes::get_opcode;
 use crate::cpu::kernel::assembler::BYTES_PER_OFFSET;
 use crate::cpu::kernel::ast::Item;
 use crate::cpu::kernel::ast::Item::*;
@@ -32,6 +33,5 @@ fn cost_estimate_standard_op(_op: &str) -> u32 {
 }
 
 fn cost_estimate_push(num_bytes: usize) -> u32 {
-    // TODO: Once PUSH is actually implemented, check if this needs to be revised.
     num_bytes as u32
 }

--- a/evm/src/cpu/kernel/stack/stack_manipulation.rs
+++ b/evm/src/cpu/kernel/stack/stack_manipulation.rs
@@ -286,15 +286,16 @@ impl StackOp {
                         panic!("Target should have been expanded already: {target:?}")
                     }
                 };
-                // This is just a rough estimate; we can update it after implementing PUSH.
-                (bytes, bytes)
+                // A PUSH takes one cycle, and 1 memory read per byte.
+                (1, bytes)
             }
             // A POP takes one cycle, and doesn't involve memory, it just decrements a pointer.
             Pop => (1, 0),
-            // A DUP takes one cycle, and a read and a write.
+            // A DUP takes one cycle, and a read and a write, unless we call DUP(0) which doesn't read to memory.
+            StackOp::Dup(0) => (1, 1),
             StackOp::Dup(_) => (1, 2),
-            // A SWAP takes one cycle with four memory ops, to read both values then write to them.
-            StackOp::Swap(_) => (1, 4),
+            // A SWAP takes one cycle with three memory ops, to read both values then write to them.
+            StackOp::Swap(_) => (1, 3),
         };
 
         let cpu_cost = cpu_rows * NUM_CPU_COLUMNS as u32;

--- a/evm/src/cpu/kernel/stack/stack_manipulation.rs
+++ b/evm/src/cpu/kernel/stack/stack_manipulation.rs
@@ -287,12 +287,11 @@ impl StackOp {
                     }
                 };
                 // A PUSH takes one cycle, and 1 memory read per byte.
-                (1, bytes)
+                (1, bytes + 1)
             }
-            // A POP takes one cycle, and doesn't involve memory, it just decrements a pointer.
-            Pop => (1, 0),
-            // A DUP takes one cycle, and a read and a write, unless we call DUP(0) which doesn't read to memory.
-            StackOp::Dup(0) => (1, 1),
+            // A POP takes one cycle, and most of the time a read to update the top of the stack.
+            Pop => (1, 1),
+            // A DUP takes one cycle, and a read and a write.
             StackOp::Dup(_) => (1, 2),
             // A SWAP takes one cycle with three memory ops, to read both values then write to them.
             StackOp::Swap(_) => (1, 3),


### PR DESCRIPTION
Updates the cost evaluation for stack operations, as some have changed since the top of the stack move to CPU table.
Also removes the TODO related to PUSH cost as it seems correct now that PUSH constraints induce 1 Memory read per byte.

Gains are clearly negligible, but at least it's coherent with the underlying implementation.

closes #1332 