### PR TITLE
Improve SHA2 precompile

### DIFF
--- a/evm/src/cpu/kernel/asm/hash/sha2/compression.asm
+++ b/evm/src/cpu/kernel/asm/hash/sha2/compression.asm
@@ -4,6 +4,9 @@
     // stack: num_blocks
     %mul_const(320)
     %add_const(2)
+    PUSH @SEGMENT_KERNEL_GENERAL
+    GET_CONTEXT
+    %build_address
 %endmacro
 
 global sha2_compression:
@@ -24,9 +27,7 @@ global sha2_compression:
     // stack: i=0, message_schedule_addr, a[0]..h[0], retdest
     SWAP1
     // stack: message_schedule_addr, i=0, a[0]..h[0], retdest
-    PUSH 0
-    // stack: 0, message_schedule_addr, i=0, a[0]..h[0], retdest
-    %mload_current_general
+    %mload_current_general_no_offset
     // stack: num_blocks, message_schedule_addr, i=0, a[0]..h[0], retdest
     DUP1
     // stack: num_blocks, num_blocks, message_schedule_addr, i=0, a[0]..h[0], retdest
@@ -53,7 +54,7 @@ compression_loop:
     // stack: 4*i, message_schedule_addr, a[i], b[i], c[i], d[i], e[i], f[i], g[i], h[i], num_blocks, scratch_space_addr, message_schedule_addr, i, a[0]..h[0], retdest
     ADD
     // stack: message_schedule_addr + 4*i, a[i], b[i], c[i], d[i], e[i], f[i], g[i], h[i], num_blocks, scratch_space_addr, message_schedule_addr, i, a[0]..h[0], retdest
-    %mload_current_general_u32
+    %mload_u32
     // stack: W[i], a[i], b[i], c[i], d[i], e[i], f[i], g[i], h[i], num_blocks, scratch_space_addr, message_schedule_addr, i, a[0]..h[0], retdest
     PUSH sha2_constants_k
     // stack: sha2_constants_k, W[i], a[i], b[i], c[i], d[i], e[i], f[i], g[i], h[i], num_blocks, scratch_space_addr, message_schedule_addr, i, a[0]..h[0], retdest

--- a/evm/src/cpu/kernel/asm/hash/sha2/main.asm
+++ b/evm/src/cpu/kernel/asm/hash/sha2/main.asm
@@ -1,20 +1,22 @@
 global sha2:
     // stack: virt, num_bytes, retdest
-    SWAP1
-    // stack: num_bytes, virt, retdest
-    DUP2
-    // stack: virt, num_bytes, virt, retdest
-    %mstore_current_general
-    // stack: virt, retdest
+    PUSH @SEGMENT_KERNEL_GENERAL
+    GET_CONTEXT
+    %build_address
+    // stack: addr, num_bytes, retdest
+    DUP1 SWAP2
+    // stack: num_bytes, addr, addr, retdest
+    MSTORE_GENERAL
+    // stack: addr, retdest
 
 
-// Precodition: input is in memory, starting at virt of kernel general segment, of the form
+// Precondition: input is in memory, starting at addr of kernel general segment, of the form
 //              num_bytes, x[0], x[1], ..., x[num_bytes - 1]
 // Postcodition: output is in memory, starting at 0, of the form
 //               num_blocks, block0[0], ..., block0[63], block1[0], ..., blocklast[63]
 global sha2_pad:
-    // stack: virt, retdest
-    %mload_current_general
+    // stack: addr, retdest
+    MLOAD_GENERAL
     // stack: num_bytes, retdest
     // STEP 1: append 1
     // insert 128 (= 1 << 7) at x[num_bytes+1]
@@ -50,8 +52,7 @@ global sha2_pad:
     DUP1
     // stack: num_blocks, num_blocks, retdest
     // STEP 5: write num_blocks to x[0]
-    PUSH 0
-    %mstore_current_general
+    %mstore_current_general_no_offset
     // stack: num_blocks, retdest
     %message_schedule_addr_from_num_blocks
     %jump(sha2_gen_all_message_schedules)

--- a/evm/src/cpu/kernel/asm/hash/sha2/message_schedule.asm
+++ b/evm/src/cpu/kernel/asm/hash/sha2/message_schedule.asm
@@ -8,10 +8,10 @@
     %build_address
 %endmacro
 
