### PR TITLE
Add IS_READ column to BytePacking CTL

### DIFF
--- a/evm/src/byte_packing/byte_packing_stark.rs
+++ b/evm/src/byte_packing/byte_packing_stark.rs
@@ -76,7 +76,7 @@ pub(crate) fn ctl_looked_data<F: Field>() -> Vec<Column<F>> {
         (0..NUM_BYTES).map(|i| (index_len(i), F::from_canonical_usize(i + 1))),
     );
 
-    Column::singles([ADDR_CONTEXT, ADDR_SEGMENT, ADDR_VIRTUAL])
+    Column::singles([IS_READ, ADDR_CONTEXT, ADDR_SEGMENT, ADDR_VIRTUAL])
         .chain([sequence_len])
         .chain(Column::singles(&[TIMESTAMP]))
         .chain(outputs)


### PR DESCRIPTION
In the CPU <-> BytePacking CTL, we were not checking whether the operation was a byte packing (with memory writes) or a byte unpacking (with memory reads). This could lead to unwanted writes in memory.