### PR TITLE
chore: fix some comment typos

### DIFF
--- a/evm/src/cpu/kernel/tests/bn254.rs
+++ b/evm/src/cpu/kernel/tests/bn254.rs
@@ -117,8 +117,8 @@ fn run_bn_frob_fp12(f: Fp12<BN254>, n: usize) -> Fp12<BN254> {
         segment: BnPairing,
         memory: vec![(ptr, f.to_stack().to_vec())],
     };
-    let interpeter: Interpreter = run_interpreter_with_memory(setup).unwrap();
-    let output: Vec<U256> = interpeter.extract_kernel_memory(BnPairing, ptr..ptr + 12);
+    let interpreter: Interpreter = run_interpreter_with_memory(setup).unwrap();
+    let output: Vec<U256> = interpreter.extract_kernel_memory(BnPairing, ptr..ptr + 12);
     Fp12::<BN254>::from_stack(&output)
 }
 

--- a/evm/src/cpu/kernel/tests/hash.rs
+++ b/evm/src/cpu/kernel/tests/hash.rs
@@ -65,7 +65,7 @@ fn prepare_test<T>(
     // Load the message into the kernel.
     let interpreter_setup = make_interpreter_setup(message, hash_fn_label, hash_input_virt);
 
-    // Run the interpeter
+    // Run the interpreter
     let result = run_interpreter_with_memory(interpreter_setup).unwrap();
 
     Ok((expected, result.stack().to_vec()))

--- a/evm/src/stark.rs
+++ b/evm/src/stark.rs
@@ -66,7 +66,7 @@ pub trait Stark<F: RichField + Extendable<D>, const D: usize>: Sync {
 
     /// Evaluate constraints at a vector of points from the degree `D` extension field. This is like
     /// `eval_ext`, except in the context of a recursive circuit.
-    /// Note: constraints must be added through`yeld_constr.constraint(builder, constraint)` in the
+    /// Note: constraints must be added through`yield_constr.constraint(builder, constraint)` in the
     /// same order as they are given in `eval_packed_generic`.
     fn eval_ext_circuit(
         &self,

--- a/starky/src/stark.rs
+++ b/starky/src/stark.rs
@@ -66,7 +66,7 @@ pub trait Stark<F: RichField + Extendable<D>, const D: usize>: Sync {
 
     /// Evaluate constraints at a vector of points from the degree `D` extension field. This is like
     /// `eval_ext`, except in the context of a recursive circuit.
-    /// Note: constraints must be added through`yeld_constr.constraint(builder, constraint)` in the
+    /// Note: constraints must be added through`yield_constr.constraint(builder, constraint)` in the
     /// same order as they are given in `eval_packed_generic`.
     fn eval_ext_circuit(
         &self,


### PR DESCRIPTION
walk through code catch some typo
- yeld_constr -> yield_constr
- interpeter -> interpreter

replaced this in  all doc