### PR TITLE
Remove some lints from being allowed in crates

### DIFF
--- a/evm/src/cpu/kernel/tests/blake2_f.rs
+++ b/evm/src/cpu/kernel/tests/blake2_f.rs
@@ -5,6 +5,8 @@ use crate::cpu::kernel::interpreter::{
 };
 use crate::memory::segments::Segment::KernelGeneral;
 
+type ConvertedBlakeInputs = (u32, [u64; 8], [u64; 16], u64, u64, bool);
+
 fn reverse_bytes_u64(input: u64) -> u64 {
     let mut result = 0;
     for i in 0..8 {
@@ -13,7 +15,7 @@ fn reverse_bytes_u64(input: u64) -> u64 {
     result
 }
 
-fn convert_input(input: &str) -> Result<(u32, [u64; 8], [u64; 16], u64, u64, bool)> {
+fn convert_input(input: &str) -> Result<ConvertedBlakeInputs> {
     let rounds = u32::from_str_radix(&input[..8], 16).unwrap();
 
     let mut h = [0u64; 8];

--- a/evm/src/lib.rs
+++ b/evm/src/lib.rs
@@ -1,7 +1,5 @@
-#![allow(incomplete_features)]
 #![allow(clippy::needless_range_loop)]
 #![allow(clippy::too_many_arguments)]
-#![allow(clippy::type_complexity)]
 #![allow(clippy::field_reassign_with_default)]
 #![allow(unused)]
 #![feature(let_chains)]

--- a/evm/tests/log_opcode.rs
+++ b/evm/tests/log_opcode.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::upper_case_acronyms)]
-
 use std::collections::HashMap;
 use std::str::FromStr;
 use std::time::Duration;

--- a/util/src/lib.rs
+++ b/util/src/lib.rs
@@ -1,6 +1,3 @@
-#![allow(clippy::new_without_default)]
-#![allow(clippy::too_many_arguments)]
-#![allow(clippy::type_complexity)]
 #![allow(clippy::needless_range_loop)]
 #![no_std]
 


### PR DESCRIPTION
Some `#![allow(clippy::foo)]` are outdated by now.