### PR TITLE
Free up some CPU cycles

### DIFF
--- a/evm/src/cpu/kernel/asm/bignum/cmp.asm
+++ b/evm/src/cpu/kernel/asm/bignum/cmp.asm
@@ -12,17 +12,19 @@ global cmp_bignum:
     // stack: len, a_start_loc, b_start_loc, retdest
     SWAP1
     // stack: a_start_loc, len, b_start_loc, retdest
-    DUP2
-    // stack: len, a_start_loc, len, b_start_loc, retdest
+    PUSH 1
+    DUP3
+    SUB
+    // stack: len-1, a_start_loc, len, b_start_loc, retdest
     ADD
-    %decrement
     // stack: a_end_loc, len, b_start_loc, retdest
     SWAP2
     // stack: b_start_loc, len, a_end_loc, retdest
-    DUP2
-    // stack: len, b_start_loc, len, a_end_loc, retdest
+    PUSH 1
+    DUP3
+    SUB
+    // stack: len-1, b_start_loc, len, a_end_loc, retdest
     ADD
-    %decrement
     // stack: b_end_loc, len, a_end_loc, retdest
     %stack (b, l, a) -> (l, a, b)
     // stack: len, a_end_loc, b_end_loc, retdest

--- a/evm/src/cpu/kernel/asm/bignum/shr.asm
+++ b/evm/src/cpu/kernel/asm/bignum/shr.asm
@@ -42,9 +42,9 @@ shr_loop:
     // stack: i, carry << 127 | a[i] >> 1, i, new_carry, start_loc, retdest
     %mstore_current_general
     // stack: i, new_carry, start_loc, retdest
-    DUP1
-    // stack: i, i, new_carry, start_loc, retdest
-    %decrement
+    PUSH 1
+    DUP2
+    SUB
     // stack: i-1, i, new_carry, start_loc, retdest
     SWAP1
     // stack: i, i-1, new_carry, start_loc, retdest

--- a/evm/src/cpu/kernel/asm/bloom_filter.asm
+++ b/evm/src/cpu/kernel/asm/bloom_filter.asm
@@ -142,10 +142,11 @@ logs_bloom_end:
 // Also updates the block bloom filter.
 %macro bloom_write_bit
     // stack: byte_index, byte_bit_index
-    DUP2 
-    // stack: byte_bit_index, byte_index, byte_bit_index
+    PUSH 1
+    DUP3
+    // stack: byte_bit_index, 1, byte_index, byte_bit_index
     PUSH 7 SUB
-    PUSH 1 SWAP1 SHL
+    SHL
     // Updates the current txn bloom filter.
     SWAP2 POP DUP1
     %mload_kernel(@SEGMENT_TXN_BLOOM)

--- a/evm/src/cpu/kernel/asm/core/gas.asm
+++ b/evm/src/cpu/kernel/asm/core/gas.asm
@@ -122,7 +122,7 @@ global sys_gasprice:
 //     L(n) = n - floor(n / 64)
 %macro all_but_one_64th
     // stack: n
-    DUP1 %div_const(64)
+    DUP1 %shr_const(6)
     // stack: floor(n / 64), n
     SWAP1 SUB
     // stack: n - floor(n / 64)

--- a/evm/src/cpu/kernel/asm/curve/secp256k1/ecrecover.asm
+++ b/evm/src/cpu/kernel/asm/curve/secp256k1/ecrecover.asm
@@ -97,8 +97,9 @@ ecdsa_after_precompute_loop_contd:
     ISZERO %jumpi(ecdsa_after_precompute_loop_end)
     %jump(secp_double)
 ecdsa_after_precompute_loop_contd2:
-    %stack (accx, accy, i, a0, a1, b0, b1, retdest) -> (i, accx, accy, a0, a1, b0, b1, retdest)
-    %decrement %jump(ecdsa_after_precompute_loop)
+    %stack (accx, accy, i, a0, a1, b0, b1, retdest) -> (i, 1, accx, accy, a0, a1, b0, b1, retdest)
+    SUB // i - 1
+    %jump(ecdsa_after_precompute_loop)
 ecdsa_after_precompute_loop_end:
     // Check that the public key is not the point at infinity. See https://github.com/ethereum/eth-keys/pull/76 for discussion.
     DUP2 DUP2 ISZERO SWAP1 ISZERO MUL %jumpi(pk_is_infinity)

