### PR TITLE
Fix fill_gaps

### DIFF
--- a/evm/src/memory/memory_stark.rs
+++ b/evm/src/memory/memory_stark.rs
@@ -199,7 +199,7 @@ impl<F: RichField + Extendable<D>, const D: usize> MemoryStark<F, D> {
                 while next.address.virt > max_rc {
                     let mut dummy_address = next.address;
                     dummy_address.virt -= max_rc;
-                    let dummy_read = MemoryOp::new_dummy_read(dummy_address, 0, next.value);
+                    let dummy_read = MemoryOp::new_dummy_read(dummy_address, 0, U256::zero());
                     memory_ops.push(dummy_read);
                     next = dummy_read;
                 }


### PR DESCRIPTION
Small PR to fix `fill_gaps`: the dummy read's value was set to the value in `next`, when it should be set to 0. This bug caused an `msize` test to fail in the EVM suite.