### PR TITLE
chore: update ci workflow

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -20,23 +20,12 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install nightly toolchain
-        id: rustc-toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: nightly
-          override: true
+        uses: dtolnay/rust-toolchain@nightly
 
-      - name: rust-cache
-        uses: actions/cache@v4
+      - name: Set up rust cache
+        uses: Swatinem/rust-cache@v2
         with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: rustc-test-${{ steps.rustc-toolchain.outputs.rustc_hash }}-cargo-${{ hashFiles('**/Cargo.toml') }}
+            cache-on-failure: true
 
       - name: Check in plonky2 subdirectory
         uses: actions-rs/cargo@v1
@@ -90,26 +79,15 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v4
 
-      - name: Install nightly wasm32 toolchain
-        id: rustc-toolchain
-        uses: actions-rs/toolchain@v1
+      - name: Install nightly toolchain
+        uses: dtolnay/rust-toolchain@nightly
         with:
-          profile: minimal
-          toolchain: nightly
           target: wasm32-unknown-unknown
-          default: true
-          override: true
 
-      - name: rust-cache
-        uses: actions/cache@v4
+      - name: Set up rust cache
+        uses: Swatinem/rust-cache@v2
         with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: rustc-wasm32-${{ steps.rustc-toolchain.outputs.rustc_hash }}-cargo-${{ hashFiles('**/Cargo.toml') }}
+            cache-on-failure: true
 
       - name: Check in plonky2 subdirectory
         uses: actions-rs/cargo@v1
@@ -139,41 +117,20 @@ jobs:
     if: "! contains(toJSON(github.event.commits.*.message), '[skip-ci]')"
     steps:
       - name: Checkout sources
-        uses: actions/cache@v4
+        uses: actions/checkout@v4
 
       - name: Install nightly toolchain
-        id: rustc-toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@nightly
         with:
-          profile: minimal
-          toolchain: nightly
-          override: true
           components: rustfmt, clippy
 
-      - name: rust-cache
-        uses: actions/cache@v4
+      - name: Set up rust cache
+        uses: Swatinem/rust-cache@v2
         with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: rustc-lints-${{ steps.rustc-toolchain.outputs.rustc_hash }}-cargo-${{ hashFiles('**/Cargo.toml') }}
+          cache-on-failure: true
 
       - name: Run cargo fmt
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
-        env:
-          CARGO_INCREMENTAL: 1
+        run: cargo fmt --all --check
 
       - name: Run cargo clippy
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --all-features --all-targets -- -D warnings -A incomplete-features
-        env:
-          # Seems necessary until https://github.com/rust-lang/rust/pull/115819 is merged.
-          CARGO_INCREMENTAL: 0
+        run: cargo clippy --all-features --all-targets -- -D warnings -A incomplete-features

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -17,7 +17,7 @@ jobs:
     if: "! contains(toJSON(github.event.commits.*.message), '[skip-ci]')"
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install nightly toolchain
         id: rustc-toolchain
@@ -28,7 +28,7 @@ jobs:
           override: true
 
       - name: rust-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/bin/
@@ -88,7 +88,7 @@ jobs:
     if: "! contains(toJSON(github.event.commits.*.message), '[skip-ci]')"
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install nightly wasm32 toolchain
         id: rustc-toolchain
@@ -101,7 +101,7 @@ jobs:
           override: true
 
       - name: rust-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/bin/
@@ -139,7 +139,7 @@ jobs:
     if: "! contains(toJSON(github.event.commits.*.message), '[skip-ci]')"
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v2
+        uses: actions/cache@v4
 
       - name: Install nightly toolchain
         id: rustc-toolchain
@@ -151,7 +151,7 @@ jobs:
           components: rustfmt, clippy
 
       - name: rust-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/bin/

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -28,10 +28,7 @@ jobs:
             cache-on-failure: true
 
       - name: Check in plonky2 subdirectory
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --manifest-path plonky2/Cargo.toml
+        run: cargo check --manifest-path plonky2/Cargo.toml
         env:
           RUSTFLAGS: -Copt-level=3 -Cdebug-assertions -Coverflow-checks=y -Cdebuginfo=0
           RUST_LOG: 1