--- a/evm/src/cpu/kernel/asm/exp.asm
+++ b/evm/src/cpu/kernel/asm/exp.asm
@@ -86,7 +86,7 @@ sys_exp_gas_loop_enter:
     // stack: e >> shift, shift, x, e, return_info
     %jumpi(sys_exp_gas_loop)
     // stack: shift_bits, x, e, return_info
-    %div_const(8)
+    %shr_const(3)
     // stack: byte_size_of_e := shift_bits / 8, x, e, return_info
     %mul_const(@GAS_EXPBYTE)
     %add_const(@GAS_EXP)

--- a/evm/src/cpu/kernel/asm/hash/blake2/compression.asm
+++ b/evm/src/cpu/kernel/asm/hash/blake2/compression.asm
@@ -21,10 +21,10 @@ compression_loop:
     // stack: addr, cur_block, retdest
     POP
     // stack: cur_block, retdest
-    PUSH 0
     PUSH 1
+    PUSH 0
     %mload_current_general
-    // stack: num_blocks, cur_block, retdest
+    // stack: num_blocks, 1, cur_block, retdest
     SUB
     // stack: num_blocks - 1, cur_block, retdest
     DUP2

--- a/evm/src/cpu/kernel/asm/hash/blake2/compression.asm
+++ b/evm/src/cpu/kernel/asm/hash/blake2/compression.asm
@@ -22,9 +22,10 @@ compression_loop:
     POP
     // stack: cur_block, retdest
     PUSH 0
+    PUSH 1
     %mload_current_general
     // stack: num_blocks, cur_block, retdest
-    %decrement
+    SUB
     // stack: num_blocks - 1, cur_block, retdest
     DUP2
     // stack: cur_block, num_blocks - 1, cur_block, retdest

--- a/evm/src/cpu/kernel/asm/hash/sha2/main.asm
+++ b/evm/src/cpu/kernel/asm/hash/sha2/main.asm
@@ -31,7 +31,7 @@ global sha2_pad:
     DUP1
     // stack: num_bytes, num_bytes, retdest
     %add_const(8)
-    %div_const(64)
+    %shr_const(6)
     
     %increment
     // stack: num_blocks = (num_bytes+8)//64 + 1, num_bytes, retdest

--- a/evm/src/cpu/kernel/asm/hash/sha2/ops.asm
+++ b/evm/src/cpu/kernel/asm/hash/sha2/ops.asm
@@ -34,7 +34,7 @@
     // stack: rotr(x, 18), x, rotr(x, 7)
     SWAP1
     // stack: x, rotr(x, 18), rotr(x, 7)
-    %div_const(8) // equivalent to %shr_const(3)
+    %shr_const(3)
     // stack: shr(x, 3), rotr(x, 18), rotr(x, 7)
     XOR
     XOR

--- a/evm/src/cpu/kernel/asm/hash/sha2/write_length.asm
+++ b/evm/src/cpu/kernel/asm/hash/sha2/write_length.asm
@@ -17,11 +17,12 @@
         %decrement
         SWAP1
         // stack: length >> (8 * i), last_addr - i - 2
-        %div_const(256) // equivalent to %shr_const(8)
+        %shr_const(8)
         // stack: length >> (8 * (i + 1)), last_addr - i - 2
-        DUP1
-        // stack: length >> (8 * (i + 1)), length >> (8 * (i + 1)), last_addr - i - 2
-        %mod_const(256)
+        PUSH 256
+        DUP2
+        // stack: length >> (8 * (i + 1)), 256, length >> (8 * (i + 1)), last_addr - i - 2
+        MOD
         // stack: (length >> (8 * (i + 1))) % (1 << 8), length >> (8 * (i + 1)), last_addr - i - 2
         DUP3
         // stack: last_addr - i - 2, (length >> (8 * (i + 1))) % (1 << 8), length >> (8 * (i + 1)), last_addr - i - 2