-// Precodition: stack contains address of one message block, followed by output address
+// Precondition: stack contains address of one message block, followed by output address
 // Postcondition: 256 bytes starting at given output address contain the 64 32-bit chunks
 //                of message schedule (in four-byte increments)
-global gen_message_schedule_from_block:
+gen_message_schedule_from_block:
     // stack: block_addr, output_addr, retdest
     DUP1
     // stack: block_addr, block_addr, output_addr, retdest
@@ -30,8 +30,7 @@ global gen_message_schedule_from_block:
     %add_const(28)
     PUSH 8
     // stack: counter=8, output_addr + 28, block[0], block[1], retdest
-    %jump(gen_message_schedule_from_block_0_loop)
-global gen_message_schedule_from_block_0_loop:
+gen_message_schedule_from_block_0_loop:
     // Split the first half (256 bits) of the block into the first eight (32-bit) chunks of the message sdchedule.
     // stack: counter, output_addr, block[0], block[1], retdest
     SWAP2
@@ -59,7 +58,7 @@ global gen_message_schedule_from_block_0_loop:
     %decrement
     DUP1
     %jumpi(gen_message_schedule_from_block_0_loop)
-global gen_message_schedule_from_block_0_end:
+gen_message_schedule_from_block_0_end:
     // stack: old counter=0, output_addr, block[0], block[1], retdest
     POP
     // stack: output_addr, block[0], block[1], retdest
@@ -69,7 +68,7 @@ global gen_message_schedule_from_block_0_end:
     // stack: output_addr + 64, counter, block[1], block[0], retdest
     SWAP1
     // stack: counter, output_addr + 64, block[1], block[0], retdest
-global gen_message_schedule_from_block_1_loop:
+gen_message_schedule_from_block_1_loop:
     // Split the second half (256 bits) of the block into the next eight (32-bit) chunks of the message sdchedule.
     // stack: counter, output_addr, block[1], block[0], retdest
     SWAP2
@@ -97,7 +96,7 @@ global gen_message_schedule_from_block_1_loop:
     %decrement
     DUP1
     %jumpi(gen_message_schedule_from_block_1_loop)
-global gen_message_schedule_from_block_1_end:
+gen_message_schedule_from_block_1_end:
     // stack: old counter=0, output_addr, block[1], block[0], retdest
     POP
     // stack: output_addr, block[0], block[1], retdest
@@ -109,7 +108,7 @@ global gen_message_schedule_from_block_1_end:
     // stack: output_addr + 36, counter, block[0], block[1], retdest
     SWAP1
     // stack: counter, output_addr + 36, block[0], block[1], retdest
-global gen_message_schedule_remaining_loop:
+gen_message_schedule_remaining_loop:
     // Generate the next 48 chunks of the message schedule, one at a time, from prior chunks.
     // stack: counter, output_addr, block[0], block[1], retdest
     SWAP1
@@ -172,7 +171,7 @@ global gen_message_schedule_remaining_loop:
     // stack: counter - 1, output_addr + 4, block[0], block[1], retdest
     DUP1
     %jumpi(gen_message_schedule_remaining_loop)
-global gen_message_schedule_remaining_end:
+gen_message_schedule_remaining_end:
     // stack: counter=0, output_addr, block[0], block[1], retdest
     %pop4
     JUMP
@@ -181,7 +180,7 @@ global gen_message_schedule_remaining_end:
 //              stack contains output_addr
 // Postcondition: starting at output_addr, set of 256 bytes per block
 //                each contains the 64 32-bit chunks of the message schedule for that block (in four-byte increments)
-global sha2_gen_all_message_schedules: 
+sha2_gen_all_message_schedules: 
     // stack: output_addr, retdest
     DUP1
     // stack: output_addr, output_addr, retdest
@@ -193,7 +192,7 @@ global sha2_gen_all_message_schedules:
     GET_CONTEXT
     %build_address
     // stack: cur_addr, counter, output_addr, output_addr, retdest
-global gen_all_message_schedules_loop:
+gen_all_message_schedules_loop:
     // stack: cur_addr, counter, cur_output_addr, output_addr, retdest
     PUSH gen_all_message_schedules_loop_end
     // stack: new_retdest = gen_all_message_schedules_loop_end, cur_addr, counter, cur_output_addr, output_addr, retdest