@@ -39,10 +36,7 @@ jobs:
           RUST_BACKTRACE: 1
 
       - name: Check in starky subdirectory
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --manifest-path starky/Cargo.toml
+        run: cargo check --manifest-path starky/Cargo.toml
         env:
           RUSTFLAGS: -Copt-level=3 -Cdebug-assertions -Coverflow-checks=y -Cdebuginfo=0
           RUST_LOG: 1
@@ -50,10 +44,7 @@ jobs:
           RUST_BACKTRACE: 1
 
       - name: Check in evm subdirectory
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --manifest-path evm/Cargo.toml
+        run: cargo check --manifest-path evm/Cargo.toml
         env:
           RUSTFLAGS: -Copt-level=3 -Cdebug-assertions -Coverflow-checks=y -Cdebuginfo=0
           RUST_LOG: 1
@@ -87,10 +78,7 @@ jobs:
             cache-on-failure: true
 
       - name: Check in plonky2 subdirectory
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --manifest-path plonky2/Cargo.toml --target wasm32-unknown-unknown --no-default-features
+        run: cargo check --manifest-path plonky2/Cargo.toml --target wasm32-unknown-unknown --no-default-features
         env:
           RUSTFLAGS: -Copt-level=3 -Cdebug-assertions -Coverflow-checks=y -Cdebuginfo=0
           RUST_LOG: 1
@@ -98,10 +86,7 @@ jobs:
           RUST_BACKTRACE: 1
 
       - name: Check in starky subdirectory
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --manifest-path starky/Cargo.toml --target wasm32-unknown-unknown --no-default-features
+        run: cargo check --manifest-path starky/Cargo.toml --target wasm32-unknown-unknown --no-default-features
         env:
           RUSTFLAGS: -Copt-level=3 -Cdebug-assertions -Coverflow-checks=y -Cdebuginfo=0
           RUST_LOG: 1

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -70,7 +70,7 @@ jobs:
       - name: Install nightly toolchain
         uses: dtolnay/rust-toolchain@nightly
         with:
-          target: wasm32-unknown-unknown
+          targets: wasm32-unknown-unknown
 
       - name: Set up rust cache
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -10,6 +10,13 @@ on:
     branches:
       - "**"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+env:
+    CARGO_TERM_COLOR: always
+
 jobs:
   test:
     name: Test Suite

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -21,6 +21,7 @@ jobs:
   test:
     name: Test Suite
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     if: "! contains(toJSON(github.event.commits.*.message), '[skip-ci]')"
     steps:
       - name: Checkout sources
@@ -69,6 +70,7 @@ jobs:
   wasm32:
     name: wasm32 compatibility
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     if: "! contains(toJSON(github.event.commits.*.message), '[skip-ci]')"
     steps:
       - name: Checkout sources
@@ -103,6 +105,7 @@ jobs:
   lints:
     name: Formatting and Clippy
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     if: "! contains(toJSON(github.event.commits.*.message), '[skip-ci]')"
     steps:
       - name: Checkout sources

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -61,10 +61,7 @@ jobs:
           RUST_BACKTRACE: 1
 
       - name: Run cargo test
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --workspace
+        run: cargo test --workspace
         env:
           RUSTFLAGS: -Copt-level=3 -Cdebug-assertions -Coverflow-checks=y -Cdebuginfo=0
           RUST_LOG: 1


### PR DESCRIPTION
## Description

Highly inspired from foundry's CI [workflow](https://github.com/foundry-rs/foundry/blob/master/.github/workflows/test.yml).

- Fix warnings shown in CI job output (e.g. https://github.com/0xPolygonZero/plonky2/actions/runs/7558066520).
- Bump `actions/checkout` and `actions/cache` versions.
- Remove [`actions-rs/toolchain`](https://github.com/actions-rs/toolchain) and [`actions-rs/cargo`](https://github.com/actions-rs/cargo) because they are not maintained anymore since Oct 13, 2023.
- To install the rust toolchain, use [`dtolnay/rust-toolchain`](https://github.com/dtolnay/rust-toolchain) instead of `actions-rs/toolchain`.
- To set up rust cache, use [`Swatinem/rust-cache`](https://github.com/Swatinem/rust-cache) instead of `actions/cache`.
- Instead of using `actions-rs/cargo` to run `cargo clippy`,  `cargo fmt` or `cargo test`, simply run the raw commands instead.
- Enable to cancel in-progress jobs.
- Add job timeouts.