### PR TITLE
add Debug trait to PartitionWitness to enable trace information output

### DIFF
--- a/plonky2/src/iop/witness.rs
+++ b/plonky2/src/iop/witness.rs
@@ -297,7 +297,7 @@ impl<F: Field> Witness<F> for PartialWitness<F> {
 
 /// `PartitionWitness` holds a disjoint-set forest of the targets respecting a circuit's copy constraints.
 /// The value of a target is defined to be the value of its root in the forest.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct PartitionWitness<'a, F: Field> {
     pub values: Vec<Option<F>>,
     pub representative_map: &'a [usize],


### PR DESCRIPTION
With this minor change, user can visualize their trace in following tool without code modification in plonky2 repo.

https://plonk.pro/play/index.html#/analyzer/plonky2