### PR TITLE
Pacify latest clippy

### DIFF
--- a/evm/src/cpu/columns/general.rs
+++ b/evm/src/cpu/columns/general.rs
@@ -76,6 +76,7 @@ impl<T: Copy> CpuGeneralColumnsView<T> {
 }
 
 impl<T: Copy + PartialEq> PartialEq<Self> for CpuGeneralColumnsView<T> {
+    #[allow(clippy::unconditional_recursion)] // false positive
     fn eq(&self, other: &Self) -> bool {
         let self_arr: &[T; NUM_SHARED_COLUMNS] = self.borrow();
         let other_arr: &[T; NUM_SHARED_COLUMNS] = other.borrow();


### PR DESCRIPTION
Latest clippy is complaining wrongly about unconditional recursion. 

```bash
error: function cannot return without recursing
  --> evm/src/cpu/columns/general.rs:79:5
   |
79 | /     fn eq(&self, other: &Self) -> bool {
80 | |         let self_arr: &[T; NUM_SHARED_COLUMNS] = self.borrow();
81 | |         let other_arr: &[T; NUM_SHARED_COLUMNS] = other.borrow();
82 | |         self_arr == other_arr
83 | |     }
   | |_____^
   |
note: recursive call site
  --> evm/src/cpu/columns/general.rs:82:9
   |
82 |         self_arr == other_arr
   |         ^^^^^^^^^^^^^^^^^^^^^
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unconditional_recursion
   = note: `-D clippy::unconditional-recursion` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(clippy::unconditional_recursion)]`
```