--- a/evm/src/cpu/kernel/asm/journal/journal.asm
+++ b/evm/src/cpu/kernel/asm/journal/journal.asm
@@ -199,8 +199,9 @@
 %endmacro
 
 %macro pop_checkpoint
+    PUSH 1
     %mload_context_metadata(@CTX_METADATA_CHECKPOINTS_LEN)
     // stack: i
-    %decrement
+    SUB
     %mstore_context_metadata(@CTX_METADATA_CHECKPOINTS_LEN)
 %endmacro

--- a/evm/src/cpu/kernel/asm/journal/log.asm
+++ b/evm/src/cpu/kernel/asm/journal/log.asm
@@ -8,8 +8,9 @@ global revert_log:
     // stack: entry_type, ptr, retdest
     POP
     // First, reduce the number of logs.
+    PUSH 1
     %mload_global_metadata(@GLOBAL_METADATA_LOGS_LEN)
-    %decrement
+    SUB
     %mstore_global_metadata(@GLOBAL_METADATA_LOGS_LEN)
     // stack: ptr, retdest
     // Second, restore payload length.

--- a/evm/src/cpu/kernel/asm/memory/metadata.asm
+++ b/evm/src/cpu/kernel/asm/memory/metadata.asm
@@ -359,7 +359,7 @@ zero_hash:
     // stack: num_bytes
     %add_const(31)
     // stack: 31 + num_bytes
-    %div_const(32)
+    %shr_const(5)
     // stack: (num_bytes + 31) / 32
 %endmacro
 
@@ -372,7 +372,7 @@ zero_hash:
     SWAP1
     // stack: num_words, num_words * GAS_MEMORY
     %square
-    %div_const(512)
+    %shr_const(9)
     // stack: num_words^2 / 512, num_words * GAS_MEMORY
     ADD
     // stack: cost = num_words^2 / 512 + num_words * GAS_MEMORY
@@ -422,8 +422,9 @@ zero_hash:
 %endmacro
 
 %macro decrement_call_depth
+    PUSH 1
     %mload_global_metadata(@GLOBAL_METADATA_CALL_STACK_DEPTH)
-    %decrement
+    SUB
     %mstore_global_metadata(@GLOBAL_METADATA_CALL_STACK_DEPTH)
 %endmacro
 

--- a/evm/src/cpu/kernel/asm/rlp/encode.asm
+++ b/evm/src/cpu/kernel/asm/rlp/encode.asm
@@ -84,8 +84,10 @@ global encode_rlp_multi_byte_string_prefix:
     %jumpi(encode_rlp_multi_byte_string_prefix_large)
     // Medium case; prefix is 0x80 + str_len.
     // stack: rlp_addr, str_len, retdest
-    DUP1
-    SWAP2 %add_const(0x80)
+    PUSH 0x80
+    DUP2
+    // stack: rlp_addr, 0x80, rlp_addr, str_len, retdest
+    SWAP3 ADD
     // stack: prefix, rlp_addr, rlp_addr, retdest
     MSTORE_GENERAL
     // stack: rlp_addr, retdest
@@ -178,7 +180,7 @@ global prepend_rlp_list_prefix:
 
     // If we got here, we have a small list, so we prepend 0xc0 + len at rlp_address 8.
     // stack: payload_len, end_rlp_addr, start_rlp_addr, retdest
-    DUP3 %decrement // offset of prefix
+    PUSH 1 DUP4 SUB // offset of prefix
     DUP2 %add_const(0xc0)
     // stack: prefix_byte, start_rlp_addr-1, payload_len, end_rlp_addr, start_rlp_addr, retdest
     MSTORE_GENERAL
@@ -198,7 +200,7 @@ prepend_rlp_list_prefix_big:
     DUP1 %num_bytes
     // stack: len_of_len, payload_len, end_rlp_addr, start_rlp_addr, retdest
     DUP1