@@ -202,7 +201,7 @@ global gen_all_message_schedules_loop:
     DUP3
     // stack: cur_addr, cur_output_addr, new_retdest, cur_addr, counter, cur_output_addr, output_addr, retdest
     %jump(gen_message_schedule_from_block)
-global gen_all_message_schedules_loop_end:
+gen_all_message_schedules_loop_end:
     // stack: cur_addr, counter, cur_output_addr, output_addr, retdest
     %add_const(64)
     // stack: cur_addr + 64, counter, cur_output_addr, output_addr, retdest
@@ -217,7 +216,7 @@ global gen_all_message_schedules_loop_end:
     DUP2
     // stack: counter - 1, cur_addr + 64, counter - 1, cur_output_addr + 256, output_addr, retdest
     %jumpi(gen_all_message_schedules_loop)
-global gen_all_message_schedules_end:
+gen_all_message_schedules_end:
     // stack: cur_addr + 64, counter - 1, cur_output_addr + 256, output_addr, retdest
     %pop3
     // stack: output_addr, retdest

--- a/evm/src/cpu/kernel/asm/hash/sha2/message_schedule.asm
+++ b/evm/src/cpu/kernel/asm/hash/sha2/message_schedule.asm
@@ -180,7 +180,7 @@ gen_message_schedule_remaining_end:
 //              stack contains output_addr
 // Postcondition: starting at output_addr, set of 256 bytes per block
 //                each contains the 64 32-bit chunks of the message schedule for that block (in four-byte increments)
-sha2_gen_all_message_schedules: 
+global sha2_gen_all_message_schedules: 
     // stack: output_addr, retdest
     DUP1
     // stack: output_addr, output_addr, retdest

--- a/evm/src/cpu/kernel/asm/hash/sha2/write_length.asm
+++ b/evm/src/cpu/kernel/asm/hash/sha2/write_length.asm
@@ -1,5 +1,8 @@
 %macro sha2_write_length
-    // stack: last_addr, length
+    // stack: last_addr_offset, length
+    PUSH @SEGMENT_KERNEL_GENERAL
+    GET_CONTEXT
+    %build_address
     SWAP1
     // stack: length, last_addr
     DUP1
@@ -8,7 +11,7 @@
     // stack: length % (1 << 8), length, last_addr
     DUP3
     // stack: last_addr, length % (1 << 8), length, last_addr
-    %mstore_current_general
+    %swap_mstore
     
     %rep 7
         // For i = 0 to 6
@@ -26,7 +29,7 @@
         // stack: (length >> (8 * (i + 1))) % (1 << 8), length >> (8 * (i + 1)), last_addr - i - 2
         DUP3
         // stack: last_addr - i - 2, (length >> (8 * (i + 1))) % (1 << 8), length >> (8 * (i + 1)), last_addr - i - 2
-        %mstore_current_general
+        %swap_mstore
     %endrep
 
     %pop2

--- a/evm/src/cpu/kernel/asm/memory/core.asm
+++ b/evm/src/cpu/kernel/asm/memory/core.asm
@@ -124,6 +124,16 @@
     // stack: value
 %endmacro
 
+// Load a single value from the kernel general memory, in the current context (not the kernel's context).
+%macro mload_current_general_no_offset
+    // stack:
+    PUSH @SEGMENT_KERNEL_GENERAL
+    GET_CONTEXT
+    %build_address_no_offset
+    MLOAD_GENERAL
+    // stack: value
+%endmacro
+
 // Load a big-endian u32 from kernel general memory in the current context.
 %macro mload_current_general_u32
     // stack: offset
@@ -180,6 +190,19 @@
     GET_CONTEXT
     // stack: context, segment, offset, value
     %build_address
+    SWAP1
+    MSTORE_GENERAL
+    // stack: (empty)
+%endmacro
+
+// Store a single value to kernel general memory in the current context.
+%macro mstore_current_general_no_offset
+    // stack: value
+    PUSH @SEGMENT_KERNEL_GENERAL
+    // stack: segment, value
+    GET_CONTEXT
+    // stack: context, segment, value
+    %build_address_no_offset
     SWAP1
     MSTORE_GENERAL
     // stack: (empty)


### PR DESCRIPTION
Reduces the number of CPU cycles for SHA2 by 7.57% on average.