### PR TITLE
Add alternative method to prove txs without pre-loaded table circuits

### DIFF
--- a/evm/src/cross_table_lookup.rs
+++ b/evm/src/cross_table_lookup.rs
@@ -566,7 +566,7 @@ impl GrandProductChallenge<Target> {
 
 /// Like `PermutationChallenge`, but with `num_challenges` copies to boost soundness.
 #[derive(Clone, Eq, PartialEq, Debug)]
-pub(crate) struct GrandProductChallengeSet<T: Copy + Eq + PartialEq + Debug> {
+pub struct GrandProductChallengeSet<T: Copy + Eq + PartialEq + Debug> {
     pub(crate) challenges: Vec<GrandProductChallenge<T>>,
 }
 

--- a/evm/src/fixed_recursive_verifier.rs
+++ b/evm/src/fixed_recursive_verifier.rs
@@ -1,9 +1,11 @@
 use core::mem::{self, MaybeUninit};
 use std::collections::BTreeMap;
 use std::ops::Range;
+use std::path::Path;
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 
+use anyhow::anyhow;
 use eth_trie_utils::partial_trie::{HashedPartialTrie, Node, PartialTrie};
 use hashbrown::HashMap;
 use itertools::{zip_eq, Itertools};
@@ -23,6 +25,7 @@ use plonky2::plonk::config::{AlgebraicHasher, GenericConfig};
 use plonky2::plonk::proof::{ProofWithPublicInputs, ProofWithPublicInputsTarget};
 use plonky2::recursion::cyclic_recursion::check_cyclic_proof_verifier_data;
 use plonky2::recursion::dummy_circuit::cyclic_base_proof;
+use plonky2::util::serialization::gate_serialization::default;
 use plonky2::util::serialization::{
     Buffer, GateSerializer, IoResult, Read, WitnessGeneratorSerializer, Write,
 };
@@ -70,7 +73,7 @@ where
     /// The block circuit, which verifies an aggregation root proof and a previous block proof.
     pub block: BlockCircuitData<F, C, D>,
     /// Holds chains of circuits for each table and for each initial `degree_bits`.
-    by_table: [RecursiveCircuitsForTable<F, C, D>; NUM_TABLES],
+    pub by_table: [RecursiveCircuitsForTable<F, C, D>; NUM_TABLES],
 }
 
 /// Data for the EVM root circuit, which is used to combine each STARK's shrunk wrapper proof
@@ -316,6 +319,7 @@ where
 
     pub fn from_bytes(
         bytes: &[u8],
+        skip_tables: bool,
         gate_serializer: &dyn GateSerializer<F, D>,
         generator_serializer: &dyn WitnessGeneratorSerializer<F, D>,
     ) -> IoResult<Self> {
@@ -330,21 +334,30 @@ where
         let block =
             BlockCircuitData::from_buffer(&mut buffer, gate_serializer, generator_serializer)?;
 
-        // Tricky use of MaybeUninit to remove the need for implementing Debug
-        // for all underlying types, necessary to convert a by_table Vec to an array.
-        let by_table = {
-            let mut by_table: [MaybeUninit<RecursiveCircuitsForTable<F, C, D>>; NUM_TABLES] =
-                unsafe { MaybeUninit::uninit().assume_init() };
-            for table in &mut by_table[..] {
-                let value = RecursiveCircuitsForTable::from_buffer(
-                    &mut buffer,
-                    gate_serializer,
-                    generator_serializer,
-                )?;
-                *table = MaybeUninit::new(value);
-            }
-            unsafe {
-                mem::transmute::<_, [RecursiveCircuitsForTable<F, C, D>; NUM_TABLES]>(by_table)
+        let by_table = match skip_tables {
+            true => (0..NUM_TABLES)
+                .map(|_| RecursiveCircuitsForTable {
+                    by_stark_size: BTreeMap::default(),
+                })
+                .collect_vec()
+                .try_into()
+                .unwrap(),
+            false => {
+                // Tricky use of MaybeUninit to remove the need for implementing Debug
+                // for all underlying types, necessary to convert a by_table Vec to an array.
+                let mut by_table: [MaybeUninit<RecursiveCircuitsForTable<F, C, D>>; NUM_TABLES] =
+                    unsafe { MaybeUninit::uninit().assume_init() };
+                for table in &mut by_table[..] {
+                    let value = RecursiveCircuitsForTable::from_buffer(
+                        &mut buffer,
+                        gate_serializer,
+                        generator_serializer,
+                    )?;
+                    *table = MaybeUninit::new(value);
+                }
+                unsafe {
+                    mem::transmute::<_, [RecursiveCircuitsForTable<F, C, D>; NUM_TABLES]>(by_table)
+                }
             }
         };
 
@@ -430,72 +443,6 @@ where
             block,
             by_table,
         }
-    }
-
-    /// Expand the preprocessed STARK table circuits with the provided ranges.
-    ///
-    /// If a range for a given table is contained within the current one, this will be a no-op.
-    /// Otherwise, it will add the circuits for the missing table sizes, and regenerate the upper circuits.
-    pub fn expand(
-        &mut self,
-        all_stark: &AllStark<F, D>,
-        degree_bits_ranges: &[Range<usize>; NUM_TABLES],
-        stark_config: &StarkConfig,
-    ) {
-        self.by_table[Table::Arithmetic as usize].expand(
-            Table::Arithmetic,
-            &all_stark.arithmetic_stark,
-            degree_bits_ranges[Table::Arithmetic as usize].clone(),
-            &all_stark.cross_table_lookups,
-            stark_config,
-        );
-        self.by_table[Table::BytePacking as usize].expand(
-            Table::BytePacking,
-            &all_stark.byte_packing_stark,
-            degree_bits_ranges[Table::BytePacking as usize].clone(),
-            &all_stark.cross_table_lookups,
-            stark_config,
-        );
-        self.by_table[Table::Cpu as usize].expand(
-            Table::Cpu,
-            &all_stark.cpu_stark,
-            degree_bits_ranges[Table::Cpu as usize].clone(),
-            &all_stark.cross_table_lookups,
-            stark_config,
-        );
-        self.by_table[Table::Keccak as usize].expand(
-            Table::Keccak,
-            &all_stark.keccak_stark,
-            degree_bits_ranges[Table::Keccak as usize].clone(),
-            &all_stark.cross_table_lookups,
-            stark_config,
-        );
-        self.by_table[Table::KeccakSponge as usize].expand(
-            Table::KeccakSponge,
-            &all_stark.keccak_sponge_stark,
-            degree_bits_ranges[Table::KeccakSponge as usize].clone(),
-            &all_stark.cross_table_lookups,
-            stark_config,
-        );
-        self.by_table[Table::Logic as usize].expand(
-            Table::Logic,
-            &all_stark.logic_stark,
-            degree_bits_ranges[Table::Logic as usize].clone(),
-            &all_stark.cross_table_lookups,
-            stark_config,
-        );
-        self.by_table[Table::Memory as usize].expand(
-            Table::Memory,
-            &all_stark.memory_stark,
-            degree_bits_ranges[Table::Memory as usize].clone(),
-            &all_stark.cross_table_lookups,
-            stark_config,
-        );
-
-        // Regenerate the upper circuits.
-        self.root = Self::create_root_circuit(&self.by_table, stark_config);
-        self.aggregation = Self::create_aggregation_circuit(&self.root);
-        self.block = Self::create_block_circuit(&self.aggregation);
     }
 
     /// Outputs the `VerifierCircuitData` needed to verify any block proof
@@ -988,7 +935,7 @@ where
                 .by_stark_size
                 .get(&original_degree_bits)
                 .ok_or_else(|| {
-                    anyhow::Error::msg(format!(
+                    anyhow!(format!(
                         "Missing preprocessed circuits for {:?} table with size {}.",
                         Table::all()[table],
                         original_degree_bits,
@@ -1003,6 +950,79 @@ where
             root_inputs.set_target(
                 self.root.index_verifier_data[table],
                 F::from_canonical_usize(index_verifier_data),
+            );
+            root_inputs.set_proof_with_pis_target(&self.root.proof_with_pis[table], &shrunk_proof);
+
+            check_abort_signal(abort_signal.clone())?;
+        }
+
+        root_inputs.set_verifier_data_target(
+            &self.root.cyclic_vk,
+            &self.aggregation.circuit.verifier_only,
+        );
+
+        set_public_value_targets(
+            &mut root_inputs,
+            &self.root.public_values,
+            &all_proof.public_values,
+        )
+        .map_err(|_| {
+            anyhow::Error::msg("Invalid conversion when setting public values targets.")
+        })?;
+
+        let root_proof = self.root.circuit.prove(root_inputs)?;
+
+        Ok((root_proof, all_proof.public_values))
+    }
+
+    /// Create a proof for each STARK, then combine them, eventually culminating in a root proof.
+    /// Fairly similar to `prove_root()` but aimed at being used when preprocessed table circuits
+    /// have not been loaded to memory.
+    pub fn prove_root_light(
+        &self,
+        preprocessed_tables_path: &Path,
+        all_stark: &AllStark<F, D>,
+        config: &StarkConfig,
+        generation_inputs: GenerationInputs,
+        gate_serializer: &dyn GateSerializer<F, D>,
+        generator_serializer: &dyn WitnessGeneratorSerializer<F, D>,
+        timing: &mut TimingTree,
+        abort_signal: Option<Arc<AtomicBool>>,
+    ) -> anyhow::Result<(ProofWithPublicInputs<F, C, D>, PublicValues)> {
+        let all_proof = prove::<F, C, D>(
+            all_stark,
+            config,
+            generation_inputs,
+            timing,
+            abort_signal.clone(),
+        )?;
+        let mut root_inputs = PartialWitness::new();
+
+        for table in 0..NUM_TABLES {
+            let stark_proof = &all_proof.stark_proofs[table];
+            let original_degree_bits = stark_proof.proof.recover_degree_bits(config);
+
+            let table_path = preprocessed_tables_path.join(format!(
+                "{:?}_{:?}.ser",
+                Table::all()[table],
+                original_degree_bits
+            ));
+            let bytes = std::fs::read(table_path)
+                .map_err(|_| anyhow::Error::msg("Invalid path to preprocessed circuits."))?;
+            let index_verifier_data = bytes[0];
+
+            let mut buffer = Buffer::new(&bytes[1..]);
+            let table_circuit = RecursiveCircuitsForTableSize::from_buffer(
+                &mut buffer,
+                gate_serializer,
+                generator_serializer,
+            )
+            .map_err(|_| anyhow::Error::msg("Circuit improperly serialized."))?;
+
+            let shrunk_proof = table_circuit.shrink(stark_proof, &all_proof.ctl_challenges)?;
+            root_inputs.set_target(
+                self.root.index_verifier_data[table],
+                F::from_canonical_u8(index_verifier_data),
             );
             root_inputs.set_proof_with_pis_target(&self.root.proof_with_pis[table], &shrunk_proof);
 
@@ -1255,7 +1275,7 @@ where
 {
     /// A map from `log_2(height)` to a chain of shrinking recursion circuits starting at that
     /// height.
-    by_stark_size: BTreeMap<usize, RecursiveCircuitsForTableSize<F, C, D>>,
+    pub by_stark_size: BTreeMap<usize, RecursiveCircuitsForTableSize<F, C, D>>,
 }
 
 impl<F, C, const D: usize> RecursiveCircuitsForTable<F, C, D>
@@ -1321,32 +1341,6 @@ where
         Self { by_stark_size }
     }
 
-    fn expand<S: Stark<F, D>>(
-        &mut self,
-        table: Table,
-        stark: &S,
-        degree_bits_range: Range<usize>,
-        all_ctls: &[CrossTableLookup<F>],
-        stark_config: &StarkConfig,
-    ) {
-        let new_ranges = degree_bits_range
-            .filter(|degree_bits| !self.by_stark_size.contains_key(degree_bits))
-            .collect_vec();
-
-        for degree_bits in new_ranges {
-            self.by_stark_size.insert(
-                degree_bits,
-                RecursiveCircuitsForTableSize::new::<S>(
-                    table,
-                    stark,
-                    degree_bits,
-                    all_ctls,
-                    stark_config,
-                ),
-            );
-        }
-    }
-
     /// For each initial `degree_bits`, get the final circuit at the end of that shrinking chain.
     /// Each of these final circuits should have degree `THRESHOLD_DEGREE_BITS`.
     fn final_circuits(&self) -> Vec<&CircuitData<F, C, D>> {
@@ -1366,7 +1360,7 @@ where
 /// A chain of shrinking wrapper circuits, ending with a final circuit with `degree_bits`
 /// `THRESHOLD_DEGREE_BITS`.
 #[derive(Eq, PartialEq, Debug)]
-struct RecursiveCircuitsForTableSize<F, C, const D: usize>
+pub struct RecursiveCircuitsForTableSize<F, C, const D: usize>
 where
     F: RichField + Extendable<D>,
     C: GenericConfig<D, F = F>,
@@ -1382,7 +1376,7 @@ where
     C: GenericConfig<D, F = F>,
     C::Hasher: AlgebraicHasher<F>,
 {
-    fn to_buffer(
+    pub fn to_buffer(
         &self,
         buffer: &mut Vec<u8>,
         gate_serializer: &dyn GateSerializer<F, D>,
@@ -1409,7 +1403,7 @@ where
         Ok(())
     }
 
-    fn from_buffer(
+    pub fn from_buffer(
         buffer: &mut Buffer,
         gate_serializer: &dyn GateSerializer<F, D>,
         generator_serializer: &dyn WitnessGeneratorSerializer<F, D>,
@@ -1500,7 +1494,7 @@ where
         }
     }
 
-    fn shrink(
+    pub fn shrink(
         &self,
         stark_proof_with_metadata: &StarkProofWithMetadata<F, C, D>,
         ctl_challenges: &GrandProductChallengeSet<F>,

--- a/evm/src/fixed_recursive_verifier.rs
+++ b/evm/src/fixed_recursive_verifier.rs
@@ -300,6 +300,7 @@ where
 {
     pub fn to_bytes(
         &self,
+        skip_tables: bool,
         gate_serializer: &dyn GateSerializer<F, D>,
         generator_serializer: &dyn WitnessGeneratorSerializer<F, D>,
     ) -> IoResult<Vec<u8>> {
@@ -311,8 +312,10 @@ where
             .to_buffer(&mut buffer, gate_serializer, generator_serializer)?;
         self.block
             .to_buffer(&mut buffer, gate_serializer, generator_serializer)?;
-        for table in &self.by_table {
-            table.to_buffer(&mut buffer, gate_serializer, generator_serializer)?;
+        if !skip_tables {
+            for table in &self.by_table {
+                table.to_buffer(&mut buffer, gate_serializer, generator_serializer)?;
+            }
         }
         Ok(buffer)
     }

--- a/evm/src/proof.rs
+++ b/evm/src/proof.rs
@@ -270,7 +270,7 @@ impl ExtraBlockData {
 /// Memory values which are public.
 /// Note: All the larger integers are encoded with 32-bit limbs in little-endian order.
 #[derive(Eq, PartialEq, Debug)]
-pub(crate) struct PublicValuesTarget {
+pub struct PublicValuesTarget {
     /// Trie hashes before the execution of the local state transition.
     pub trie_roots_before: TrieRootsTarget,
     /// Trie hashes after the execution of the local state transition.
@@ -485,7 +485,7 @@ impl PublicValuesTarget {
 /// Circuit version of `TrieRoots`.
 /// `Target`s for trie hashes. Since a `Target` holds a 32-bit limb, each hash requires 8 `Target`s.
 #[derive(Eq, PartialEq, Debug, Copy, Clone)]
-pub(crate) struct TrieRootsTarget {
+pub struct TrieRootsTarget {
     /// Targets for the state trie hash.
     pub(crate) state_root: [Target; 8],
     /// Targets for the transactions trie hash.
@@ -556,7 +556,7 @@ impl TrieRootsTarget {
 /// Metadata contained in a block header. Those are identical between
 /// all state transition proofs within the same block.
 #[derive(Eq, PartialEq, Debug, Copy, Clone)]
-pub(crate) struct BlockMetadataTarget {
+pub struct BlockMetadataTarget {
     /// `Target`s for the address of this block's producer.
     pub(crate) block_beneficiary: [Target; 5],
     /// `Target` for the timestamp of this block.
@@ -681,7 +681,7 @@ impl BlockMetadataTarget {
 /// When the block number is less than 256, dummy values, i.e. `H256::default()`,
 /// should be used for the additional block hashes.
 #[derive(Eq, PartialEq, Debug, Copy, Clone)]
-pub(crate) struct BlockHashesTarget {
+pub struct BlockHashesTarget {
     /// `Target`s for the previous 256 hashes to the current block. The leftmost hash, i.e. `prev_hashes[0..8]`,
     /// is the oldest, and the rightmost, i.e. `prev_hashes[255 * 7..255 * 8]` is the hash of the parent block.
     pub(crate) prev_hashes: [Target; 2048],
@@ -739,7 +739,7 @@ impl BlockHashesTarget {
 /// Additional block data that are specific to the local transaction being proven,
 /// unlike `BlockMetadata`.
 #[derive(Eq, PartialEq, Debug, Copy, Clone)]
-pub(crate) struct ExtraBlockDataTarget {
+pub struct ExtraBlockDataTarget {
     /// `Target`s for the state trie digest of the checkpoint block.
     pub checkpoint_state_trie_root: [Target; 8],
     /// `Target` for the transaction count prior execution of the local state transition, starting

--- a/evm/src/prover.rs
+++ b/evm/src/prover.rs
@@ -668,7 +668,7 @@ where
 /// Utility method that checks whether a kill signal has been emitted by one of the workers,
 /// which will result in an early abort for all the other processes involved in the same set
 /// of transactions.
-pub(crate) fn check_abort_signal(abort_signal: Option<Arc<AtomicBool>>) -> Result<()> {
+pub fn check_abort_signal(abort_signal: Option<Arc<AtomicBool>>) -> Result<()> {
     if let Some(signal) = abort_signal {
         if signal.load(Ordering::Relaxed) {
             return Err(anyhow!("Stopping job from abort signal."));

--- a/evm/src/recursive_verifier.rs
+++ b/evm/src/recursive_verifier.rs
@@ -803,7 +803,7 @@ pub(crate) fn set_stark_proof_target<F, C: GenericConfig<D, F = F>, W, const D: 
     set_fri_proof_target(witness, &proof_target.opening_proof, &proof.opening_proof);
 }
 
-pub(crate) fn set_public_value_targets<F, W, const D: usize>(
+pub fn set_public_value_targets<F, W, const D: usize>(
     witness: &mut W,
     public_values_target: &PublicValuesTarget,
     public_values: &PublicValues,

--- a/evm/tests/empty_txn_list.rs
+++ b/evm/tests/empty_txn_list.rs
@@ -75,11 +75,9 @@ fn test_empty_txn_list() -> anyhow::Result<()> {
     };
 
     // Initialize the preprocessed circuits for the zkEVM.
-    // The provided ranges are the minimal ones to prove an empty list, except the one of the CPU
-    // that is wrong for testing purposes, see below.
-    let mut all_circuits = AllRecursiveCircuits::<F, C, D>::new(
+    let all_circuits = AllRecursiveCircuits::<F, C, D>::new(
         &all_stark,
-        &[16..17, 10..11, 11..12, 14..15, 9..11, 12..13, 17..18], // Minimal ranges to prove an empty list
+        &[16..17, 10..11, 12..13, 14..15, 9..11, 12..13, 17..18], // Minimal ranges to prove an empty list
         &config,
     );
 
@@ -102,6 +100,7 @@ fn test_empty_txn_list() -> anyhow::Result<()> {
         let timing = TimingTree::new("deserialize AllRecursiveCircuits", log::Level::Info);
         let all_circuits_from_bytes = AllRecursiveCircuits::<F, C, D>::from_bytes(
             &all_circuits_bytes,
+            false,
             &gate_serializer,
             &generator_serializer,
         )
@@ -110,20 +109,6 @@ fn test_empty_txn_list() -> anyhow::Result<()> {
 
         assert_eq!(all_circuits, all_circuits_from_bytes);
     }
-
-    let mut timing = TimingTree::new("prove", log::Level::Info);
-    // We're missing some preprocessed circuits.
-    assert!(all_circuits
-        .prove_root(&all_stark, &config, inputs.clone(), &mut timing, None)
-        .is_err());
-
-    // Expand the preprocessed circuits.
-    // We pass an empty range if we don't want to add different table sizes.
-    all_circuits.expand(
-        &all_stark,
-        &[0..0, 0..0, 12..13, 0..0, 0..0, 0..0, 0..0],
-        &StarkConfig::standard_fast_config(),
-    );
 
     let mut timing = TimingTree::new("prove", log::Level::Info);
     let (root_proof, public_values) =

--- a/evm/tests/empty_txn_list.rs
+++ b/evm/tests/empty_txn_list.rs
@@ -89,7 +89,7 @@ fn test_empty_txn_list() -> anyhow::Result<()> {
 
         let timing = TimingTree::new("serialize AllRecursiveCircuits", log::Level::Info);
         let all_circuits_bytes = all_circuits
-            .to_bytes(&gate_serializer, &generator_serializer)
+            .to_bytes(false, &gate_serializer, &generator_serializer)
             .map_err(|_| anyhow::Error::msg("AllRecursiveCircuits serialization failed."))?;
         timing.filter(Duration::from_millis(100)).print();
         info!(


### PR DESCRIPTION
This PR:
- Allows to write/load only upper circuits when serializing/deserializing the prover state (i.e. by skipping all the STARK table circuits).
- Adds an alternative method to prove txns (`prove_root_light()`) by passing an additional path to a folder containing all different table circuits. After generating the initial STARK, the prover will read only the necessary circuit files, deserializes them and process to recursion. The files are expected to be stored at `initial_path/TableName_size.ser`.
- Also removes the `expand` methods, which were only added previously for easier testing but ended up never being really useful.

cc @cpubot: For zero-bin / eth-tx-proof, we would:

- still be generating the initial prover state as usual.
- instead of writing the entire state in a single file, we would write the upper circuits to a single file, which would be the default prover state (and sufficient for aggreg/block proofs).
- for each individual table, write them to a dedicated file within the same folder, with the format above.
- pass the serializers and the folder containing serialized tables when calling `generate_txn_proof`, with new signature below:

_Important note_: when writing the individual tables to file, we *MUST* prepend the byte payload by a byte indicating the position of this table in the initial range specified when constructing the prover state. Say we specified ranges 16..28 for the `Arithmetic` table, we should write first 3 in the file `Arithmetic_19.ser` before writing the actual serialized circuit. This is necessary to be able to prove transactions recursively.

```rust
pub fn generate_txn_proof(
    p_state: &ProverState,
    preprocessed_tables_path: &Path,
    start_info: TxnProofGenIR,
    gate_serializer: &dyn GateSerializer<GoldilocksField, 2>,
    generator_serializer: &dyn WitnessGeneratorSerializer<GoldilocksField, 2>,
    abort_signal: Option<Arc<AtomicBool>>,
) -> ProofGenResult<GeneratedTxnProof> {
```

Please let me know if there's anything that you'd like changed. I can also help with the integration in the decoder and zero-bin.


closes #1394 