-    DUP5 %decrement // start_rlp_addr - 1
+    PUSH 1 DUP6 SUB // start_rlp_addr - 1
     SUB
     // stack: prefix_start_rlp_addr, len_of_len, payload_len, end_rlp_addr, start_rlp_addr, retdest
     DUP2 %add_const(0xf7) DUP2 %swap_mstore // rlp[prefix_start_rlp_addr] = 0xf7 + len_of_len

--- a/evm/src/cpu/kernel/asm/rlp/encode_rlp_scalar.asm
+++ b/evm/src/cpu/kernel/asm/rlp/encode_rlp_scalar.asm
@@ -86,6 +86,14 @@ encode_rlp_scalar_small:
     JUMP
 
 // Convenience macro to call encode_rlp_scalar and return where we left off.
+// It takes swapped inputs, i.e. `scalar, rlp_addr` instead of `rlp_addr, scalar`.
+%macro encode_rlp_scalar_swapped_inputs
+    %stack (scalar, rlp_addr) -> (rlp_addr, scalar, %%after)
+    %jump(encode_rlp_scalar)
+%%after:
+%endmacro
+
+// Convenience macro to call encode_rlp_scalar and return where we left off.
 %macro encode_rlp_scalar
     %stack (rlp_addr, scalar) -> (rlp_addr, scalar, %%after)
     %jump(encode_rlp_scalar)

--- a/evm/src/cpu/kernel/asm/rlp/num_bytes.asm
+++ b/evm/src/cpu/kernel/asm/rlp/num_bytes.asm
@@ -5,8 +5,12 @@ global num_bytes:
     DUP1 ISZERO %jumpi(return_1)
     // Non-deterministically guess the number of bits
     PROVER_INPUT(num_bits)
-    %stack (num_bits, x) -> (num_bits, x, num_bits)
-    %decrement
+    // stack: num_bits, x
+    SWAP1
+    PUSH 1
+    DUP3
+    // stack: num_bits, 1, x, num_bits
+    SUB
     SHR
     // stack: 1, num_bits
     %assert_eq_const(1)
@@ -17,7 +21,10 @@ global num_bytes:
     SWAP1
     JUMP
 
-return_1:  POP PUSH  1 SWAP1 JUMP
+return_1:
+    // stack: x, retdest
+    %stack(x, retdest) -> (retdest, 1)
+    JUMP
 
 // Convenience macro to call num_bytes and return where we left off.
 %macro num_bytes

--- a/evm/src/cpu/kernel/asm/rlp/num_bytes.asm
+++ b/evm/src/cpu/kernel/asm/rlp/num_bytes.asm
@@ -5,11 +5,7 @@ global num_bytes:
     DUP1 ISZERO %jumpi(return_1)
     // Non-deterministically guess the number of bits
     PROVER_INPUT(num_bits)
-    // stack: num_bits, x
-    SWAP1
-    PUSH 1
-    DUP3
-    // stack: num_bits, 1, x, num_bits
+    %stack(num_bits, x) -> (num_bits, 1, x, num_bits)
     SUB
     SHR
     // stack: 1, num_bits

--- a/evm/src/cpu/kernel/asm/transactions/router.asm
+++ b/evm/src/cpu/kernel/asm/transactions/router.asm
@@ -5,10 +5,8 @@
 global route_txn:
     // stack: txn_counter, num_nibbles, retdest
     // First load transaction data into memory, where it will be parsed.
-    PUSH read_txn_from_memory
-    SWAP2 SWAP1
-    PUSH update_txn_trie
-    // stack: update_txn_trie, tx_counter, num_nibbles, read_txn_from_memory, retdest
+    %stack(txn_counter, num_nibbles) -> (update_txn_trie, txn_counter, num_nibbles, read_txn_from_memory)
+    // stack: update_txn_trie, txn_counter, num_nibbles, read_txn_from_memory, retdest
     %jump(read_rlp_to_memory)
 
 // At this point, the raw txn data is in memory.

