### PR TITLE
Add aborting signal

### DIFF
--- a/evm/src/fixed_recursive_verifier.rs
+++ b/evm/src/fixed_recursive_verifier.rs
@@ -969,7 +969,7 @@ where
         config: &StarkConfig,
         generation_inputs: GenerationInputs,
         timing: &mut TimingTree,
-        abort_signal: Arc<AtomicBool>,
+        abort_signal: Option<Arc<AtomicBool>>,
     ) -> anyhow::Result<(ProofWithPublicInputs<F, C, D>, PublicValues)> {
         let all_proof = prove::<F, C, D>(
             all_stark,

--- a/evm/src/fixed_recursive_verifier.rs
+++ b/evm/src/fixed_recursive_verifier.rs
@@ -1,6 +1,8 @@
 use core::mem::{self, MaybeUninit};
 use std::collections::BTreeMap;
 use std::ops::Range;
+use std::sync::atomic::AtomicBool;
+use std::sync::Arc;
 
 use eth_trie_utils::partial_trie::{HashedPartialTrie, Node, PartialTrie};
 use hashbrown::HashMap;
@@ -39,7 +41,7 @@ use crate::proof::{
     BlockHashesTarget, BlockMetadataTarget, ExtraBlockData, ExtraBlockDataTarget, PublicValues,
     PublicValuesTarget, StarkProofWithMetadata, TrieRoots, TrieRootsTarget,
 };
-use crate::prover::prove;
+use crate::prover::{check_abort_signal, prove};
 use crate::recursive_verifier::{
     add_common_recursion_gates, add_virtual_public_values, get_memory_extra_looking_sum_circuit,
     recursive_stark_circuit, set_public_value_targets, PlonkWrapperCircuit, PublicInputs,
@@ -967,8 +969,15 @@ where
         config: &StarkConfig,
         generation_inputs: GenerationInputs,
         timing: &mut TimingTree,
+        abort_signal: Arc<AtomicBool>,
     ) -> anyhow::Result<(ProofWithPublicInputs<F, C, D>, PublicValues)> {
-        let all_proof = prove::<F, C, D>(all_stark, config, generation_inputs, timing)?;
+        let all_proof = prove::<F, C, D>(
+            all_stark,
+            config,
+            generation_inputs,
+            timing,
+            abort_signal.clone(),
+        )?;
         let mut root_inputs = PartialWitness::new();
 
         for table in 0..NUM_TABLES {
@@ -996,6 +1005,8 @@ where
                 F::from_canonical_usize(index_verifier_data),
             );
             root_inputs.set_proof_with_pis_target(&self.root.proof_with_pis[table], &shrunk_proof);
+
+            check_abort_signal(abort_signal.clone())?;
         }
 
         root_inputs.set_verifier_data_target(

--- a/evm/src/generation/mod.rs
+++ b/evm/src/generation/mod.rs
@@ -1,4 +1,6 @@
 use std::collections::HashMap;
+use std::sync::atomic::AtomicBool;
+use std::sync::Arc;
 
 use anyhow::anyhow;
 use eth_trie_utils::partial_trie::{HashedPartialTrie, PartialTrie};
@@ -23,6 +25,7 @@ use crate::cpu::kernel::constants::global_metadata::GlobalMetadata;
 use crate::generation::state::GenerationState;
 use crate::memory::segments::Segment;
 use crate::proof::{BlockHashes, BlockMetadata, ExtraBlockData, PublicValues, TrieRoots};
+use crate::prover::check_abort_signal;
 use crate::util::h2u;
 use crate::witness::memory::{MemoryAddress, MemoryChannel};
 use crate::witness::transition::transition;

--- a/evm/src/keccak/keccak_stark.rs
+++ b/evm/src/keccak/keccak_stark.rs
@@ -620,9 +620,6 @@ impl<F: RichField + Extendable<D>, const D: usize> Stark<F, D> for KeccakStark<F
 
 #[cfg(test)]
 mod tests {
-    use std::sync::atomic::AtomicBool;
-    use std::sync::Arc;
-
     use anyhow::Result;
     use env_logger::{try_init_from_env, Env, DEFAULT_FILTER_ENV};
     use plonky2::field::polynomial::PolynomialValues;
@@ -757,8 +754,6 @@ mod tests {
             zs_columns: vec![ctl_z_data.clone(); config.num_challenges],
         };
 
-        let abort_signal = Arc::new(AtomicBool::from(false));
-
         prove_single_table(
             &stark,
             &config,
@@ -770,7 +765,7 @@ mod tests {
             },
             &mut Challenger::new(),
             &mut timing,
-            abort_signal,
+            None,
         )?;
 
         timing.print();

--- a/evm/src/keccak/keccak_stark.rs
+++ b/evm/src/keccak/keccak_stark.rs
@@ -620,6 +620,9 @@ impl<F: RichField + Extendable<D>, const D: usize> Stark<F, D> for KeccakStark<F
 
 #[cfg(test)]
 mod tests {
+    use std::sync::atomic::AtomicBool;
+    use std::sync::Arc;
+
     use anyhow::Result;
     use env_logger::{try_init_from_env, Env, DEFAULT_FILTER_ENV};
     use plonky2::field::polynomial::PolynomialValues;
@@ -754,6 +757,8 @@ mod tests {
             zs_columns: vec![ctl_z_data.clone(); config.num_challenges],
         };
 
+        let abort_signal = Arc::new(AtomicBool::from(false));
+
         prove_single_table(
             &stark,
             &config,
@@ -765,6 +770,7 @@ mod tests {
             },
             &mut Challenger::new(),
             &mut timing,
+            abort_signal,
         )?;
 
         timing.print();

--- a/evm/src/prover.rs
+++ b/evm/src/prover.rs
@@ -671,7 +671,7 @@ where
 /// which will result in an early abort for all the other processes involved in the same set
 /// of transactions.
 pub(crate) fn check_abort_signal(signal: Arc<AtomicBool>) -> Result<()> {
-    if signal.load(Ordering::Relaxed) == true {
+    if signal.load(Ordering::Relaxed) {
         return Err(anyhow!("Stopping job from abort signal."));
     }
 

--- a/evm/tests/add11_yml.rs
+++ b/evm/tests/add11_yml.rs
@@ -1,7 +1,5 @@
 use std::collections::HashMap;
 use std::str::FromStr;
-use std::sync::atomic::AtomicBool;
-use std::sync::Arc;
 use std::time::Duration;
 
 use env_logger::{try_init_from_env, Env, DEFAULT_FILTER_ENV};
@@ -169,9 +167,8 @@ fn add11_yml() -> anyhow::Result<()> {
         },
     };
 
-    let signal = Arc::new(AtomicBool::from(false));
     let mut timing = TimingTree::new("prove", log::Level::Debug);
-    let proof = prove::<F, C, D>(&all_stark, &config, inputs, &mut timing, signal)?;
+    let proof = prove::<F, C, D>(&all_stark, &config, inputs, &mut timing, None)?;
     timing.filter(Duration::from_millis(100)).print();
 
     verify_proof(&all_stark, proof, &config)

--- a/evm/tests/add11_yml.rs
+++ b/evm/tests/add11_yml.rs
@@ -1,5 +1,7 @@
 use std::collections::HashMap;
 use std::str::FromStr;
+use std::sync::atomic::AtomicBool;
+use std::sync::Arc;
 use std::time::Duration;
 
 use env_logger::{try_init_from_env, Env, DEFAULT_FILTER_ENV};
@@ -167,8 +169,9 @@ fn add11_yml() -> anyhow::Result<()> {
         },
     };
 
+    let signal = Arc::new(AtomicBool::from(false));
     let mut timing = TimingTree::new("prove", log::Level::Debug);
-    let proof = prove::<F, C, D>(&all_stark, &config, inputs, &mut timing)?;
+    let proof = prove::<F, C, D>(&all_stark, &config, inputs, &mut timing, signal)?;
     timing.filter(Duration::from_millis(100)).print();
 
     verify_proof(&all_stark, proof, &config)

--- a/evm/tests/basic_smart_contract.rs
+++ b/evm/tests/basic_smart_contract.rs
@@ -1,7 +1,5 @@
 use std::collections::HashMap;
 use std::str::FromStr;
-use std::sync::atomic::AtomicBool;
-use std::sync::Arc;
 use std::time::Duration;
 
 use env_logger::{try_init_from_env, Env, DEFAULT_FILTER_ENV};
@@ -201,9 +199,8 @@ fn test_basic_smart_contract() -> anyhow::Result<()> {
         },
     };
 
-    let signal = Arc::new(AtomicBool::from(false));
     let mut timing = TimingTree::new("prove", log::Level::Debug);
-    let proof = prove::<F, C, D>(&all_stark, &config, inputs, &mut timing, signal)?;
+    let proof = prove::<F, C, D>(&all_stark, &config, inputs, &mut timing, None)?;
     timing.filter(Duration::from_millis(100)).print();
 
     verify_proof(&all_stark, proof, &config)

--- a/evm/tests/basic_smart_contract.rs
+++ b/evm/tests/basic_smart_contract.rs
@@ -1,5 +1,7 @@
 use std::collections::HashMap;
 use std::str::FromStr;
+use std::sync::atomic::AtomicBool;
+use std::sync::Arc;
 use std::time::Duration;
 
 use env_logger::{try_init_from_env, Env, DEFAULT_FILTER_ENV};
@@ -199,8 +201,9 @@ fn test_basic_smart_contract() -> anyhow::Result<()> {
         },
     };
 
+    let signal = Arc::new(AtomicBool::from(false));
     let mut timing = TimingTree::new("prove", log::Level::Debug);
-    let proof = prove::<F, C, D>(&all_stark, &config, inputs, &mut timing)?;
+    let proof = prove::<F, C, D>(&all_stark, &config, inputs, &mut timing, signal)?;
     timing.filter(Duration::from_millis(100)).print();
 
     verify_proof(&all_stark, proof, &config)

--- a/evm/tests/empty_txn_list.rs
+++ b/evm/tests/empty_txn_list.rs
@@ -1,5 +1,7 @@
 use std::collections::HashMap;
 use std::marker::PhantomData;
+use std::sync::atomic::AtomicBool;
+use std::sync::Arc;
 use std::time::Duration;
 
 use env_logger::{try_init_from_env, Env, DEFAULT_FILTER_ENV};
@@ -111,10 +113,17 @@ fn test_empty_txn_list() -> anyhow::Result<()> {
         assert_eq!(all_circuits, all_circuits_from_bytes);
     }
 
+    let signal = Arc::new(AtomicBool::from(false));
     let mut timing = TimingTree::new("prove", log::Level::Info);
     // We're missing some preprocessed circuits.
     assert!(all_circuits
-        .prove_root(&all_stark, &config, inputs.clone(), &mut timing)
+        .prove_root(
+            &all_stark,
+            &config,
+            inputs.clone(),
+            &mut timing,
+            signal.clone()
+        )
         .is_err());
 
     // Expand the preprocessed circuits.
@@ -127,7 +136,7 @@ fn test_empty_txn_list() -> anyhow::Result<()> {
 
     let mut timing = TimingTree::new("prove", log::Level::Info);
     let (root_proof, public_values) =
-        all_circuits.prove_root(&all_stark, &config, inputs, &mut timing)?;
+        all_circuits.prove_root(&all_stark, &config, inputs, &mut timing, signal)?;
     timing.filter(Duration::from_millis(100)).print();
     all_circuits.verify_root(root_proof.clone())?;
 

--- a/evm/tests/empty_txn_list.rs
+++ b/evm/tests/empty_txn_list.rs
@@ -1,7 +1,5 @@
 use std::collections::HashMap;
 use std::marker::PhantomData;
-use std::sync::atomic::AtomicBool;
-use std::sync::Arc;
 use std::time::Duration;
 
 use env_logger::{try_init_from_env, Env, DEFAULT_FILTER_ENV};
@@ -113,17 +111,10 @@ fn test_empty_txn_list() -> anyhow::Result<()> {
         assert_eq!(all_circuits, all_circuits_from_bytes);
     }
 
-    let signal = Arc::new(AtomicBool::from(false));
     let mut timing = TimingTree::new("prove", log::Level::Info);
     // We're missing some preprocessed circuits.
     assert!(all_circuits
-        .prove_root(
-            &all_stark,
-            &config,
-            inputs.clone(),
-            &mut timing,
-            signal.clone()
-        )
+        .prove_root(&all_stark, &config, inputs.clone(), &mut timing, None)
         .is_err());
 
     // Expand the preprocessed circuits.
@@ -136,7 +127,7 @@ fn test_empty_txn_list() -> anyhow::Result<()> {
 
     let mut timing = TimingTree::new("prove", log::Level::Info);
     let (root_proof, public_values) =
-        all_circuits.prove_root(&all_stark, &config, inputs, &mut timing, signal)?;
+        all_circuits.prove_root(&all_stark, &config, inputs, &mut timing, None)?;
     timing.filter(Duration::from_millis(100)).print();
     all_circuits.verify_root(root_proof.clone())?;
 

--- a/evm/tests/erc20.rs
+++ b/evm/tests/erc20.rs
@@ -1,6 +1,4 @@
 use std::str::FromStr;
-use std::sync::atomic::AtomicBool;
-use std::sync::Arc;
 use std::time::Duration;
 
 use env_logger::{try_init_from_env, Env, DEFAULT_FILTER_ENV};
@@ -177,9 +175,8 @@ fn test_erc20() -> anyhow::Result<()> {
         },
     };
 
-    let signal = Arc::new(AtomicBool::from(false));
     let mut timing = TimingTree::new("prove", log::Level::Debug);
-    let proof = prove::<F, C, D>(&all_stark, &config, inputs, &mut timing, signal)?;
+    let proof = prove::<F, C, D>(&all_stark, &config, inputs, &mut timing, None)?;
     timing.filter(Duration::from_millis(100)).print();
 
     verify_proof(&all_stark, proof, &config)

--- a/evm/tests/erc20.rs
+++ b/evm/tests/erc20.rs
@@ -1,4 +1,6 @@
 use std::str::FromStr;
+use std::sync::atomic::AtomicBool;
+use std::sync::Arc;
 use std::time::Duration;
 
 use env_logger::{try_init_from_env, Env, DEFAULT_FILTER_ENV};
@@ -175,8 +177,9 @@ fn test_erc20() -> anyhow::Result<()> {
         },
     };
 
+    let signal = Arc::new(AtomicBool::from(false));
     let mut timing = TimingTree::new("prove", log::Level::Debug);
-    let proof = prove::<F, C, D>(&all_stark, &config, inputs, &mut timing)?;
+    let proof = prove::<F, C, D>(&all_stark, &config, inputs, &mut timing, signal)?;
     timing.filter(Duration::from_millis(100)).print();
 
     verify_proof(&all_stark, proof, &config)

--- a/evm/tests/log_opcode.rs
+++ b/evm/tests/log_opcode.rs
@@ -2,6 +2,8 @@
 
 use std::collections::HashMap;
 use std::str::FromStr;
+use std::sync::atomic::AtomicBool;
+use std::sync::Arc;
 use std::time::Duration;
 
 use bytes::Bytes;
@@ -233,8 +235,9 @@ fn test_log_opcodes() -> anyhow::Result<()> {
         },
     };
 
+    let signal = Arc::new(AtomicBool::from(false));
     let mut timing = TimingTree::new("prove", log::Level::Debug);
-    let proof = prove::<F, C, D>(&all_stark, &config, inputs, &mut timing)?;
+    let proof = prove::<F, C, D>(&all_stark, &config, inputs, &mut timing, signal)?;
     timing.filter(Duration::from_millis(100)).print();
 
     // Assert that the proof leads to the correct state and receipt roots.
@@ -448,9 +451,16 @@ fn test_log_with_aggreg() -> anyhow::Result<()> {
         &config,
     );
 
+    let signal = Arc::new(AtomicBool::from(false));
+
     let mut timing = TimingTree::new("prove root first", log::Level::Info);
-    let (root_proof_first, public_values_first) =
-        all_circuits.prove_root(&all_stark, &config, inputs_first, &mut timing)?;
+    let (root_proof_first, public_values_first) = all_circuits.prove_root(
+        &all_stark,
+        &config,
+        inputs_first,
+        &mut timing,
+        signal.clone(),
+    )?;
 
     timing.filter(Duration::from_millis(100)).print();
     all_circuits.verify_root(root_proof_first.clone())?;
@@ -570,7 +580,7 @@ fn test_log_with_aggreg() -> anyhow::Result<()> {
 
     let mut timing = TimingTree::new("prove root second", log::Level::Info);
     let (root_proof_second, public_values_second) =
-        all_circuits.prove_root(&all_stark, &config, inputs, &mut timing)?;
+        all_circuits.prove_root(&all_stark, &config, inputs, &mut timing, signal.clone())?;
     timing.filter(Duration::from_millis(100)).print();
 
     all_circuits.verify_root(root_proof_second.clone())?;
@@ -635,7 +645,7 @@ fn test_log_with_aggreg() -> anyhow::Result<()> {
     };
 
     let (root_proof, public_values) =
-        all_circuits.prove_root(&all_stark, &config, inputs, &mut timing)?;
+        all_circuits.prove_root(&all_stark, &config, inputs, &mut timing, signal)?;
     all_circuits.verify_root(root_proof.clone())?;
 
     // We can just duplicate the initial proof as the state didn't change.

--- a/evm/tests/log_opcode.rs
+++ b/evm/tests/log_opcode.rs
@@ -2,8 +2,6 @@
 
 use std::collections::HashMap;
 use std::str::FromStr;
-use std::sync::atomic::AtomicBool;
-use std::sync::Arc;
 use std::time::Duration;
 
 use bytes::Bytes;
@@ -235,9 +233,8 @@ fn test_log_opcodes() -> anyhow::Result<()> {
         },
     };
 
-    let signal = Arc::new(AtomicBool::from(false));
     let mut timing = TimingTree::new("prove", log::Level::Debug);
-    let proof = prove::<F, C, D>(&all_stark, &config, inputs, &mut timing, signal)?;
+    let proof = prove::<F, C, D>(&all_stark, &config, inputs, &mut timing, None)?;
     timing.filter(Duration::from_millis(100)).print();
 
     // Assert that the proof leads to the correct state and receipt roots.
@@ -451,16 +448,9 @@ fn test_log_with_aggreg() -> anyhow::Result<()> {
         &config,
     );
 
-    let signal = Arc::new(AtomicBool::from(false));
-
     let mut timing = TimingTree::new("prove root first", log::Level::Info);
-    let (root_proof_first, public_values_first) = all_circuits.prove_root(
-        &all_stark,
-        &config,
-        inputs_first,
-        &mut timing,
-        signal.clone(),
-    )?;
+    let (root_proof_first, public_values_first) =
+        all_circuits.prove_root(&all_stark, &config, inputs_first, &mut timing, None)?;
 
     timing.filter(Duration::from_millis(100)).print();
     all_circuits.verify_root(root_proof_first.clone())?;
@@ -580,7 +570,7 @@ fn test_log_with_aggreg() -> anyhow::Result<()> {
 
     let mut timing = TimingTree::new("prove root second", log::Level::Info);
     let (root_proof_second, public_values_second) =
-        all_circuits.prove_root(&all_stark, &config, inputs, &mut timing, signal.clone())?;
+        all_circuits.prove_root(&all_stark, &config, inputs, &mut timing, None.clone())?;
     timing.filter(Duration::from_millis(100)).print();
 
     all_circuits.verify_root(root_proof_second.clone())?;
@@ -645,7 +635,7 @@ fn test_log_with_aggreg() -> anyhow::Result<()> {
     };
 
     let (root_proof, public_values) =
-        all_circuits.prove_root(&all_stark, &config, inputs, &mut timing, signal)?;
+        all_circuits.prove_root(&all_stark, &config, inputs, &mut timing, None)?;
     all_circuits.verify_root(root_proof.clone())?;
 
     // We can just duplicate the initial proof as the state didn't change.

--- a/evm/tests/self_balance_gas_cost.rs
+++ b/evm/tests/self_balance_gas_cost.rs
@@ -1,7 +1,5 @@
 use std::collections::HashMap;
 use std::str::FromStr;
-use std::sync::atomic::AtomicBool;
-use std::sync::Arc;
 use std::time::Duration;
 
 use env_logger::{try_init_from_env, Env, DEFAULT_FILTER_ENV};
@@ -188,9 +186,8 @@ fn self_balance_gas_cost() -> anyhow::Result<()> {
         },
     };
 
-    let signal = Arc::new(AtomicBool::from(false));
     let mut timing = TimingTree::new("prove", log::Level::Debug);
-    let proof = prove::<F, C, D>(&all_stark, &config, inputs, &mut timing, signal)?;
+    let proof = prove::<F, C, D>(&all_stark, &config, inputs, &mut timing, None)?;
     timing.filter(Duration::from_millis(100)).print();
 
     verify_proof(&all_stark, proof, &config)

--- a/evm/tests/self_balance_gas_cost.rs
+++ b/evm/tests/self_balance_gas_cost.rs
@@ -1,5 +1,7 @@
 use std::collections::HashMap;
 use std::str::FromStr;
+use std::sync::atomic::AtomicBool;
+use std::sync::Arc;
 use std::time::Duration;
 
 use env_logger::{try_init_from_env, Env, DEFAULT_FILTER_ENV};
@@ -186,8 +188,9 @@ fn self_balance_gas_cost() -> anyhow::Result<()> {
         },
     };
 
+    let signal = Arc::new(AtomicBool::from(false));
     let mut timing = TimingTree::new("prove", log::Level::Debug);
-    let proof = prove::<F, C, D>(&all_stark, &config, inputs, &mut timing)?;
+    let proof = prove::<F, C, D>(&all_stark, &config, inputs, &mut timing, signal)?;
     timing.filter(Duration::from_millis(100)).print();
 
     verify_proof(&all_stark, proof, &config)

--- a/evm/tests/selfdestruct.rs
+++ b/evm/tests/selfdestruct.rs
@@ -1,6 +1,4 @@
 use std::str::FromStr;
-use std::sync::atomic::AtomicBool;
-use std::sync::Arc;
 use std::time::Duration;
 
 use env_logger::{try_init_from_env, Env, DEFAULT_FILTER_ENV};
@@ -140,9 +138,8 @@ fn test_selfdestruct() -> anyhow::Result<()> {
         },
     };
 
