### PR TITLE
Use web-time crate

### DIFF
--- a/plonky2/Cargo.toml
+++ b/plonky2/Cargo.toml
@@ -15,7 +15,7 @@ default = ["gate_testing", "parallel", "rand_chacha", "std", "timing"]
 gate_testing = []
 parallel = ["hashbrown/rayon", "plonky2_maybe_rayon/parallel"]
 std = ["anyhow/std", "rand/std", "itertools/use_std"]
-timing = ["std"]
+timing = ["std", "dep:web-time"]
 
 [dependencies]
 ahash = { version = "0.8.3", default-features = false, features = ["compile-time-rng"] } # NOTE: Be sure to keep this version the same as the dependency in `hashbrown`.
@@ -34,6 +34,7 @@ serde = { version = "1.0", default-features = false, features = ["derive", "rc"]
 serde_json = "1.0"
 static_assertions = { version = "1.1.0", default-features = false }
 unroll = { version = "0.1.5", default-features = false }
+web-time = { version = "1.0.0", optional = true }
 
 [target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
 getrandom = { version = "0.2", default-features = false, features = ["js"] }

--- a/plonky2/src/fri/reduction_strategies.rs
+++ b/plonky2/src/fri/reduction_strategies.rs
@@ -1,10 +1,10 @@
 use alloc::vec;
 use alloc::vec::Vec;
-#[cfg(feature = "timing")]
-use std::time::Instant;
 
 use log::debug;
 use serde::Serialize;
+#[cfg(feature = "timing")]
+use web_time::Instant;
 
 /// A method for deciding what arity to use at each reduction layer.
 #[derive(Debug, Clone, Eq, PartialEq, Serialize)]

--- a/plonky2/src/util/timing.rs
+++ b/plonky2/src/util/timing.rs
@@ -1,7 +1,6 @@
-#[cfg(feature = "timing")]
-use std::time::{Duration, Instant};
-
 use log::{log, Level};
+#[cfg(feature = "timing")]
+use web_time::{Duration, Instant};
 
 /// The hierarchy of scopes, and the time consumed by each one. Useful for profiling.
 #[cfg(feature = "timing")]


### PR DESCRIPTION
Use web-time crate (https://github.com/daxpedda/web-time) instead of std version. It works for wasm32 targets too. If target support time in std then it's just an alias to that.