--- a/evm/src/cpu/kernel/asm/transactions/type_0.asm
+++ b/evm/src/cpu/kernel/asm/transactions/type_0.asm
@@ -61,7 +61,7 @@ process_v_new_style:
     %sub_const(35)
     DUP1
     // stack: v - 35, v - 35, rlp_addr, retdest
-    %div_const(2)
+    %div2
     // stack: chain_id, v - 35, rlp_addr, retdest
     %mstore_txn_field(@TXN_FIELD_CHAIN_ID)
 
@@ -94,11 +94,11 @@ type_0_compute_signed_data:
     // stack: rlp_addr, rlp_addr_start, retdest
 
     %mload_txn_field(@TXN_FIELD_MAX_FEE_PER_GAS)
-    SWAP1 %encode_rlp_scalar
+    %encode_rlp_scalar_swapped_inputs
     // stack: rlp_addr, rlp_addr_start, retdest
 
     %mload_txn_field(@TXN_FIELD_GAS_LIMIT)
-    SWAP1 %encode_rlp_scalar
+    %encode_rlp_scalar_swapped_inputs
     // stack: rlp_addr, rlp_addr_start, retdest
 
     %mload_txn_field(@TXN_FIELD_TO)
@@ -108,12 +108,12 @@ type_0_compute_signed_data:
     %jump(after_to)
 zero_to:
     // stack: to, rlp_addr, rlp_addr_start, retdest
-    SWAP1 %encode_rlp_scalar
+    %encode_rlp_scalar_swapped_inputs
     // stack: rlp_addr, rlp_addr_start, retdest
 
 after_to:
     %mload_txn_field(@TXN_FIELD_VALUE)
-    SWAP1 %encode_rlp_scalar
+    %encode_rlp_scalar_swapped_inputs
     // stack: rlp_addr, rlp_addr_start, retdest
 
     // Encode txn data.
@@ -133,15 +133,15 @@ after_serializing_txn_data:
     // stack: rlp_addr, rlp_addr_start, retdest
 
     %mload_txn_field(@TXN_FIELD_CHAIN_ID)
-    SWAP1 %encode_rlp_scalar
+    %encode_rlp_scalar_swapped_inputs
     // stack: rlp_addr, rlp_addr_start, retdest
 
     PUSH 0
-    SWAP1 %encode_rlp_scalar
+    %encode_rlp_scalar_swapped_inputs
     // stack: rlp_addr, rlp_addr_start, retdest
 
     PUSH 0
-    SWAP1 %encode_rlp_scalar
+    %encode_rlp_scalar_swapped_inputs
     // stack: rlp_addr, rlp_addr_start, retdest
 
 finish_rlp_list:

--- a/evm/src/cpu/kernel/asm/transactions/type_1.asm
+++ b/evm/src/cpu/kernel/asm/transactions/type_1.asm
@@ -48,15 +48,15 @@ type_1_compute_signed_data:
     // stack: rlp_addr, rlp_addr_start, retdest
 
     %mload_txn_field(@TXN_FIELD_NONCE)
-    SWAP1 %encode_rlp_scalar
+    %encode_rlp_scalar_swapped_inputs
     // stack: rlp_addr, rlp_addr_start, retdest
 
     %mload_txn_field(@TXN_FIELD_MAX_FEE_PER_GAS)
-    SWAP1 %encode_rlp_scalar
+    %encode_rlp_scalar_swapped_inputs
     // stack: rlp_addr, rlp_addr_start, retdest
 
     %mload_txn_field(@TXN_FIELD_GAS_LIMIT)
-    SWAP1 %encode_rlp_scalar
+    %encode_rlp_scalar_swapped_inputs
     // stack: rlp_addr, rlp_addr_start, retdest
 
     %mload_txn_field(@TXN_FIELD_TO)
@@ -66,12 +66,12 @@ type_1_compute_signed_data:
     %jump(after_to)
 zero_to:
     // stack: to, rlp_addr, rlp_addr_start, retdest