-    let signal = Arc::new(AtomicBool::from(false));
     let mut timing = TimingTree::new("prove", log::Level::Debug);
-    let proof = prove::<F, C, D>(&all_stark, &config, inputs, &mut timing, signal)?;
+    let proof = prove::<F, C, D>(&all_stark, &config, inputs, &mut timing, None)?;
     timing.filter(Duration::from_millis(100)).print();
 
     verify_proof(&all_stark, proof, &config)

--- a/evm/tests/selfdestruct.rs
+++ b/evm/tests/selfdestruct.rs
@@ -1,4 +1,6 @@
 use std::str::FromStr;
+use std::sync::atomic::AtomicBool;
+use std::sync::Arc;
 use std::time::Duration;
 
 use env_logger::{try_init_from_env, Env, DEFAULT_FILTER_ENV};
@@ -138,8 +140,9 @@ fn test_selfdestruct() -> anyhow::Result<()> {
         },
     };
 
+    let signal = Arc::new(AtomicBool::from(false));
     let mut timing = TimingTree::new("prove", log::Level::Debug);
-    let proof = prove::<F, C, D>(&all_stark, &config, inputs, &mut timing)?;
+    let proof = prove::<F, C, D>(&all_stark, &config, inputs, &mut timing, signal)?;
     timing.filter(Duration::from_millis(100)).print();
 
     verify_proof(&all_stark, proof, &config)

