### PR TITLE
Improve some calls to `%mstore_rlp`

### DIFF
--- a/evm/src/cpu/kernel/asm/memory/core.asm
+++ b/evm/src/cpu/kernel/asm/memory/core.asm
@@ -410,7 +410,7 @@
 %endmacro
 
 // Store a single byte to @SEGMENT_RLP_RAW.
-%macro mstore_rlp
+%macro swap_mstore
     // stack: addr, value
     SWAP1
     MSTORE_GENERAL

--- a/evm/src/cpu/kernel/asm/memory/core.asm
+++ b/evm/src/cpu/kernel/asm/memory/core.asm
@@ -409,7 +409,6 @@
     %mstore_u32
 %endmacro
 
-// Store a single byte to @SEGMENT_RLP_RAW.
 %macro swap_mstore
     // stack: addr, value
     SWAP1

--- a/evm/src/cpu/kernel/asm/mpt/hash/hash.asm
+++ b/evm/src/cpu/kernel/asm/mpt/hash/hash.asm
@@ -151,8 +151,8 @@ global encode_node_branch:
 
     // No value; append the empty string (0x80).
     // stack: value_ptr, rlp_pos', rlp_start, encode_value, cur_len, retdest
-    %stack (value_ptr, rlp_pos, rlp_start, encode_value) -> (rlp_pos, 0x80, rlp_pos, rlp_start)
-    %mstore_rlp
+    %stack (value_ptr, rlp_pos, rlp_start, encode_value) -> (0x80, rlp_pos, rlp_pos, rlp_start)
+    MSTORE_GENERAL
     // stack: rlp_pos', rlp_start, cur_len, retdest
     %increment
     // stack: rlp_pos'', rlp_start, cur_len, retdest
@@ -192,9 +192,9 @@ encode_node_branch_prepend_prefix:
     SWAP1 DUP1 %sub_const(32) %jumpi(%%unpack)
     // Otherwise, result is a hash, and we need to add the prefix 0x80 + 32 = 160.
     // stack: result_len, result, cur_len, rlp_pos, rlp_start, node_payload_ptr, encode_value, retdest
+    DUP4 // rlp_pos
     PUSH 160
-    DUP5 // rlp_pos
-    %mstore_rlp
+    MSTORE_GENERAL
     SWAP3 %increment SWAP3 // rlp_pos += 1
 %%unpack:
     %stack (result_len, result, cur_len, rlp_pos, rlp_start, node_payload_ptr, encode_value, retdest)
@@ -233,9 +233,9 @@ encode_node_extension_after_hex_prefix:
     // If result_len != 32, result is raw RLP, with an appropriate RLP prefix already.
     DUP4 %sub_const(32) %jumpi(encode_node_extension_unpack)
     // Otherwise, result is a hash, and we need to add the prefix 0x80 + 32 = 160.
+    DUP1 // rlp_pos
     PUSH 160
-    DUP2 // rlp_pos
-    %mstore_rlp
+    MSTORE_GENERAL
     %increment // rlp_pos += 1
 encode_node_extension_unpack:
     %stack (rlp_pos, rlp_start, result, result_len, node_payload_ptr, cur_len)

--- a/evm/src/cpu/kernel/asm/mpt/hash/hash_trie_specific.asm
+++ b/evm/src/cpu/kernel/asm/mpt/hash/hash_trie_specific.asm
@@ -326,8 +326,8 @@ encode_nonzero_receipt_type:
     // stack: rlp_receipt_len, txn_type, rlp_addr, value_ptr, retdest
     DUP3 %encode_rlp_multi_byte_string_prefix
     // stack: rlp_addr, txn_type, old_rlp_addr, value_ptr, retdest
-    DUP2 DUP2
-    %mstore_rlp
+    DUP1 DUP3
+    MSTORE_GENERAL
     %increment
     // stack: rlp_addr, txn_type, old_rlp_addr, value_ptr, retdest
     %stack (rlp_addr, txn_type, old_rlp_addr, value_ptr, retdest) -> (rlp_addr, value_ptr, retdest)

--- a/evm/src/cpu/kernel/asm/mpt/hex_prefix.asm
+++ b/evm/src/cpu/kernel/asm/mpt/hex_prefix.asm
@@ -27,7 +27,7 @@ first_byte:
     // stack: rlp_addr, num_nibbles, packed_nibbles, terminated, retdest
     // get the first nibble, if num_nibbles is odd, or zero otherwise
     SWAP2
-    // stack: packed_nibbles, num_nibbbles, rlp_addr, terminated, retdest
+    // stack: packed_nibbles, num_nibbles, rlp_addr, terminated, retdest
     DUP2 DUP1
     %mod_const(2)
     // stack: parity, num_nibbles, packed_nibbles, num_nibbles, rlp_addr, terminated, retdest
@@ -50,7 +50,7 @@ first_byte:
     ADD
     // stack: first_byte, rlp_addr, retdest
     DUP2
-    %mstore_rlp
+    %swap_mstore
     %increment
     // stack: rlp_addr', retdest
     SWAP1
@@ -88,7 +88,7 @@ rlp_header_medium:
     // stack: hp_len, rlp_addr, num_nibbles, packed_nibbles, terminated, retdest
     %add_const(0x80) // value = 0x80 + hp_len
     DUP2
-    %mstore_rlp
+    %swap_mstore
     // stack: rlp_addr, num_nibbles, packed_nibbles, terminated, retdest
     // rlp_addr += 1
     %increment
@@ -108,14 +108,14 @@ rlp_header_large:
     // In practice hex-prefix length will never exceed 256, so the length of the
     // length will always be 1 byte in this case.
 
+    DUP2 // rlp_addr
     PUSH 0xb8 // value = 0xb7 + len_of_len = 0xb8
-    DUP3
-    %mstore_rlp
+    MSTORE_GENERAL
     // stack: rlp_addr, value, hp_len, i, rlp_addr, num_nibbles, packed_nibbles, terminated, retdest
 
     // stack: hp_len, rlp_addr, num_nibbles, packed_nibbles, terminated, retdest
     DUP2 %increment
-    %mstore_rlp
+    %swap_mstore
 
     // stack: rlp_addr, num_nibbles, packed_nibbles, terminated, retdest
     // rlp_addr += 2

--- a/evm/src/cpu/kernel/asm/mpt/util.asm
+++ b/evm/src/cpu/kernel/asm/mpt/util.asm
@@ -11,9 +11,9 @@
 %endmacro
 
 %macro initialize_rlp_segment
-    PUSH 0x80
     PUSH @ENCODED_EMPTY_NODE_POS
-    %mstore_rlp
+    PUSH 0x80
+    MSTORE_GENERAL
 %endmacro
 
 %macro alloc_rlp_block


### PR DESCRIPTION
Following #1426, `%mstore_rlp`'s name is not really meaningful, as it only performs `SWAP MSTORE_GENERAL`.
Additionally, most calls can be changed to a single call to `MSTORE_GENERAL` instead by reordering previous stack operations. This addresses it and renames the last remaining calls to `%mstore_rlp` as `%swap_mstore` for clarity.