-    SWAP1 %encode_rlp_scalar
+    %encode_rlp_scalar_swapped_inputs
     // stack: rlp_addr, rlp_addr_start, retdest
 
 after_to:
     %mload_txn_field(@TXN_FIELD_VALUE)
-    SWAP1 %encode_rlp_scalar
+    %encode_rlp_scalar_swapped_inputs
     // stack: rlp_addr, rlp_addr_start, retdest
 
     // Encode txn data.

--- a/evm/src/cpu/kernel/asm/transactions/type_2.asm
+++ b/evm/src/cpu/kernel/asm/transactions/type_2.asm
@@ -51,19 +51,19 @@ type_2_compute_signed_data:
     // stack: rlp_addr, rlp_start, retdest
 
     %mload_txn_field(@TXN_FIELD_NONCE)
-    SWAP1 %encode_rlp_scalar
+    %encode_rlp_scalar_swapped_inputs
     // stack: rlp_addr, rlp_start, retdest
 
     %mload_txn_field(@TXN_FIELD_MAX_PRIORITY_FEE_PER_GAS)
-    SWAP1 %encode_rlp_scalar
+    %encode_rlp_scalar_swapped_inputs
     // stack: rlp_addr, rlp_start, retdest
 
     %mload_txn_field(@TXN_FIELD_MAX_FEE_PER_GAS)
-    SWAP1 %encode_rlp_scalar
+    %encode_rlp_scalar_swapped_inputs
     // stack: rlp_addr, rlp_start, retdest
 
     %mload_txn_field(@TXN_FIELD_GAS_LIMIT)
-    SWAP1 %encode_rlp_scalar
+    %encode_rlp_scalar_swapped_inputs
     // stack: rlp_addr, rlp_start, retdest
 
     %mload_txn_field(@TXN_FIELD_TO)
@@ -73,12 +73,12 @@ type_2_compute_signed_data:
     %jump(after_to)
 zero_to:
     // stack: to, rlp_addr, rlp_start, retdest
-    SWAP1 %encode_rlp_scalar
+    %encode_rlp_scalar_swapped_inputs
     // stack: rlp_addr, rlp_start, retdest
 
 after_to:
     %mload_txn_field(@TXN_FIELD_VALUE)
-    SWAP1 %encode_rlp_scalar
+    %encode_rlp_scalar_swapped_inputs
     // stack: rlp_addr, rlp_start, retdest
 
     // Encode txn data.

--- a/evm/src/cpu/kernel/asm/util/basic_macros.asm
+++ b/evm/src/cpu/kernel/asm/util/basic_macros.asm
@@ -271,9 +271,9 @@
 
 %macro ceil_div
     // stack: x, y
-    DUP2
-    // stack: y, x, y
-    %decrement
+    PUSH 1
+    DUP3
+    SUB // y - 1
     // stack: y - 1, x, y
     ADD
     DIV
@@ -333,7 +333,10 @@
 %endmacro
 
 %macro div2
-    %div_const(2)
+    // stack: x
+    PUSH 1
+    SHR
+    // stack: x >> 1
 %endmacro
 
 %macro iseven

--- a/evm/src/cpu/kernel/asm/util/math.asm
+++ b/evm/src/cpu/kernel/asm/util/math.asm
@@ -5,7 +5,7 @@ log2_floor_helper:
     ISZERO
     %jumpi(end)
     // stack: val, counter, retdest
-    %div_const(2)
+    %div2
     // stack: val/2, counter, retdest
     SWAP1
     %increment
@@ -22,7 +22,7 @@ end:
 
 global log2_floor:
     // stack: val, retdest
-    %div_const(2)
+    %div2
     // stack: val/2, retdest
     PUSH 0
     // stack: 0, val/2, retdest


### PR DESCRIPTION
Some light tweaks on the kernel side

- %decrement / %div / %mod -> try preventing the SWAP call
- %div_const(pow_two) -> %shr_const (no SWAP)
- sibling of `encode_rlp_scalar` with swapped inputs (as the `%stack` macro inside becomes actually cheaper)