--- a/evm/tests/simple_transfer.rs
+++ b/evm/tests/simple_transfer.rs
@@ -1,5 +1,7 @@
 use std::collections::HashMap;
 use std::str::FromStr;
+use std::sync::atomic::AtomicBool;
+use std::sync::Arc;
 use std::time::Duration;
 
 use env_logger::{try_init_from_env, Env, DEFAULT_FILTER_ENV};
@@ -154,8 +156,9 @@ fn test_simple_transfer() -> anyhow::Result<()> {
         },
     };
 
+    let signal = Arc::new(AtomicBool::from(false));
     let mut timing = TimingTree::new("prove", log::Level::Debug);
-    let proof = prove::<F, C, D>(&all_stark, &config, inputs, &mut timing)?;
+    let proof = prove::<F, C, D>(&all_stark, &config, inputs, &mut timing, signal)?;
     timing.filter(Duration::from_millis(100)).print();
 
     verify_proof(&all_stark, proof, &config)

--- a/evm/tests/simple_transfer.rs
+++ b/evm/tests/simple_transfer.rs
@@ -1,7 +1,5 @@
 use std::collections::HashMap;
 use std::str::FromStr;
-use std::sync::atomic::AtomicBool;
-use std::sync::Arc;
 use std::time::Duration;
 
 use env_logger::{try_init_from_env, Env, DEFAULT_FILTER_ENV};
