### PR TITLE
fix: Make `add_generators` public

### DIFF
--- a/plonky2/src/plonk/circuit_builder.rs
+++ b/plonky2/src/plonk/circuit_builder.rs
@@ -546,7 +546,7 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
         self.connect(x, one);
     }
 
-    fn add_generators(&mut self, generators: Vec<WitnessGeneratorRef<F, D>>) {
+    pub fn add_generators(&mut self, generators: Vec<WitnessGeneratorRef<F, D>>) {
         self.generators.extend(generators);
     }
 


### PR DESCRIPTION
Downstream repo's, such as [plonky2x](https://github.com/succinctlabs/succinctx/tree/main/plonky2x), need access to `add_generators`.