@@ -156,9 +154,8 @@ fn test_simple_transfer() -> anyhow::Result<()> {
         },
     };
 
-    let signal = Arc::new(AtomicBool::from(false));
     let mut timing = TimingTree::new("prove", log::Level::Debug);
-    let proof = prove::<F, C, D>(&all_stark, &config, inputs, &mut timing, signal)?;
+    let proof = prove::<F, C, D>(&all_stark, &config, inputs, &mut timing, None)?;
     timing.filter(Duration::from_millis(100)).print();
 
     verify_proof(&all_stark, proof, &config)

--- a/evm/tests/withdrawals.rs
+++ b/evm/tests/withdrawals.rs
@@ -1,6 +1,4 @@
 use std::collections::HashMap;
-use std::sync::atomic::AtomicBool;
-use std::sync::Arc;
 use std::time::Duration;
 
 use env_logger::{try_init_from_env, Env, DEFAULT_FILTER_ENV};
@@ -86,9 +84,8 @@ fn test_withdrawals() -> anyhow::Result<()> {
         },
     };
 
-    let signal = Arc::new(AtomicBool::from(false));
     let mut timing = TimingTree::new("prove", log::Level::Debug);
-    let proof = prove::<F, C, D>(&all_stark, &config, inputs, &mut timing, signal)?;
+    let proof = prove::<F, C, D>(&all_stark, &config, inputs, &mut timing, None)?;
     timing.filter(Duration::from_millis(100)).print();
 
     verify_proof(&all_stark, proof, &config)

--- a/evm/tests/withdrawals.rs
+++ b/evm/tests/withdrawals.rs
@@ -1,4 +1,6 @@
 use std::collections::HashMap;
+use std::sync::atomic::AtomicBool;
+use std::sync::Arc;
 use std::time::Duration;
 
 use env_logger::{try_init_from_env, Env, DEFAULT_FILTER_ENV};
@@ -84,8 +86,9 @@ fn test_withdrawals() -> anyhow::Result<()> {
         },
     };
 
+    let signal = Arc::new(AtomicBool::from(false));
     let mut timing = TimingTree::new("prove", log::Level::Debug);
-    let proof = prove::<F, C, D>(&all_stark, &config, inputs, &mut timing)?;
+    let proof = prove::<F, C, D>(&all_stark, &config, inputs, &mut timing, signal)?;
     timing.filter(Duration::from_millis(100)).print();
 
     verify_proof(&all_stark, proof, &config)


### PR DESCRIPTION
@cpubot: I'm not super satisfied with how it looks, but it's probably conceptually the simplest way to do what you wanted to notify workers to abort early. Does this look good on your end? 
Note that the logic is only present for transaction proofs (i.e. `prove_root()`) as aggregation / block proofs are orders of magnitude faster and don't need this special handling.