### PR TITLE
Fast-forward `main` to `audit/rc2`

### DIFF
--- a/evm/Cargo.toml
+++ b/evm/Cargo.toml
@@ -2,6 +2,7 @@
 name = "plonky2_evm"
 description = "Implementation of STARKs for the Ethereum Virtual Machine"
 version = "0.1.1"
+license = "MIT or Apache-2.0"
 authors = ["Daniel Lubarov <daniel@lubarov.com>", "William Borgeaud <williamborgeaud@gmail.com>"]
 readme = "README.md"
 repository = "https://github.com/0xPolygonZero/plonky2"

--- a/evm/LICENSE-APACHE
+++ b/evm/LICENSE-APACHE
@@ -1,0 +1,176 @@
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS

--- a/evm/LICENSE-MIT
+++ b/evm/LICENSE-MIT
@@ -1,0 +1,19 @@
+The MIT License (MIT)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/evm/README.md
+++ b/evm/README.md
@@ -20,5 +20,17 @@ Audits for the ZK-EVM will begin on November 27th, 2023. See the [Audit RC1 Mile
 
 The current specification is located in the [/spec](/spec) directory, with the most currently up-to-date PDF [available here](https://github.com/0xPolygonZero/plonky2/blob/main/evm/spec/zkevm.pdf). Further documentation will be made over the coming months.
 
----
-Copyright (C) 2023 PT Services DMCC
+## License
+Copyright (c) 2023 PT Services DMCC
+
+Licensed under either of:
+* Apache License, Version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
+* MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
+
+at your option. 
+
+The SPDX license identifier for this project is `MIT OR Apache-2.0`.
+
+### Contribution
+
+Unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in the work by you, as defined in the Apache-2.0 license, shall be dual licensed as above, without any additional terms or conditions.

--- a/evm/src/cpu/kernel/asm/bignum/add.asm
+++ b/evm/src/cpu/kernel/asm/bignum/add.asm
@@ -9,49 +9,55 @@ global add_bignum:
     ISZERO
     %jumpi(len_zero)
     // stack: len, a_start_loc, b_start_loc, retdest
+    %build_current_general_address_no_offset
     PUSH 0
-    // stack: carry=0, i=len, a_cur_loc=a_start_loc, b_cur_loc=b_start_loc, retdest
+    // stack: carry=0, base_addr, i=len, a_cur_loc=a_start_loc, b_cur_loc=b_start_loc, retdest
 add_loop:
-    // stack: carry, i, a_cur_loc, b_cur_loc, retdest
-    DUP4
-    %mload_current_general
-    // stack: b[cur], carry, i, a_cur_loc, b_cur_loc, retdest
-    DUP4
-    %mload_current_general
-    // stack: a[cur], b[cur], carry, i, a_cur_loc, b_cur_loc, retdest
-    ADD
-    ADD
-    // stack: a[cur] + b[cur] + carry, i, a_cur_loc, b_cur_loc, retdest
-    DUP1
-    // stack: a[cur] + b[cur] + carry, a[cur] + b[cur] + carry, i, a_cur_loc, b_cur_loc, retdest
-    %shr_const(128)
-    // stack: (a[cur] + b[cur] + carry) // 2^128, a[cur] + b[cur] + carry, i, a_cur_loc, b_cur_loc, retdest
-    SWAP1
-    // stack: a[cur] + b[cur] + carry, (a[cur] + b[cur] + carry) // 2^128, i, a_cur_loc, b_cur_loc, retdest
-    %mod_const(0x100000000000000000000000000000000)
-    // stack: c[cur] = (a[cur] + b[cur] + carry) % 2^128, carry_new = (a[cur] + b[cur] + carry) // 2^128, i, a_cur_loc, b_cur_loc, retdest
-    DUP4
-    // stack: a_cur_loc, c[cur], carry_new, i, a_cur_loc, b_cur_loc, retdest
-    %mstore_current_general
-    // stack: carry_new, i, a_cur_loc, b_cur_loc, retdest
-    SWAP2
-    %increment
-    SWAP2
-    // stack: carry_new, i, a_cur_loc + 1, b_cur_loc, retdest
-    SWAP3
-    %increment
-    SWAP3
-    // stack: carry_new, i, a_cur_loc + 1, b_cur_loc + 1, retdest
-    SWAP1
-    %decrement
-    SWAP1
-    // stack: carry_new, i - 1, a_cur_loc + 1, b_cur_loc + 1, retdest
+    // stack: carry, base_addr, i, a_cur_loc, b_cur_loc, retdest
     DUP2
-    // stack: i - 1, carry_new, i - 1, a_cur_loc + 1, b_cur_loc + 1, retdest
+    // stack: base_addr, carry, base_addr, i, a_cur_loc, b_cur_loc, retdest
+    DUP6 ADD // base_addr + b_cur_loc
+    MLOAD_GENERAL
+    // stack: b[cur], carry, base_addr, i, a_cur_loc, b_cur_loc, retdest
+    DUP3
+    DUP6 ADD // base_addr + a_cur_loc
+    MLOAD_GENERAL
+    // stack: a[cur], b[cur], carry, base_addr, i, a_cur_loc, b_cur_loc, retdest
+    ADD
+    ADD
+    // stack: a[cur] + b[cur] + carry, base_addr, i, a_cur_loc, b_cur_loc, retdest
+    DUP1
+    // stack: a[cur] + b[cur] + carry, a[cur] + b[cur] + carry, base_addr, i, a_cur_loc, b_cur_loc, retdest
+    %shr_const(128)
+    // stack: (a[cur] + b[cur] + carry) // 2^128, a[cur] + b[cur] + carry, base_addr, i, a_cur_loc, b_cur_loc, retdest
+    SWAP1
+    // stack: a[cur] + b[cur] + carry, (a[cur] + b[cur] + carry) // 2^128, base_addr, i, a_cur_loc, b_cur_loc, retdest
+    %mod_const(0x100000000000000000000000000000000)
+    // stack: c[cur] = (a[cur] + b[cur] + carry) % 2^128, carry_new = (a[cur] + b[cur] + carry) // 2^128, base_addr, i, a_cur_loc, b_cur_loc, retdest
+    DUP3
+    DUP6
+    ADD // base_addr + a_cur_loc
+    // stack: a_cur_addr, c[cur], carry_new,  base_addr, i, a_cur_loc, b_cur_loc, retdest
+    %swap_mstore
+    // stack: carry_new, base_addr, i, a_cur_loc, b_cur_loc, retdest
+    SWAP3
+    %increment
+    SWAP3
+    // stack: carry_new, base_addr, i, a_cur_loc + 1, b_cur_loc, retdest
+    SWAP4
+    %increment
+    SWAP4
+    // stack: carry_new, base_addr, i, a_cur_loc + 1, b_cur_loc + 1, retdest
+    SWAP2
+    %decrement
+    SWAP2
+    // stack: carry_new, base_addr, i - 1, a_cur_loc + 1, b_cur_loc + 1, retdest
+    DUP3
+    // stack: i - 1, carry_new, base_addr, i - 1, a_cur_loc + 1, b_cur_loc + 1, retdest
     %jumpi(add_loop)
 add_end:
-    // stack: carry_new, i - 1, a_cur_loc + 1, b_cur_loc + 1, retdest
-    %stack (c, i, a, b) -> (c)
+    // stack: carry_new, base_addr, i - 1, a_cur_loc + 1, b_cur_loc + 1, retdest
+    %stack (c, addr, i, a, b) -> (c)
     // stack: carry_new, retdest
     SWAP1
     // stack: retdest, carry_new

--- a/evm/src/cpu/kernel/asm/bignum/addmul.asm
+++ b/evm/src/cpu/kernel/asm/bignum/addmul.asm
@@ -8,95 +8,99 @@ global addmul_bignum:
     // stack: len, len, a_start_loc, b_start_loc, val, retdest
     ISZERO
     %jumpi(len_zero)
+    %build_current_general_address_no_offset
     PUSH 0
-    // stack: carry_limb=0, i=len, a_cur_loc=a_start_loc, b_cur_loc=b_start_loc, val, retdest
+    // stack: carry_limb=0, base_addr, i=len, a_cur_loc=a_start_loc, b_cur_loc=b_start_loc, val, retdest
 addmul_loop:
-    // stack: carry_limb, i, a_cur_loc, b_cur_loc, val, retdest
-    DUP4
-    // stack: b_cur_loc, carry_limb, i, a_cur_loc, b_cur_loc, val, retdest
-    %mload_current_general
-    // stack: b[cur], carry_limb, i, a_cur_loc, b_cur_loc, val, retdest
-    DUP6
-    // stack: val, b[cur], carry_limb, i, a_cur_loc, b_cur_loc, val, retdest
+    // stack: carry_limb, addr, i, a_cur_loc, b_cur_loc, val, retdest
+    DUP2
+    DUP6 ADD // base_addr + b_cur_loc
+    // stack: b_cur_addr, carry_limb, addr, i, a_cur_loc, b_cur_loc, val, retdest
+    MLOAD_GENERAL
+    // stack: b[cur], carry_limb, addr, i, a_cur_loc, b_cur_loc, val, retdest
+    DUP7
+    // stack: val, b[cur], carry_limb, addr, i, a_cur_loc, b_cur_loc, val, retdest
     MUL
-    // stack: val * b[cur], carry_limb, i, a_cur_loc, b_cur_loc, val, retdest
+    // stack: val * b[cur], carry_limb, addr, i, a_cur_loc, b_cur_loc, val, retdest
     DUP1
-    // stack: val * b[cur], val * b[cur], carry_limb, i, a_cur_loc, b_cur_loc, val, retdest
+    // stack: val * b[cur], val * b[cur], carry_limb, addr, i, a_cur_loc, b_cur_loc, val, retdest
     %shr_const(128)
-    // stack: (val * b[cur]) // 2^128, val * b[cur], carry_limb, i, a_cur_loc, b_cur_loc, val, retdest
+    // stack: (val * b[cur]) // 2^128, val * b[cur], carry_limb, addr, i, a_cur_loc, b_cur_loc, val, retdest
     SWAP1
-    // stack: val * b[cur], (val * b[cur]) // 2^128, carry_limb, i, a_cur_loc, b_cur_loc, val, retdest
+    // stack: val * b[cur], (val * b[cur]) // 2^128, carry_limb, addr, i, a_cur_loc, b_cur_loc, val, retdest
     %shl_const(128)
     %shr_const(128)
-    // stack: prod_lo = val * b[cur] % 2^128, prod_hi = (val * b[cur]) // 2^128, carry_limb, i, a_cur_loc, b_cur_loc, val, retdest
-    DUP5
-    // stack: a_cur_loc, prod_lo, prod_hi, carry_limb, i, a_cur_loc, b_cur_loc, val, retdest
-    %mload_current_general
-    // stack: a[cur], prod_lo, prod_hi, carry_limb, i, a_cur_loc, b_cur_loc, val, retdest
+    // stack: prod_lo = val * b[cur] % 2^128, prod_hi = (val * b[cur]) // 2^128, carry_limb, addr, i, a_cur_loc, b_cur_loc, val, retdest
+    DUP4
+    DUP7 ADD // base_addr + a_cur_loc
+    // stack: a_cur_addr, prod_lo, prod_hi, carry_limb, addr, i, a_cur_loc, b_cur_loc, val, retdest
+    MLOAD_GENERAL
+    // stack: a[cur], prod_lo, prod_hi, carry_limb, addr, i, a_cur_loc, b_cur_loc, val, retdest
     DUP1
-    // stack: a[cur], a[cur], prod_lo, prod_hi, carry_limb, i, a_cur_loc, b_cur_loc, val, retdest
+    // stack: a[cur], a[cur], prod_lo, prod_hi, carry_limb, addr, i, a_cur_loc, b_cur_loc, val, retdest
     SWAP2
-    // stack: prod_lo, a[cur], a[cur], prod_hi, carry_limb, i, a_cur_loc, b_cur_loc, val, retdest
+    // stack: prod_lo, a[cur], a[cur], prod_hi, carry_limb, addr, i, a_cur_loc, b_cur_loc, val, retdest
     ADD
     %shl_const(128)
     %shr_const(128)
-    // stack: prod_lo' = (prod_lo + a[cur]) % 2^128, a[cur], prod_hi, carry_limb, i, a_cur_loc, b_cur_loc, val, retdest
+    // stack: prod_lo' = (prod_lo + a[cur]) % 2^128, a[cur], prod_hi, carry_limb, addr, i, a_cur_loc, b_cur_loc, val, retdest
     DUP1
-    // stack: prod_lo', prod_lo', a[cur], prod_hi, carry_limb, i, a_cur_loc, b_cur_loc, val, retdest
+    // stack: prod_lo', prod_lo', a[cur], prod_hi, carry_limb, addr, i, a_cur_loc, b_cur_loc, val, retdest
     SWAP2
-    // stack: a[cur], prod_lo', prod_lo', prod_hi, carry_limb, i, a_cur_loc, b_cur_loc, val, retdest
+    // stack: a[cur], prod_lo', prod_lo', prod_hi, carry_limb, addr, i, a_cur_loc, b_cur_loc, val, retdest
     GT
-    // stack: prod_lo_carry_limb = a[cur] > prod_lo', prod_lo', prod_hi, carry_limb, i, a_cur_loc, b_cur_loc, val, retdest
+    // stack: prod_lo_carry_limb = a[cur] > prod_lo', prod_lo', prod_hi, carry_limb, addr, i, a_cur_loc, b_cur_loc, val, retdest
     SWAP1
-    // stack: prod_lo', prod_lo_carry_limb, prod_hi, carry_limb, i, a_cur_loc, b_cur_loc, val, retdest
+    // stack: prod_lo', prod_lo_carry_limb, prod_hi, carry_limb, addr, i, a_cur_loc, b_cur_loc, val, retdest
     SWAP2
-    // stack: prod_hi, prod_lo_carry_limb, prod_lo', carry_limb, i, a_cur_loc, b_cur_loc, val, retdest
+    // stack: prod_hi, prod_lo_carry_limb, prod_lo', carry_limb, addr, i, a_cur_loc, b_cur_loc, val, retdest
     ADD
-    // stack: prod_hi' = prod_hi + prod_lo_carry_limb, prod_lo', carry_limb, i, a_cur_loc, b_cur_loc, val, retdest
+    // stack: prod_hi' = prod_hi + prod_lo_carry_limb, prod_lo', carry_limb, addr, i, a_cur_loc, b_cur_loc, val, retdest
     DUP3
-    // stack: carry_limb, prod_hi', prod_lo', carry_limb, i, a_cur_loc, b_cur_loc, val, retdest
+    // stack: carry_limb, prod_hi', prod_lo', carry_limb, addr, i, a_cur_loc, b_cur_loc, val, retdest
     DUP3
-    // stack: prod_lo', carry_limb, prod_hi', prod_lo', carry_limb, i, a_cur_loc, b_cur_loc, val, retdest
+    // stack: prod_lo', carry_limb, prod_hi', prod_lo', carry_limb, addr, i, a_cur_loc, b_cur_loc, val, retdest
     ADD
     %shl_const(128)
     %shr_const(128)
-    // stack: to_write = (prod_lo' + carry_limb) % 2^128, prod_hi', prod_lo', carry_limb, i, a_cur_loc, b_cur_loc, val, retdest
+    // stack: to_write = (prod_lo' + carry_limb) % 2^128, prod_hi', prod_lo', carry_limb, addr, i, a_cur_loc, b_cur_loc, val, retdest
     SWAP2
-    // stack: prod_lo', prod_hi', to_write, carry_limb, i, a_cur_loc, b_cur_loc, val, retdest
+    // stack: prod_lo', prod_hi', to_write, carry_limb, addr, i, a_cur_loc, b_cur_loc, val, retdest
     DUP3
-    // stack: to_write, prod_lo', prod_hi', to_write, carry_limb, i, a_cur_loc, b_cur_loc, val, retdest
+    // stack: to_write, prod_lo', prod_hi', to_write, carry_limb, addr, i, a_cur_loc, b_cur_loc, val, retdest
     LT
     // stack: carry_limb_new = to_write < prod_lo', prod_hi', to_write, carry_limb, i, a_cur_loc, b_cur_loc, val, retdest
     %stack (vals: 3, c) -> (vals)
-    // stack: carry_limb_new, prod_hi', to_write, i, a_cur_loc, b_cur_loc, val, retdest
+    // stack: carry_limb_new, prod_hi', to_write, addr, i, a_cur_loc, b_cur_loc, val, retdest
     ADD
-    // stack: carry_limb = carry_limb_new' + prod_hi', to_write, i, a_cur_loc, b_cur_loc, val, retdest
+    // stack: carry_limb = carry_limb_new' + prod_hi', to_write, addr, i, a_cur_loc, b_cur_loc, val, retdest
     SWAP1
-    // stack: to_write, carry_limb, i, a_cur_loc, b_cur_loc, val, retdest
-    DUP4
-    // stack: a_cur_loc, to_write, carry_limb, i, a_cur_loc, b_cur_loc, val, retdest
-    %mstore_current_general
-    // stack: carry_limb, i, a_cur_loc, b_cur_loc, val, retdest
-    SWAP1
-    // stack: i, carry_limb, a_cur_loc, b_cur_loc, val, retdest
-    %decrement
-    // stack: i-1, carry_limb, a_cur_loc, b_cur_loc, val, retdest
+    // stack: to_write, carry_limb, addr, i, a_cur_loc, b_cur_loc, val, retdest
+    DUP3
+    DUP6 ADD // base_addr + a_cur_loc
+    // stack: a_cur_addr, to_write, carry_limb, addr, i, a_cur_loc, b_cur_loc, val, retdest
+    %swap_mstore
+    // stack: carry_limb, base_addr, i, a_cur_loc, b_cur_loc, val, retdest
     SWAP2
-    // stack: a_cur_loc, carry_limb, i-1, b_cur_loc, val, retdest
-    %increment
-    // stack: a_cur_loc+1, carry_limb, i-1, b_cur_loc, val, retdest
+    // stack: i, base_addr, carry_limb, a_cur_loc, b_cur_loc, val, retdest
+    %decrement
+    // stack: i-1, base_addr, carry_limb, a_cur_loc, b_cur_loc, val, retdest
     SWAP3
-    // stack: b_cur_loc, carry_limb, i-1, a_cur_loc+1, val, retdest
+    // stack: a_cur_loc, base_addr, carry_limb, i-1, b_cur_loc, val, retdest
     %increment
-    // stack: b_cur_loc+1, carry_limb, i-1, a_cur_loc+1, val, retdest
-    %stack (b, c, i, a) -> (c, i, a, b)
-    // stack: carry_limb, i-1, a_cur_loc+1, b_cur_loc+1, val, retdest
-    DUP2
-    // stack: i-1, carry_limb, i-1, a_cur_loc+1, b_cur_loc+1, val, retdest
+    // stack: a_cur_loc+1, base_addr, carry_limb, i-1, b_cur_loc, val, retdest
+    SWAP4
+    // stack: b_cur_loc, base_addr, carry_limb, i-1, a_cur_loc+1, val, retdest
+    %increment
+    // stack: b_cur_loc+1, base_addr, carry_limb, i-1, a_cur_loc+1, val, retdest
+    %stack (b, addr, c, i, a) -> (c, addr, i, a, b)
+    // stack: carry_limb, base_addr, i-1, a_cur_loc+1, b_cur_loc+1, val, retdest
+    DUP3
+    // stack: i-1, carry_limb, base_addr, i-1, a_cur_loc+1, b_cur_loc+1, val, retdest
     %jumpi(addmul_loop)
 addmul_end:
-    // stack: carry_limb_new, i-1, a_cur_loc+1, b_cur_loc+1, val, retdest
-    %stack (c, i, a, b, v) -> (c)
+    // stack: carry_limb_new, base_addr, i-1, a_cur_loc+1, b_cur_loc+1, val, retdest
+    %stack (c, addr, i, a, b, v) -> (c)
     // stack: carry_limb_new, retdest
     SWAP1
     // stack: retdest, carry_limb_new

--- a/evm/src/cpu/kernel/asm/bignum/cmp.asm
+++ b/evm/src/cpu/kernel/asm/bignum/cmp.asm
@@ -5,82 +5,87 @@
 // Returns 1 if a > b, 0 if a == b, and -1 (that is, 2^256 - 1) if a < b.
 global cmp_bignum:
     // stack: len, a_start_loc, b_start_loc, retdest
-    DUP1
-    // stack: len, len, a_start_loc, b_start_loc, retdest
+    %build_current_general_address_no_offset
+    // stack: base_addr, len, a_start_loc, b_start_loc, retdest
+    DUP2
+    // stack: len, base_addr, len, a_start_loc, b_start_loc, retdest
     ISZERO
-    %jumpi(equal)
-    // stack: len, a_start_loc, b_start_loc, retdest
-    SWAP1
-    // stack: a_start_loc, len, b_start_loc, retdest
-    PUSH 1
-    DUP3
-    SUB
-    // stack: len-1, a_start_loc, len, b_start_loc, retdest
-    ADD
-    // stack: a_end_loc, len, b_start_loc, retdest
+    %jumpi(equal) // len and base_addr are swapped, but they will be popped anyway
+    // stack: base_addr, len, a_start_loc, b_start_loc, retdest
     SWAP2
-    // stack: b_start_loc, len, a_end_loc, retdest
+    // stack: a_start_loc, len, base_addr, b_start_loc, retdest
     PUSH 1
     DUP3
     SUB
-    // stack: len-1, b_start_loc, len, a_end_loc, retdest
+    // stack: len-1, a_start_loc, len, base_addr, b_start_loc, retdest
     ADD
-    // stack: b_end_loc, len, a_end_loc, retdest
-    %stack (b, l, a) -> (l, a, b)
-    // stack: len, a_end_loc, b_end_loc, retdest
+    // stack: a_end_loc, len, base_addr, b_start_loc, retdest
+    SWAP3
+    // stack: b_start_loc, len, base_addr, a_end_loc, retdest
+    PUSH 1
+    DUP3
+    SUB
+    // stack: len-1, b_start_loc, len, base_addr, a_end_loc, retdest
+    ADD
+    // stack: b_end_loc, len, base_addr, a_end_loc, retdest
+
+    %stack (b, l, addr, a) -> (l, addr, a, b)
+    // stack: len, base_addr, a_end_loc, b_end_loc, retdest
     %decrement
 ge_loop:
-    // stack: i, a_i_loc, b_i_loc, retdest
-    DUP3
-    DUP3
-    // stack: a_i_loc, b_i_loc, i, a_i_loc, b_i_loc, retdest
-    %mload_current_general
-    SWAP1
-    %mload_current_general
-    SWAP1
-    // stack: a[i], b[i], i, a_i_loc, b_i_loc, retdest
+    // stack: i, base_addr, a_i_loc, b_i_loc, retdest
+    DUP4
+    // stack: b_i_loc, i, base_addr, a_i_loc, b_i_loc, retdest
+    DUP3 ADD // b_i_addr
+    MLOAD_GENERAL
+    // stack: b[i], i, base_addr, a_i_loc, b_i_loc, retdest
+    DUP4
+    // stack: a_i_loc, b[i], i, base_addr, a_i_loc, b_i_loc, retdest
+    DUP4 ADD // a_i_addr
+    MLOAD_GENERAL
+    // stack: a[i], b[i], i, base_addr, a_i_loc, b_i_loc, retdest
     %stack (vals: 2) -> (vals, vals)
     GT
     %jumpi(greater)
-    // stack: a[i], b[i], i, a_i_loc, b_i_loc, retdest
+    // stack: a[i], b[i], i, base_addr, a_i_loc, b_i_loc, retdest
     LT
     %jumpi(less)
-    // stack: i, a_i_loc, b_i_loc, retdest
+    // stack: i, base_addr, a_i_loc, b_i_loc, retdest
     DUP1
     ISZERO
     %jumpi(equal)
     %decrement
-    // stack: i-1, a_i_loc, b_i_loc, retdest
-    SWAP1
-    // stack: a_i_loc, i-1, b_i_loc, retdest
-    %decrement
-    // stack: a_i_loc_new, i-1, b_i_loc, retdest
+    // stack: i-1, base_addr, a_i_loc, b_i_loc, retdest
     SWAP2
-    // stack: b_i_loc, i-1, a_i_loc_new, retdest
+    // stack: a_i_loc, base_addr, i-1, b_i_loc, retdest
     %decrement
-    // stack: b_i_loc_new, i-1, a_i_loc_new, retdest
-    %stack (b, i, a) -> (i, a, b)
-    // stack: i-1, a_i_loc_new, b_i_loc_new, retdest
+    // stack: a_i_loc_new, base_addr, i-1, b_i_loc, retdest
+    SWAP3
+    // stack: b_i_loc, base_addr, i-1, a_i_loc_new, retdest
+    %decrement
+    // stack: b_i_loc_new, base_addr, i-1, a_i_loc_new, retdest
+    %stack (b, addr, i, a) -> (i, addr, a, b)
+    // stack: i-1, base_addr, a_i_loc_new, b_i_loc_new, retdest
     %jump(ge_loop)
 equal:
-    // stack: i, a_i_loc, b_i_loc, retdest
-    %pop3
+    // stack: i, base_addr, a_i_loc, b_i_loc, retdest
+    %pop4
     // stack: retdest
     PUSH 0
     // stack: 0, retdest
     SWAP1
     JUMP
 greater:
-    // stack: a[i], b[i], i, a_i_loc, b_i_loc, retdest
-    %pop5
+    // stack: a[i], b[i], i, base_addr, a_i_loc, b_i_loc, retdest
+    %pop6
     // stack: retdest
     PUSH 1
     // stack: 1, retdest
     SWAP1
     JUMP
 less:
-    // stack: i, a_i_loc, b_i_loc, retdest
-    %pop3
+    // stack: i, base_addr, a_i_loc, b_i_loc, retdest
+    %pop4
     // stack: retdest
     PUSH 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
     // stack: -1, retdest

--- a/evm/src/cpu/kernel/asm/bignum/modmul.asm
+++ b/evm/src/cpu/kernel/asm/bignum/modmul.asm
@@ -21,28 +21,32 @@ global modmul_bignum:
     // STEP 1:
     // The prover provides x := (a * b) % m, which we store in output_loc.
     
+    %build_current_general_address_no_offset
+
     PUSH 0
-    // stack: i=0, len, a_loc, b_loc, m_loc, out_loc, s1, s2, s3, retdest
+    // stack: i=0, base_addr, len, a_loc, b_loc, m_loc, out_loc, s1, s2, s3, retdest
 modmul_remainder_loop:
-    // stack: i, len, a_loc, b_loc, m_loc, out_loc, s1, s2, s3, retdest
+    // stack: i, base_addr, len, a_loc, b_loc, m_loc, out_loc, s1, s2, s3, retdest
     PROVER_INPUT(bignum_modmul)
-    // stack: PI, i, len, a_loc, b_loc, m_loc, out_loc, s1, s2, s3, retdest
-    DUP7
+    // stack: PI, i, base_addr, len, a_loc, b_loc, m_loc, out_loc, s1, s2, s3, retdest
+    DUP8
     DUP3
     ADD
-    // stack: out_loc[i], PI, i, len, a_loc, b_loc, m_loc, out_loc, s1, s2, s3, retdest
-    %mstore_current_general
-    // stack: i, len, a_loc, b_loc, m_loc, out_loc, s1, s2, s3, retdest
+    // stack: out_loc[i], PI, i, base_addr, len, a_loc, b_loc, m_loc, out_loc, s1, s2, s3, retdest
+    DUP4 ADD // out_addr_i
+    %swap_mstore
+    // stack: i, base_addr, len, a_loc, b_loc, m_loc, out_loc, s1, s2, s3, retdest
     %increment
+    DUP3
     DUP2
-    DUP2
-    // stack: i+1, len, i+1, len, a_loc, b_loc, m_loc, out_loc, s1, s2, s3, retdest
+    // stack: i+1, len, i+1, base_addr, len, a_loc, b_loc, m_loc, out_loc, s1, s2, s3, retdest
     SUB // functions as NEQ
-    // stack: i+1!=len, i+1, len, a_loc, b_loc, m_loc, out_loc, s1, s2, s3, retdest
+    // stack: i+1!=len, i+1, base_addr, len, a_loc, b_loc, m_loc, out_loc, s1, s2, s3, retdest
     %jumpi(modmul_remainder_loop)
 // end of modmul_remainder_loop
-    // stack: i, len, a_loc, b_loc, m_loc, out_loc, s1, s2, s3, retdest
-    POP
+    // stack: i, base_addr, len, a_loc, b_loc, m_loc, out_loc, s1, s2, s3, retdest
+    %pop2
+    // stack: len, a_loc, b_loc, m_loc, out_loc, s1, s2, s3, retdest
 
     // stack: len, a_loc, b_loc, m_loc, out_loc, s1, s2, s3, retdest
 
@@ -69,28 +73,32 @@ modmul_return_1:
     // stack: len, len, a_loc, b_loc, m_loc, out_loc, s1, s2, s3, retdest
     %mul_const(2)
     // stack: 2*len, len, a_loc, b_loc, m_loc, out_loc, s1, s2, s3, retdest
+
+    %build_current_general_address_no_offset
+
     PUSH 0
-    // stack: i=0, 2*len, len, a_loc, b_loc, m_loc, out_loc, s1, s2, s3, retdest
+    // stack: i=0, base_addr, 2*len, len, a_loc, b_loc, m_loc, out_loc, s1, s2, s3, retdest
 modmul_quotient_loop:
-    // stack: i, 2*len, len, a_loc, b_loc, m_loc, out_loc, s1, s2, s3, retdest
+    // stack: i, base_addr, 2*len, len, a_loc, b_loc, m_loc, out_loc, s1, s2, s3, retdest
     PROVER_INPUT(bignum_modmul)
-    // stack: PI, i, 2*len, len, a_loc, b_loc, m_loc, out_loc, s1, s2, s3, retdest
-    DUP9
+    // stack: PI, i, base_addr, 2*len, len, a_loc, b_loc, m_loc, out_loc, s1, s2, s3, retdest
+    DUP10
     DUP3
     ADD
-    // stack: s1[i], PI, i, 2*len, len, a_loc, b_loc, m_loc, out_loc, s1, s2, s3, retdest
-    %mstore_current_general
-    // stack: i, 2*len, len, a_loc, b_loc, m_loc, out_loc, s1, s2, s3, retdest
+    // stack: s1[i], PI, i, base_addr, 2*len, len, a_loc, b_loc, m_loc, out_loc, s1, s2, s3, retdest
+    DUP4 ADD // s1_addr_i
+    %swap_mstore
+    // stack: i, base_addr, 2*len, len, a_loc, b_loc, m_loc, out_loc, s1, s2, s3, retdest
     %increment
+    DUP3
     DUP2
-    DUP2
-    // stack: i+1, 2*len, i+1, 2*len, len, a_loc, b_loc, m_loc, out_loc, s1, s2, s3, retdest
+    // stack: i+1, 2*len, i+1, base_addr, 2*len, len, a_loc, b_loc, m_loc, out_loc, s1, s2, s3, retdest
     SUB // functions as NEQ
-    // stack: i+1!=2*len, i+1, 2*len, len, a_loc, b_loc, m_loc, out_loc, s1, s2, s3, retdest
+    // stack: i+1!=2*len, i+1, base_addr, 2*len, len, a_loc, b_loc, m_loc, out_loc, s1, s2, s3, retdest
     %jumpi(modmul_quotient_loop)
 // end of modmul_quotient_loop
-    // stack: i, 2*len, len, a_loc, b_loc, m_loc, out_loc, s1, s2, s3, retdest
-    %pop2
+    // stack: i, base_addr, 2*len, len, a_loc, b_loc, m_loc, out_loc, s1, s2, s3, retdest
+    %pop3
     // stack: len, a_loc, b_loc, m_loc, out_loc, s1, s2, s3, retdest
 
     // STEP 4:
@@ -130,33 +138,36 @@ modmul_return_4:
     // STEP 6:
     // Check that x + k * m = a * b.
 
-    // Walk through scratch_2 and scratch_3, checking that they are equal.
-    // stack: n=len, i=s2, j=s3, retdest
+    %build_current_general_address_no_offset
+    // stack: base_addr, n=len, i=s2, j=s3, retdest
 modmul_check_loop:
-    // stack: n, i, j, retdest
-    %stack (l, idx: 2) -> (idx, l, idx)
-    // stack: i, j, n, i, j, retdest
-    %mload_current_general
-    SWAP1
-    %mload_current_general
-    SWAP1
-    // stack: mem[i], mem[j], n, i, j, retdest
+    // stack: base_addr, n, i, j, retdest
+    %stack (addr, l, i, j) -> (j, i, addr, addr, l, i, j)
+    // stack: j, i, base_addr, base_addr, n, i, j, retdest
+    DUP3 ADD // addr_j
+    MLOAD_GENERAL
+    // stack: mem[j], i, base_addr, base_addr, n, i, j, retdest
+    SWAP2
+    ADD // addr_i
+    MLOAD_GENERAL
+    // stack: mem[i], mem[j], base_addr, n, i, j, retdest
     %assert_eq
-    // stack: n, i, j, retdest
+    // stack: base_addr, n, i, j, retdest
+    SWAP1
     %decrement
-    SWAP1
-    %increment
+    // stack: n-1, base_addr, i, j, retdest
     SWAP2
     %increment
-    SWAP2
-    SWAP1
-    // stack: n-1, i+1, j+1, retdest
-    DUP1
-    // stack: n-1, n-1, i+1, j+1, retdest
+    // stack: i+1, base_addr, n-1, j, retdest
+    SWAP3
+    %increment
+    // stack: j+1, base_addr, n-1, i+1, retdest
+    %stack (j, addr, n, i) -> (n, addr, n, i, j)
+    // stack: n-1, base_addr, n-1, i+1, j+1, retdest
     %jumpi(modmul_check_loop)
 // end of modmul_check_loop
-    // stack: n-1, i+1, j+1, retdest
-    %pop3
+    // stack: base_addr, n-1, i+1, j+1, retdest
+    %pop4
     // stack: retdest
     JUMP
 

--- a/evm/src/cpu/kernel/asm/bignum/mul.asm
+++ b/evm/src/cpu/kernel/asm/bignum/mul.asm
@@ -12,49 +12,54 @@ global mul_bignum:
     // stack: len, len, a_start_loc, b_start_loc, output_loc, retdest
     ISZERO
     %jumpi(len_zero)
-    DUP1
-    // stack: n=len, len, a_start_loc, bi=b_start_loc, output_cur=output_loc, retdest
+    
+    %build_current_general_address_no_offset
+
+    DUP2
+    // stack: n=len, base_addr, len, a_start_loc, bi=b_start_loc, output_cur=output_loc, retdest
 mul_loop:
-    // stack: n, len, a_start_loc, bi, output_cur, retdest
+    // stack: n, base_addr, len, a_start_loc, bi, output_cur, retdest
     PUSH mul_addmul_return
-    // stack: mul_addmul_return, n, len, a_start_loc, bi, output_cur, retdest
-    DUP5
-    // stack: bi, mul_addmul_return, n, len, a_start_loc, bi, output_cur, retdest
-    %mload_current_general
-    // stack: b[i], mul_addmul_return, n, len, a_start_loc, bi, output_cur, retdest, b
-    DUP5
-    // stack: a_start_loc, b[i], mul_addmul_return, n, len, a_start_loc, bi, output_cur, retdest, b
-    DUP8
-    // stack: output_loc, a_start_loc, b[i], mul_addmul_return, n, len, a_start_loc, bi, output_cur, retdest, b
+    // stack: mul_addmul_return, n, base_addr, len, a_start_loc, bi, output_cur, retdest
     DUP6
-    // stack: len, output_loc, a_start_loc, b[i], mul_addmul_return, n, len, a_start_loc, bi, output_cur, retdest, b
+    // stack: bi, mul_addmul_return, n, base_addr, len, a_start_loc, bi, output_cur, retdest
+    DUP4 ADD // bi_addr
+    MLOAD_GENERAL
+    // stack: b[i], mul_addmul_return, n, base_addr, len, a_start_loc, bi, output_cur, retdest
+    DUP6
+    // stack: a_start_loc, b[i], mul_addmul_return, n, base_addr, len, a_start_loc, bi, output_cur, retdest
+    DUP9
+    // stack: output_loc, a_start_loc, b[i], mul_addmul_return, n, base_addr, len, a_start_loc, bi, output_cur, retdest
+    DUP7
+    // stack: len, output_loc, a_start_loc, b[i], mul_addmul_return, n, base_addr, len, a_start_loc, bi, output_cur, retdest
     %jump(addmul_bignum)
 mul_addmul_return:
-    // stack: carry_limb, n, len, a_start_loc, bi, output_cur, retdest
-    DUP6
-    // stack: output_cur, carry_limb, n, len, a_start_loc, bi, output_cur, retdest
-    DUP4
-    // stack: len, output_cur, carry_limb, n, len, a_start_loc, bi, output_cur, retdest
+    // stack: carry_limb, n, base_addr, len, a_start_loc, bi, output_cur, retdest
+    DUP7
+    // stack: output_cur, carry_limb, n, base_addr, len, a_start_loc, bi, output_cur, retdest
+    DUP5
+    // stack: len, output_cur, carry_limb, n, base_addr, len, a_start_loc, bi, output_cur, retdest
     ADD
-    // stack: output_cur + len, carry_limb, n, len, a_start_loc, bi, output_cur, retdest
-    %mstore_current_general
-    // stack: n, len, a_start_loc, bi, output_cur, retdest
+    // stack: output_cur + len, carry_limb, n, base_addr, len, a_start_loc, bi, output_cur, retdest
+    DUP4 ADD
+    %swap_mstore
+    // stack: n, base_addr, len, a_start_loc, bi, output_cur, retdest
     %decrement
-    // stack: n-1, len, a_start_loc, bi, output_cur, retdest
-    SWAP3
-    %increment
-    SWAP3
-    // stack: n-1, len, a_start_loc, bi+1, output_cur, retdest
+    // stack: n-1, base_addr, len, a_start_loc, bi, output_cur, retdest
     SWAP4
     %increment
     SWAP4
-    // stack: n-1, len, a_start_loc, bi+1, output_cur+1, retdest
+    // stack: n-1, base_addr, len, a_start_loc, bi+1, output_cur, retdest
+    SWAP5
+    %increment
+    SWAP5
+    // stack: n-1, base_addr, len, a_start_loc, bi+1, output_cur+1, retdest
     DUP1
-    // stack: n-1, n-1, len, a_start_loc, bi+1, output_cur+1, retdest
+    // stack: n-1, n-1, base_addr, len, a_start_loc, bi+1, output_cur+1, retdest
     %jumpi(mul_loop)
 mul_end:
-    // stack: n-1, len, a_start_loc, bi+1, output_cur+1, retdest
-    %pop5
+    // stack: n-1, base_addr, len, a_start_loc, bi+1, output_cur+1, retdest
+    %pop6
     // stack: retdest
     JUMP
 

--- a/evm/src/cpu/kernel/asm/bignum/shr.asm
+++ b/evm/src/cpu/kernel/asm/bignum/shr.asm
@@ -16,48 +16,54 @@ global shr_bignum:
     // stack: start_loc + len, start_loc, retdest
     %decrement
     // stack: end_loc, start_loc, retdest
-    %stack (e) -> (e, 0)
-    // stack: i=end_loc, carry=0, start_loc, retdest
+    
+    %build_current_general_address_no_offset
+
+    // stack: base_addr, end_loc, start_loc, retdest
+    %stack (addr, e) -> (e, addr, 0)
+    // stack: i=end_loc, base_addr, carry=0, start_loc, retdest
 shr_loop:
-    // stack: i, carry, start_loc, retdest
+    // stack: i, base_addr, carry, start_loc, retdest
     DUP1
-    // stack: i, i, carry, start_loc, retdest
-    %mload_current_general
-    // stack: a[i], i, carry, start_loc, retdest
+    // stack: i, i, base_addr, carry, start_loc, retdest
+    DUP3 ADD // addr_i
+    MLOAD_GENERAL
+    // stack: a[i], i, base_addr, carry, start_loc, retdest
     DUP1
-    // stack: a[i], a[i], i, carry, start_loc, retdest
+    // stack: a[i], a[i], i, base_addr, carry, start_loc, retdest
     %shr_const(1)
-    // stack: a[i] >> 1, a[i], i, carry, start_loc, retdest
+    // stack: a[i] >> 1, a[i], i, base_addr, carry, start_loc, retdest
     SWAP1
-    // stack: a[i], a[i] >> 1, i, carry, start_loc, retdest
+    // stack: a[i], a[i] >> 1, i, base_addr, carry, start_loc, retdest
     %mod_const(2)
-    // stack: new_carry = a[i] % 2, a[i] >> 1, i, carry, start_loc, retdest
-    SWAP3
-    // stack: carry, a[i] >> 1, i, new_carry, start_loc, retdest
+    // stack: new_carry = a[i] % 2, a[i] >> 1, i, base_addr, carry, start_loc, retdest
+    SWAP4
+    // stack: carry, a[i] >> 1, i, base_addr, new_carry, start_loc, retdest
     %shl_const(127)
-    // stack: carry << 127, a[i] >> 1, i, new_carry, start_loc, retdest
+    // stack: carry << 127, a[i] >> 1, i, base_addr, new_carry, start_loc, retdest
     ADD
-    // stack: carry << 127 | a[i] >> 1, i, new_carry, start_loc, retdest
+    // stack: carry << 127 | a[i] >> 1, i, base_addr, new_carry, start_loc, retdest
     DUP2
-    // stack: i, carry << 127 | a[i] >> 1, i, new_carry, start_loc, retdest
-    %mstore_current_general
-    // stack: i, new_carry, start_loc, retdest
+    // stack: i, carry << 127 | a[i] >> 1, i, base_addr, new_carry, start_loc, retdest
+    DUP4 ADD // addr_i
+    %swap_mstore
+    // stack: i, base_addr, new_carry, start_loc, retdest
     PUSH 1
     DUP2
     SUB
-    // stack: i-1, i, new_carry, start_loc, retdest
+    // stack: i-1, i, base_addr, new_carry, start_loc, retdest
     SWAP1
-    // stack: i, i-1, new_carry, start_loc, retdest
-    DUP4
-    // stack: start_loc, i, i-1, new_carry, start_loc, retdest
+    // stack: i, i-1, base_addr, new_carry, start_loc, retdest
+    DUP5
+    // stack: start_loc, i, i-1, base_addr, new_carry, start_loc, retdest
     EQ
-    // stack: i == start_loc, i-1, new_carry, start_loc, retdest
+    // stack: i == start_loc, i-1, base_addr, new_carry, start_loc, retdest
     ISZERO
-    // stack: i != start_loc, i-1, new_carry, start_loc, retdest
+    // stack: i != start_loc, i-1, base_addr, new_carry, start_loc, retdest
     %jumpi(shr_loop)
 shr_end:
-    // stack: i, new_carry, start_loc, retdest
-    %pop3
+    // stack: i, base_addr, new_carry, start_loc, retdest
+    %pop4
     // stack: retdest
     JUMP
 

--- a/evm/src/cpu/kernel/asm/bignum/util.asm
+++ b/evm/src/cpu/kernel/asm/bignum/util.asm
@@ -1,7 +1,7 @@
 %macro memcpy_current_general
     // stack: dst, src, len
     // DST and SRC are offsets, for the same memory segment
-    GET_CONTEXT PUSH @SEGMENT_KERNEL_GENERAL %build_address_no_offset
+    %build_current_general_address_no_offset
     %stack (addr_no_offset, dst, src, len) -> (addr_no_offset, src, addr_no_offset, dst, len, %%after)
     ADD
     // stack: SRC, addr_no_offset, dst, len, %%after
@@ -14,7 +14,7 @@
 
 %macro clear_current_general
     // stack: dst, len
-    GET_CONTEXT PUSH @SEGMENT_KERNEL_GENERAL %build_address
+    %build_current_general_address
     %stack (DST, len) -> (DST, len, %%after)
     %jump(memset)
 %%after:

--- a/evm/src/cpu/kernel/asm/core/jumpdest_analysis.asm
+++ b/evm/src/cpu/kernel/asm/core/jumpdest_analysis.asm
@@ -164,12 +164,10 @@ global write_table_if_jumpdest:
     // stack: (is_1_at_1 or is_0_at_2_or_3|X⁷)³², packed_opcodes, proof_prefix_addr, ctx, jumpdest, retdest
     // stack: (~has_prefix|X⁷)³², packed_opcodes, proof_prefix_addr, ctx, jumpdest, retdest
 
-    // Compute in_range = 
-    //   - (0xFF|X⁷)³² for the first 15 bytes
-    //   - (has_prefix => is_0_at_4 |X⁷)³² for the next 15 bytes
-    //   - (~has_prefix|X⁷)³² for the last byte
-    // Compute also ~has_prefix = ~has_prefix OR is_0_at_4 for all bytes. We don't need to update ~has_prefix
-    // for the second half but it takes less cycles if we do it.
+    // Compute in_range and has_prefix' = 
+    //   - in_range = (0xFF|X⁷)³²                     and ~has_prefix' = ~has_prefix OR is_0_at_4, for the first 15 bytes
+    //   - in_range = (has_prefix => is_0_at_4 |X⁷)³² and ~has_prefix' = ~has_prefix,              for the next 15 bytes
+    //   - in_range = (~has_prefix|X⁷)³²              and ~has_prefix' = ~has_prefix,              for the last byte.
     DUP2 %shl_const(3)
     NOT
     // stack: (is_0_at_4|X⁷)³²,  (~has_prefix|X⁷)³², packed_opcodes, proof_prefix_addr, ctx, jumpdest, retdest
@@ -177,93 +175,97 @@ global write_table_if_jumpdest:
     PUSH 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF00
     AND
     // stack: (is_0_at_4|X⁷)³¹|0⁸,  (~has_prefix|X⁷)³², packed_opcodes, proof_prefix_addr, ctx, jumpdest, retdest
-    DUP2
-    DUP2
+    DUP1
+    // pos 0102030405060708091011121314151617181920212223242526272829303132
+    PUSH 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF0000000000000000000000000000000000
+    AND
+    // stack: (is_0_at_4|X⁷)¹⁵|(0⁸)¹⁷, (is_0_at_4|X⁷)³¹|0⁸, (~has_prefix|X⁷)³², packed_opcodes, proof_prefix_addr, ctx, jumpdest, retdest
+    DUP3
+    OR
+    // (~has_prefix'|X⁷)³²,  (is_0_at_4|X⁷)³¹|0⁸, (~has_prefix|X⁷)³², packed_opcodes, proof_prefix_addr, ctx, jumpdest, retdest
+    SWAP2
     OR
     // pos 0102030405060708091011121314151617181920212223242526272829303132
     PUSH 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF0000000000000000000000000000000000
     OR
-    // stack: (in_range|X⁷)³², (is_0_at_4|X⁷)³²,  (~has_prefix|X⁷)³², packed_opcodes, proof_prefix_addr, ctx, jumpdest, retdest
-    SWAP2
-    OR
-    // stack: (~has_prefix|X⁷)³², (in_range|X⁷)³², packed_opcodes, proof_prefix_addr, ctx, jumpdest, retdest
+    // stack: (in_range|X⁷)³², (~has_prefix'|X⁷)³², packed_opcodes, proof_prefix_addr, ctx, jumpdest, retdest
 
-    // Compute in_range' = in_range AND
-    //   - (0xFF|X⁷)³² for bytes in positions 1-7 and 16-23 
-    //   - (has_prefix => is_0_at_5 |X⁷)³² on the rest
-    // Compute also ~has_prefix = ~has_prefix OR is_0_at_5 for all bytes.
+    // Compute in_range' and ~has_prefix as
+    //   - in_range' = in_range                                     and has_prefix' = ~has_prefix OR is_0_at_5, for bytes in positions 1-7 and 16-23 
+    //   - in_range' = in_range AND (has_prefix => is_0_at_5 |X⁷)³² and has_prefix' = ~has_prefix,              for the rest.
 
     DUP3 %shl_const(4)
     NOT
-    // stack: (is_0_at_5|X⁷)³²,  (~has_prefix|X⁷)³², (in_range|X⁷)³², packed_opcodes, proof_prefix_addr, ctx, jumpdest, retdest
-    DUP2
-    DUP2
+    // stack: (is_0_at_5|X⁷)³²,  (in_range|X⁷)³², (~has_prefix|X⁷)³², packed_opcodes, proof_prefix_addr, ctx, jumpdest, retdest
+    DUP1
+    // pos 0102030405060708091011121314151617181920212223242526272829303132
+    PUSH 0xFFFFFFFFFFFFFF0000000000000000FFFFFFFFFFFFFFFF000000000000000000
+    AND
+    // stack: (is_0_at_5|X⁷)⁷|(0⁸)⁸|(is_0_at_5|X⁷)⁸|(0⁸)⁸, (is_0_at_5|X⁷)³²,  (in_range|X⁷)³², (~has_prefix|X⁷)³², packed_opcodes, proof_prefix_addr, ctx, jumpdest, retdest
+    DUP4
+    OR
+    // stack: (~has_prefix'|X⁷)³², (is_0_at_5|X⁷)³²,  (in_range|X⁷)³², (~has_prefix|X⁷)³², packed_opcodes, proof_prefix_addr, ctx, jumpdest, retdest
+    SWAP3
     OR
     // pos 0102030405060708091011121314151617181920212223242526272829303132
     PUSH 0xFFFFFFFFFFFFFF0000000000000000FFFFFFFFFFFFFFFF000000000000000000
     OR
-    // stack: (in_range'|X⁷)³², (is_0_at_5|X⁷)³²,  (~has_prefix|X⁷)³², (in_range|X⁷)³², packed_opcodes, proof_prefix_addr, ctx, jumpdest, retdest
-    SWAP2
-    OR
-    // stack: (~has_prefix|X⁷)³², (in_range'|X⁷)³², (in_range|X⁷)³², packed_opcodes, proof_prefix_addr, ctx, jumpdest, retdest
-    SWAP2
     AND
-    SWAP1 
+    // stack: (in_range'|X⁷)³²,  (~has_prefix'|X⁷)³², packed_opcodes, proof_prefix_addr, ctx, jumpdest, retdest
 
-    // Compute in_range' = in_range AND
-    //   - (0xFF|X⁷)³² for bytes in positions 1-3, 8-11, 16-19, and 24-27 
-    //   - (has_prefix => is_0_at_6 |X⁷)³² on the rest
-    // Compute also that ~has_prefix = ~has_prefix OR is_0_at_4 for all bytes.
-
-    // stack: (~has_prefix|X⁷)³², (in_range|X⁷)³², packed_opcodes, proof_prefix_addr, ctx, jumpdest, retdest
+    // Compute in_range' and ~has_prefix' as
+    //   - in_range' = in_range                                     and ~has_prefix' = ~has_prefix OR is_0_at_6, for bytes in positions 1-3, 8-11, 16-19, and 24-27 
+    //   - in_range' = in_range AND (has_prefix => is_0_at_6 |X⁷)³² and ~has_prefix' = has_prefix,               for the rest.
     DUP3 %shl_const(5)
     NOT
-    // stack: (is_0_at_6|X⁷)³²,  (~has_prefix|X⁷)³², (in_range|X⁷)³², packed_opcodes, proof_prefix_addr, ctx, jumpdest, retdest
-    DUP2
-    DUP2
+    // stack: (is_0_at_6|X⁷)³²,  (in_range|X⁷)³², (~has_prefix|X⁷)³², packed_opcodes, proof_prefix_addr, ctx, jumpdest, retdest
+    DUP1
+    // pos 0102030405060708091011121314151617181920212223242526272829303132
+    PUSH 0xFFFFFF00000000FFFFFFFF00000000FFFFFFFF00000000FFFFFFFF0000000000
+    AND
+    // stack: (is_0_at_6|X⁷)³|(0⁸)⁴|((is_0_at_6|X⁷)⁴|(0⁸)⁴)³, (is_0_at_6|X⁷)³²,  (in_range|X⁷)³², (~has_prefix|X⁷)³², packed_opcodes, proof_prefix_addr, ctx, jumpdest, retdest
+    DUP4
+    OR
+    // stack: (~has_prefix'|X⁷)³², (is_0_at_6|X⁷)³²,  (in_range|X⁷)³², (~has_prefix|X⁷)³², packed_opcodes, proof_prefix_addr, ctx, jumpdest, retdest
+    SWAP3
     OR
     // pos 0102030405060708091011121314151617181920212223242526272829303132
     PUSH 0xFFFFFF00000000FFFFFFFF00000000FFFFFFFF00000000FFFFFFFF0000000000
     OR
-    // stack: (in_range'|X⁷)³², (is_0_at_6|X⁷)³²,  (~has_prefix|X⁷)³², (in_range|X⁷)³², packed_opcodes, proof_prefix_addr, ctx, jumpdest, retdest
-    SWAP2
-    OR
-    // stack: (~has_prefix|X⁷)³², (in_range'|X⁷)³², (in_range|X⁷)³², packed_opcodes, proof_prefix_addr, ctx, jumpdest, retdest
-    SWAP2
     AND
-    SWAP1 
+    // stack: (in_range'|X⁷)³², (~has_prefix'|X⁷)³², (in_range|X⁷)³², packed_opcodes, proof_prefix_addr, ctx, jumpdest, retdest
 
-    // Compute in_range' = in_range AND
-    //   - (0xFF|X⁷)³² for bytes in 1, 4-5, 8-9, 12-13, 16-17, 20-21, 24-25, 28-29
-    //   - (has_prefix => is_0_at_7 |X⁷)³² on the rest
-    // Compute also that ~has_prefix = ~has_prefix OR is_0_at_7 for all bytes.
-
-    // stack: (~has_prefix|X⁷)³², (in_range|X⁷)³², packed_opcodes, proof_prefix_addr, ctx, jumpdest, retdest
+    // Compute in_range' and ~has_prefix' as
+    //   - in_range' = in_range                                     and ~has_prefix' = has_prefix OR is_0_at_7, for bytes in 1, 4-5, 8-9, 12-13, 16-17, 20-21, 24-25, 28-29
+    //   - in_range' = in_range AND (has_prefix => is_0_at_7 |X⁷)³² and ~has_prefix' = ~has_prefix,             for the rest.
     DUP3 %shl_const(6)
     NOT
-    // stack: (is_0_at_7|X⁷)³²,  (~has_prefix|X⁷)³², (in_range|X⁷)³², packed_opcodes, proof_prefix_addr, ctx, jumpdest, retdest
-    DUP2
-    DUP2
+    // stack: (is_0_at_7|X⁷)³², (in_range|X⁷)³², (~has_prefix|X⁷)³², packed_opcodes, proof_prefix_addr, ctx, jumpdest, retdest
+    DUP1
+    // pos 0102030405060708091011121314151617181920212223242526272829303132
+    PUSH 0xFF0000FFFF0000FFFF0000FFFF0000FFFF0000FFFF0000FFFF0000FFFF000000
+    AND
+    // stack:  is_0_at_7|X⁷|(0⁸)²|((is_0_at_7|X⁷)²|(0⁸)²)⁷, (is_0_at_7|X⁷)³², (in_range|X⁷)³², (~has_prefix|X⁷)³², packed_opcodes, proof_prefix_addr, ctx, jumpdest, retdest
+    DUP4
+    OR
+    // (~has_prefix'|X⁷)³², (is_0_at_7|X⁷)³²,  (in_range|X⁷)³², (~has_prefix|X⁷)³², packed_opcodes, proof_prefix_addr, ctx, jumpdest, retdest
+    SWAP3
     OR
     // pos 0102030405060708091011121314151617181920212223242526272829303132
     PUSH 0xFF0000FFFF0000FFFF0000FFFF0000FFFF0000FFFF0000FFFF0000FFFF000000
     OR
-    // stack: (in_range'|X⁷)³², (is_0_at_7|X⁷)³²,  (~has_prefix|X⁷)³², (in_range|X⁷)³², packed_opcodes, proof_prefix_addr, ctx, jumpdest, retdest
-    SWAP2
-    OR
-    // stack: (~has_prefix|X⁷)³², (in_range'|X⁷)³², (in_range|X⁷)³², packed_opcodes, proof_prefix_addr, ctx, jumpdest, retdest
-    SWAP2
     AND
+    // stack: (in_range'|X⁷)³², (~has_prefix'|X⁷)³², packed_opcodes, proof_prefix_addr, ctx, jumpdest, retdest
+
+    // Compute in_range' as
+    //   - in_range' = in_range,                                    for odd positions
+    //   - in_range' = in_range AND (has_prefix => is_0_at_8 |X⁷)³², for the rest
+
     SWAP1
-
-    // Compute in_range' = in_range AND
-    //   - (0xFF|X⁷)³² for bytes in odd positions
-    //   - (has_prefix => is_0_at_8 |X⁷)³² on the rest
-
     // stack: (~has_prefix|X⁷)³², (in_range|X⁷)³², packed_opcodes, proof_prefix_addr, ctx, jumpdest, retdest
     DUP3 %shl_const(7)
     NOT
-    // stack: (is_0_at_8|X⁷)³²,  (~has_prefix|X⁷)³², (in_range|X⁷)³², packed_opcodes, proof_prefix_addr, ctx, jumpdest, retdest
+    // stack: (is_0_at_8|X⁷)³², (~has_prefix|X⁷)³², (in_range|X⁷)³², packed_opcodes, proof_prefix_addr, ctx, jumpdest, retdest
     OR
     // pos 0102030405060708091011121314151617181920212223242526272829303132
     PUSH 0x00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF00FF
@@ -275,14 +277,18 @@ global write_table_if_jumpdest:
     // pos 0102030405060708091011121314151617181920212223242526272829303132
     PUSH 0x8080808080808080808080808080808080808080808080808080808080808080
     AND
-    %jump_neq_const(0x8080808080808080808080808080808080808080808080808080808080808080, return)
+    %jump_neq_const(0x8080808080808080808080808080808080808080808080808080808080808080, return_pop_opcode)
     POP
     %add_const(32)
 
     // check the remaining path
     %jump(verify_path_and_write_jumpdest_table)
+return_pop_opcode:
+    POP
 return:
-    // stack: proof_prefix_addr, jumpdest, ctx, retdest
+    // stack: proof_prefix_addr, ctx, jumpdest, retdest
+    // or
+    // stack: jumpdest, ctx, proof_prefix_addr, retdest
     %pop3
     JUMP
 

--- a/evm/src/cpu/kernel/asm/curve/bn254/curve_arithmetic/final_exponent.asm
+++ b/evm/src/cpu/kernel/asm/curve/bn254/curve_arithmetic/final_exponent.asm
@@ -56,14 +56,21 @@ final_exp:
     %stack (val) -> (val, 0, val)
     // stack:        val, 0, val, retdest
     %move_fp254_12
-    // stack:             0, val, retdest  {0: sqr}
-    %stack () -> (1, 1, 1)
-    // stack:    1, 1, 1, 0, val, retdest
-    %mstore_bn254_pairing(12)
-    %mstore_bn254_pairing(24)
-    %mstore_bn254_pairing(36)
-    // stack:             0, val, retdest  {0: sqr, 12: y0, 24: y2, 36: y4}
-    %stack () -> (64, 62, 65)
+    // dest addr returned by %move_fp254_12 is already scaled
+    // stack:          addr, val, retdest  {0: sqr}
+
+    // Write 1s at offset 12, 24 and 36
+    PUSH 12
+    ADD
+    DUP1 %add_const(12)
+    DUP1 %add_const(12)
+    // stack: addr_1, addr_2, addr_3
+    %rep 3
+        PUSH 1 MSTORE_GENERAL
+    %endrep
+
+    // stack:             val, retdest  {0: sqr, 12: y0, 24: y2, 36: y4}
+    %stack () -> (64, 62, 65, 0)
     // stack: 64, 62, 65, 0, val, retdest  {0: sqr, 12: y0, 24: y2, 36: y4}
     %jump(power_loop_4)
 

--- a/evm/src/cpu/kernel/asm/curve/bn254/curve_arithmetic/pairing.asm
+++ b/evm/src/cpu/kernel/asm/curve/bn254/curve_arithmetic/pairing.asm
@@ -83,9 +83,9 @@ bn_pairing_invalid_input:
 
 bn254_pairing_start:
     // stack:      0, k, inp, out,                   retdest
-    %stack (j, k, inp, out) -> (out, 1, k, inp, out, bn254_pairing_output_validation, out)
-    // stack: out, 1, k, inp, out, bn254_pairing_output_validation, out, retdest
-    %mstore_bn254_pairing
+    %stack (j, k, inp, out) -> (out, k, inp, out, bn254_pairing_output_validation, out)
+    // stack: out, k, inp, out, bn254_pairing_output_validation, out, retdest
+    %mstore_bn254_pairing_value(1)
     // stack:         k, inp, out, bn254_pairing_output_validation, out, retdest
 
 bn254_pairing_loop:
@@ -125,8 +125,9 @@ bn_skip_input:
 
 bn254_pairing_output_validation:
     // stack:        out, retdest
+    %create_bn254_pairing_address
     PUSH 1
-    // stack: check, out, retdest
+    // stack: check, out_addr, retdest
     %check_output_term
     %check_output_term(1)
     %check_output_term(2)
@@ -139,15 +140,15 @@ bn254_pairing_output_validation:
     %check_output_term(9)
     %check_output_term(10)
     %check_output_term(11)
-    // stack: check, out, retdest
-    %stack (check, out, retdest) -> (retdest, check)
+    // stack: check, out_addr, retdest
+    %stack (check, out_addr, retdest) -> (retdest, check)
     JUMP
 
 %macro check_output_term
     // stack:          check, out
     DUP2
     // stack:    out0, check, out
-    %mload_bn254_pairing
+    MLOAD_GENERAL
     // stack:      f0, check, out
     %eq_const(1)
     // stack:  check0, check, out
@@ -160,7 +161,7 @@ bn254_pairing_output_validation:
     DUP2
     %add_const($j)
     // stack:    outj, check, out
-    %mload_bn254_pairing
+    MLOAD_GENERAL
     // stack:      fj, check, out
     ISZERO
     // stack:  checkj, check, out

--- a/evm/src/cpu/kernel/asm/curve/bn254/field_arithmetic/inverse.asm
+++ b/evm/src/cpu/kernel/asm/curve/bn254/field_arithmetic/inverse.asm
@@ -42,9 +42,12 @@ check_inv_fp254_12:
     // stack: unit?, retdest
     %assert_eq_unit_fp254_12
     // stack:        retdest
+    PUSH 60
+    %create_bn254_pairing_address
     PUSH 0
-    // stack:     0, retdest
-    %mstore_bn254_pairing(60)
+    // stack: 0, addr, retdest
+    MSTORE_GENERAL
+    // stack: retdest
     JUMP
 
 %macro prover_inv_fp254_12

--- a/evm/src/cpu/kernel/asm/curve/bn254/field_arithmetic/util.asm
+++ b/evm/src/cpu/kernel/asm/curve/bn254/field_arithmetic/util.asm
@@ -20,6 +20,24 @@
     // stack:
 %endmacro
 
+// Build an address on the current context within SEGMENT_BN_PAIRING.
+%macro create_bn254_pairing_address
+    // stack: offset
+    PUSH @SEGMENT_BN_PAIRING
+    GET_CONTEXT
+    %build_address
+    // stack: addr
+%endmacro
+
+// Store a single value to bn254 pairings memory.
+%macro mstore_bn254_pairing_value(value)
+    // stack: offset
+    %create_bn254_pairing_address
+    PUSH $value
+    MSTORE_GENERAL
+    // stack:
+%endmacro
+
 %macro mstore_bn254_pairing(offset)
     // stack: value
     PUSH $offset
@@ -32,14 +50,15 @@
 
 %macro load_fp254_2
     // stack:       ptr
-    DUP1  
+    %create_bn254_pairing_address
+    DUP1
     %add_const(1)
-    // stack: ind1, ptr
-    %mload_bn254_pairing
-    // stack:   x1, ptr
+    // stack: addr1, addr
+    MLOAD_GENERAL
+    // stack:   x1, addr
     SWAP1
-    // stack: ind0, x1
-    %mload_bn254_pairing
+    // stack: addr0, x1
+    MLOAD_GENERAL
     // stack:   x0, x1
 %endmacro 
 
@@ -101,14 +120,14 @@
     // stack:      b,  a , b
     DUP2
     // stack:  a , b,  a , b
-    PUSH 9  
+    PUSH 9
     MULFP254
     // stack: 9a , b,  a , b
     SUBFP254
     // stack: 9a - b,  a , b
     SWAP2 
     // stack:  b , a, 9a - b
-    PUSH 9  
+    PUSH 9
     MULFP254
     // stack  9b , a, 9a - b
     ADDFP254
@@ -145,24 +164,25 @@
 
 %macro load_fp254_4
     // stack:                         ptr
-    DUP1  
+    %create_bn254_pairing_address
+    DUP1
     %add_const(2)
-    // stack:                   ind2, ptr
-    %mload_bn254_pairing
-    // stack:                     x2, ptr
-    DUP2  
+    // stack:                  addr2, addr
+    MLOAD_GENERAL
+    // stack:                     x2, addr
+    DUP2
     %add_const(1)
-    // stack:               ind1, x2, ptr
-    %mload_bn254_pairing
-    // stack:                 x1, x2, ptr
-    DUP3  
+    // stack:              addr1, x2, addr
+    MLOAD_GENERAL
+    // stack:                 x1, x2, addr
+    DUP3
     %add_const(3)
-    // stack:           ind3, x1, x2, ptr
-    %mload_bn254_pairing
-    // stack:             x3, x1, x2, ptr
+    // stack:          addr3, x1, x2, addr
+    MLOAD_GENERAL
+    // stack:             x3, x1, x2, addr
     SWAP3
-    // stack:            ind0, x1, x2, x3
-    %mload_bn254_pairing
+    // stack:           addr0, x1, x2, x3
+    MLOAD_GENERAL
     // stack:              x0, x1, x2, x3
 %endmacro
 
@@ -170,228 +190,177 @@
 
 %macro load_fp254_6
     // stack:                         ptr
-    DUP1  
+    %create_bn254_pairing_address
+    DUP1
     %add_const(4)
-    // stack:                   ind4, ptr
-    %mload_bn254_pairing
-    // stack:                     x4, ptr
-    DUP2  
+    // stack:                   addr4, addr
+    MLOAD_GENERAL
+    // stack:                     x4, addr
+    DUP2
     %add_const(3)
-    // stack:               ind3, x4, ptr
-    %mload_bn254_pairing
-    // stack:                 x3, x4, ptr
-    DUP3  
+    // stack:               addr3, x4, addr
+    MLOAD_GENERAL
+    // stack:                 x3, x4, addr
+    DUP3
     %add_const(2)
-    // stack:           ind2, x3, x4, ptr
-    %mload_bn254_pairing
-    // stack:             x2, x3, x4, ptr
-    DUP4  
+    // stack:           addr2, x3, x4, addr
+    MLOAD_GENERAL
+    // stack:             x2, x3, x4, addr
+    DUP4
     %add_const(1)
-    // stack:       ind1, x2, x3, x4, ptr
-    %mload_bn254_pairing
-    // stack:         x1, x2, x3, x4, ptr
-    DUP5  
+    // stack:       addr1, x2, x3, x4, addr
+    MLOAD_GENERAL
+    // stack:         x1, x2, x3, x4, addr
+    DUP5
     %add_const(5)
-    // stack:   ind5, x1, x2, x3, x4, ptr
-    %mload_bn254_pairing
-    // stack:     x5, x1, x2, x3, x4, ptr
+    // stack:   addr5, x1, x2, x3, x4, addr
+    MLOAD_GENERAL
+    // stack:     x5, x1, x2, x3, x4, addr
     SWAP5
-    // stack:   ind0, x1, x2, x3, x4, x5
-    %mload_bn254_pairing
+    // stack:   addr0, x1, x2, x3, x4, x5
+    MLOAD_GENERAL
     // stack:     x0, x1, x2, x3, x4, x5
 %endmacro
 
-// cost: 6 loads + 6 pushes + 5 adds = 6*4 + 6*1 + 5*2 = 40
 %macro load_fp254_6(ptr)
     // stack:
-    PUSH $ptr  
-    %add_const(5)
-    // stack:                     ind5
-    %mload_bn254_pairing
-    // stack:                       x5
-    PUSH $ptr  
-    %add_const(4)
-    // stack:                 ind4, x5
-    %mload_bn254_pairing
-    // stack:                   x4, x5
-    PUSH $ptr  
-    %add_const(3)
-    // stack:             ind3, x4, x5
-    %mload_bn254_pairing
-    // stack:               x3, x4, x5
-    PUSH $ptr  
-    %add_const(2)
-    // stack:         ind2, x3, x4, x5
-    %mload_bn254_pairing
-    // stack:           x2, x3, x4, x5
-    PUSH $ptr  
-    %add_const(1)
-    // stack:     ind1, x2, x3, x4, x5
-    %mload_bn254_pairing
-    // stack:       x1, x2, x3, x4, x5
     PUSH $ptr
-    // stack: ind0, x1, x2, x3, x4, x5
-    %mload_bn254_pairing
-    // stack:   x0, x1, x2, x3, x4, x5
+    %load_fp254_6
+    // stack: x0, x1, x2, x3, x4, x5
 %endmacro
 
-// cost: 6 stores + 6 swaps/dups + 5 adds = 6*4 + 6*1 + 5*2 = 40
 %macro store_fp254_6
     // stack:      ptr, x0, x1, x2, x3, x4 , x5
+    %create_bn254_pairing_address
     SWAP5
-    // stack:       x4, x0, x1, x2, x3, ptr, x5
-    DUP6  
+    // stack:       x4, x0, x1, x2, x3, addr, x5
+    DUP6
     %add_const(4)
-    // stack: ind4, x4, x0, x1, x2, x3, ptr, x5
-    %mstore_bn254_pairing
-    // stack:           x0, x1, x2, x3, ptr, x5
+    // stack: addr4, x4, x0, x1, x2, x3, addr, x5
+    %swap_mstore
+    // stack:           x0, x1, x2, x3, addr, x5
     DUP5
-    // stack:     ind0, x0, x1, x2, x3, ptr, x5
-    %mstore_bn254_pairing
-    // stack:               x1, x2, x3, ptr, x5
-    DUP4  
+    // stack:     addr0, x0, x1, x2, x3, addr, x5
+    %swap_mstore
+    // stack:               x1, x2, x3, addr, x5
+    DUP4
     %add_const(1)
-    // stack:         ind1, x1, x2, x3, ptr, x5
-    %mstore_bn254_pairing
-    // stack:                   x2, x3, ptr, x5
-    DUP3  
+    // stack:         addr1, x1, x2, x3, addr, x5
+    %swap_mstore
+    // stack:                   x2, x3, addr, x5
+    DUP3
     %add_const(2)
-    // stack:             ind2, x2, x3, ptr, x5
-    %mstore_bn254_pairing
-    // stack:                       x3, ptr, x5
-    DUP2  
+    // stack:             addr2, x2, x3, addr, x5
+    %swap_mstore
+    // stack:                       x3, addr, x5
+    DUP2
     %add_const(3)
-    // stack:                 ind3, x3, ptr, x5
-    %mstore_bn254_pairing
-    // stack:                           ptr, x5
+    // stack:                 addr3, x3, addr, x5
+    %swap_mstore
+    // stack:                           addr, x5
     %add_const(5)
-    // stack:                          ind5, x5
-    %mstore_bn254_pairing
+    // stack:                          addr5, x5
+    %swap_mstore
     // stack:
 %endmacro
 
-// cost: 6 stores + 7 swaps/dups + 5 adds + 6 doubles = 6*4 + 7*1 + 5*2 + 6*2 = 53
 %macro store_fp254_6_double
     // stack:        ptr, x0, x1, x2, x3, x4, x5
+    %create_bn254_pairing_address
     SWAP6
-    // stack:         x5, x0, x1, x2, x3, x4, ptr
-    PUSH 2  
+    // stack:         x5, x0, x1, x2, x3, x4, addr
+    PUSH 2
     MULFP254
-    // stack:       2*x5, x0, x1, x2, x3, x4, ptr
-    DUP7  
+    // stack:       2*x5, x0, x1, x2, x3, x4, addr
+    DUP7
     %add_const(5)
-    // stack: ind5, 2*x5, x0, x1, x2, x3, x4, ptr
-    %mstore_bn254_pairing
-    // stack:             x0, x1, x2, x3, x4, ptr
-    PUSH 2  
+    // stack: addr5, 2*x5, x0, x1, x2, x3, x4, addr
+    %swap_mstore
+    // stack:             x0, x1, x2, x3, x4, addr
+    PUSH 2
     MULFP254
-    // stack:           2*x0, x1, x2, x3, x4, ptr
+    // stack:           2*x0, x1, x2, x3, x4, addr
     DUP6
-    // stack:     ind0, 2*x0, x1, x2, x3, x4, ptr
-    %mstore_bn254_pairing
-    // stack:                 x1, x2, x3, x4, ptr
-    PUSH 2  
+    // stack:     addr0, 2*x0, x1, x2, x3, x4, addr
+    %swap_mstore
+    // stack:                 x1, x2, x3, x4, addr
+    PUSH 2
     MULFP254
-    // stack:               2*x1, x2, x3, x4, ptr
-    DUP5  
+    // stack:               2*x1, x2, x3, x4, addr
+    DUP5
     %add_const(1)
-    // stack:         ind1, 2*x1, x2, x3, x4, ptr
-    %mstore_bn254_pairing
-    // stack:                     x2, x3, x4, ptr
-    PUSH 2  
+    // stack:         addr1, 2*x1, x2, x3, x4, addr
+    %swap_mstore
+    // stack:                     x2, x3, x4, addr
+    PUSH 2
     MULFP254
-    // stack:                   2*x2, x3, x4, ptr
-    DUP4  
+    // stack:                   2*x2, x3, x4, addr
+    DUP4
     %add_const(2)
-    // stack:             ind2, 2*x2, x3, x4, ptr
-    %mstore_bn254_pairing
-    // stack:                         x3, x4, ptr
+    // stack:             addr2, 2*x2, x3, x4, addr
+    %swap_mstore
+    // stack:                         x3, x4, addr
     PUSH 2 
     MULFP254
-    // stack:                       2*x3, x4, ptr
-    DUP3  
+    // stack:                       2*x3, x4, addr
+    DUP3
     %add_const(3)
-    // stack:                 ind3, 2*x3, x4, ptr
-    %mstore_bn254_pairing
-    // stack:                             x4, ptr
-    PUSH 2  
+    // stack:                 addr3, 2*x3, x4, addr
+    %swap_mstore
+    // stack:                             x4, addr
+    PUSH 2
     MULFP254
-    // stack:                           2*x4, ptr
+    // stack:                           2*x4, addr
     SWAP1
-    // stack:                           ptr, 2*x4
+    // stack:                           addr, 2*x4
     %add_const(4)
-    // stack:                          ind4, 2*x4
-    %mstore_bn254_pairing
+    // stack:                          addr4, 2*x4
+    %swap_mstore
     // stack:
 %endmacro
 
-// cost: 6 stores + 6 pushes + 5 adds = 6*4 + 6*1 + 5*2 = 40
 %macro store_fp254_6(ptr)
-    // stack:       x0, x1, x2, x3, x4, x5
+    // stack: x0, x1, x2, x3, x4, x5
     PUSH $ptr
-    // stack: ind0, x0, x1, x2, x3, x4, x5
-    %mstore_bn254_pairing
-    // stack:           x1, x2, x3, x4, x5
-    PUSH $ptr  
-    %add_const(1)
-    // stack:     ind1, x1, x2, x3, x4, x5
-    %mstore_bn254_pairing
-    // stack:               x2, x3, x4, x5
-    PUSH $ptr  
-    %add_const(2)
-    // stack:         ind2, x2, x3, x4, x5
-    %mstore_bn254_pairing
-    // stack:                   x3, x4, x5
-    PUSH $ptr  
-    %add_const(3)
-    // stack:             ind3, x3, x4, x5
-    %mstore_bn254_pairing
-    // stack:                       x4, x5
-    PUSH $ptr  
-    %add_const(4)
-    // stack:                 ind4, x4, x5
-    %mstore_bn254_pairing
-    // stack:                           x5
-    PUSH $ptr  
-    %add_const(5)
-    // stack:                     ind5, x5
-    %mstore_bn254_pairing
+    %store_fp254_6
     // stack:
 %endmacro
 
-// cost: store (40) + i9 (9) = 49
 %macro store_fp254_6_sh(ptr)
     // stack:       x0, x1, x2, x3, x4, x5
-    PUSH $ptr  
+    PUSH $ptr
+    %create_bn254_pairing_address
+    // stack: addr, x0, x1, x2, x3, x4, x5
     %add_const(2)
-    // stack: ind2, x0, x1, x2, x3, x4, x5
-    %mstore_bn254_pairing
-    // stack:           x1, x2, x3, x4, x5
-    PUSH $ptr  
-    %add_const(3)
-    // stack:     ind3, x1, x2, x3, x4, x5
-    %mstore_bn254_pairing
-    // stack:               x2, x3, x4, x5
-    PUSH $ptr  
-    %add_const(4)
-    // stack:         ind4, x2, x3, x4, x5
-    %mstore_bn254_pairing
-    // stack:                   x3, x4, x5
-    PUSH $ptr  
-    %add_const(5)
-    // stack:             ind5, x3, x4, x5
-    %mstore_bn254_pairing
+    DUP1
+    // stack: addr2, addr2, x0, x1, x2, x3, x4, x5
+    SWAP2 MSTORE_GENERAL
+    // stack:    addr2, x1, x2, x3, x4, x5
+    %add_const(1)
+    DUP1
+    // stack: addr3, addr3, x1, x2, x3, x4, x5
+    SWAP2 MSTORE_GENERAL
+    // stack:        addr3, x2, x3, x4, x5
+    %add_const(1)
+    DUP1
+    // stack: addr4, addr4, x2, x3, x4, x5
+    SWAP2 MSTORE_GENERAL
+    // stack:            addr4, x3, x4, x5
+    %add_const(1)
+    // stack:            addr5, x3, x4, x5
+    %swap_mstore
     // stack:                       x4, x5
     %i9
     // stack:                       y5, y4
     PUSH $ptr  
+    %create_bn254_pairing_address
+    DUP1
     %add_const(1)
-    // stack:                 ind1, y5, y4
-    %mstore_bn254_pairing
-    // stack:                           y4
-    PUSH $ptr
-    // stack:                     ind0, y4
-    %mstore_bn254_pairing
+    // stack:          addr1, addr, y5, y4
+    SWAP3
+    MSTORE_GENERAL
+    // stack:                    y5, addr1
+    MSTORE_GENERAL
     // stack:
 %endmacro
 
@@ -575,10 +544,10 @@
     MULFP254
     SWAP3 
     // stack: c , f0,     f1, c * f2, c * f3, c *f 4, c * f5
-    SWAP2  
-    DUP3  
+    SWAP2
+    DUP3
     MULFP254
-    SWAP2  
+    SWAP2
     // stack: c , f0, c * f1, c * f2, c * f3, c * f4, c * f5
     MULFP254
     // stack: c * f0, c * f1, c * f2, c * f3, c * f4, c * f5
@@ -864,264 +833,268 @@
 
 %macro load_fp254_12
     // stack:                                                          ptr
-    DUP1  
+    %create_bn254_pairing_address
+    DUP1
     %add_const(10)
-    // stack:                                                   ind10, ptr
-    %mload_bn254_pairing
-    // stack:                                                     x10, ptr
-    DUP2  
+    // stack:                                                   addr10, addr
+    MLOAD_GENERAL
+    // stack:                                                     x10, addr
+    DUP2
     %add_const(9)
-    // stack:                                              ind09, x10, ptr
-    %mload_bn254_pairing
-    // stack:                                                x09, x10, ptr
-    DUP3  
+    // stack:                                              addr09, x10, addr
+    MLOAD_GENERAL
+    // stack:                                                x09, x10, addr
+    DUP3
     %add_const(8)
-    // stack:                                         ind08, x09, x10, ptr
-    %mload_bn254_pairing
-    // stack:                                           x08, x09, x10, ptr
-    DUP4  
+    // stack:                                         addr08, x09, x10, addr
+    MLOAD_GENERAL
+    // stack:                                           x08, x09, x10, addr
+    DUP4
     %add_const(7)
-    // stack:                                    ind07, x08, x09, x10, ptr
-    %mload_bn254_pairing
-    // stack:                                      x07, x08, x09, x10, ptr
-    DUP5  
+    // stack:                                    addr07, x08, x09, x10, addr
+    MLOAD_GENERAL
+    // stack:                                      x07, x08, x09, x10, addr
+    DUP5
     %add_const(6)
-    // stack:                               ind06, x07, x08, x09, x10, ptr
-    %mload_bn254_pairing
-    // stack:                                 x06, x07, x08, x09, x10, ptr
-    DUP6  
+    // stack:                               addr06, x07, x08, x09, x10, addr
+    MLOAD_GENERAL
+    // stack:                                 x06, x07, x08, x09, x10, addr
+    DUP6
     %add_const(5)
-    // stack:                          ind05, x06, x07, x08, x09, x10, ptr
-    %mload_bn254_pairing
-    // stack:                            x05, x06, x07, x08, x09, x10, ptr
-    DUP7  
+    // stack:                          addr05, x06, x07, x08, x09, x10, addr
+    MLOAD_GENERAL
+    // stack:                            x05, x06, x07, x08, x09, x10, addr
+    DUP7
     %add_const(4)
-    // stack:                     ind04, x05, x06, x07, x08, x09, x10, ptr
-    %mload_bn254_pairing
-    // stack:                       x04, x05, x06, x07, x08, x09, x10, ptr
-    DUP8  
+    // stack:                     addr04, x05, x06, x07, x08, x09, x10, addr
+    MLOAD_GENERAL
+    // stack:                       x04, x05, x06, x07, x08, x09, x10, addr
+    DUP8
     %add_const(3)
-    // stack:                ind03, x04, x05, x06, x07, x08, x09, x10, ptr
-    %mload_bn254_pairing
-    // stack:                  x03, x04, x05, x06, x07, x08, x09, x10, ptr
-    DUP9  
+    // stack:                addr03, x04, x05, x06, x07, x08, x09, x10, addr
+    MLOAD_GENERAL
+    // stack:                  x03, x04, x05, x06, x07, x08, x09, x10, addr
+    DUP9
     %add_const(2)
-    // stack:           ind02, x03, x04, x05, x06, x07, x08, x09, x10, ptr
-    %mload_bn254_pairing
-    // stack:             x02, x03, x04, x05, x06, x07, x08, x09, x10, ptr
-    DUP10  
+    // stack:           addr02, x03, x04, x05, x06, x07, x08, x09, x10, addr
+    MLOAD_GENERAL
+    // stack:             x02, x03, x04, x05, x06, x07, x08, x09, x10, addr
+    DUP10
     %add_const(1)
-    // stack:      ind01, x02, x03, x04, x05, x06, x07, x08, x09, x10, ptr
-    %mload_bn254_pairing
-    // stack:        x01, x02, x03, x04, x05, x06, x07, x08, x09, x10, ptr
-    DUP11  
+    // stack:      addr01, x02, x03, x04, x05, x06, x07, x08, x09, x10, addr
+    MLOAD_GENERAL
+    // stack:        x01, x02, x03, x04, x05, x06, x07, x08, x09, x10, addr
+    DUP11
     %add_const(11)
-    // stack: ind11, x01, x02, x03, x04, x05, x06, x07, x08, x09, x10, ptr
-    %mload_bn254_pairing
-    // stack:   x11, x01, x02, x03, x04, x05, x06, x07, x08, x09, x10, ptr
+    // stack: addr11, x01, x02, x03, x04, x05, x06, x07, x08, x09, x10, addr
+    MLOAD_GENERAL
+    // stack:   x11, x01, x02, x03, x04, x05, x06, x07, x08, x09, x10, addr
     SWAP11
-    // stack: ind00, x01, x02, x03, x04, x05, x06, x07, x08, x09, x10, x11
-    %mload_bn254_pairing
+    // stack: addr00, x01, x02, x03, x04, x05, x06, x07, x08, x09, x10, x11
+    MLOAD_GENERAL
     // stack:   x00, x01, x02, x03, x04, x05, x06, x07, x08, x09, x10, x11
 %endmacro
 
 %macro store_fp254_12
     // stack:        ptr, x00, x01, x02, x03, x04, x05, x06, x07, x08, x09, x10, x11
+    %create_bn254_pairing_address
     SWAP11
-    // stack:        x10, x00, x01, x02, x03, x04, x05, x06, x07, x08, x09, ptr, x11
-    DUP12  
+    // stack:        x10, x00, x01, x02, x03, x04, x05, x06, x07, x08, x09, addr, x11
+    DUP12
     %add_const(10)
-    // stack: ind10, x10, x00, x01, x02, x03, x04, x05, x06, x07, x08, x09, ptr, x11
-    %mstore_bn254_pairing
-    // stack:             x00, x01, x02, x03, x04, x05, x06, x07, x08, x09, ptr, x11
+    // stack: addr10, x10, x00, x01, x02, x03, x04, x05, x06, x07, x08, x09, addr, x11
+    %swap_mstore
+    // stack:             x00, x01, x02, x03, x04, x05, x06, x07, x08, x09, addr, x11
     DUP11
-    // stack:      ind00, x00, x01, x02, x03, x04, x05, x06, x07, x08, x09, ptr, x11
-    %mstore_bn254_pairing
-    // stack:                  x01, x02, x03, x04, x05, x06, x07, x08, x09, ptr, x11
-    DUP10  
+    // stack:      addr00, x00, x01, x02, x03, x04, x05, x06, x07, x08, x09, addr, x11
+    %swap_mstore
+    // stack:                  x01, x02, x03, x04, x05, x06, x07, x08, x09, addr, x11
+    DUP10
     %add_const(01)
-    // stack:           ind01, x01, x02, x03, x04, x05, x06, x07, x08, x09, ptr, x11
-    %mstore_bn254_pairing
-    // stack:                       x02, x03, x04, x05, x06, x07, x08, x09, ptr, x11
+    // stack:           addr01, x01, x02, x03, x04, x05, x06, x07, x08, x09, addr, x11
+    %swap_mstore
+    // stack:                       x02, x03, x04, x05, x06, x07, x08, x09, addr, x11
     DUP9   
     %add_const(02)
-    // stack:                ind02, x02, x03, x04, x05, x06, x07, x08, x09, ptr, x11
-    %mstore_bn254_pairing
-    // stack:                            x03, x04, x05, x06, x07, x08, x09, ptr, x11
+    // stack:                addr02, x02, x03, x04, x05, x06, x07, x08, x09, addr, x11
+    %swap_mstore
+    // stack:                            x03, x04, x05, x06, x07, x08, x09, addr, x11
     DUP8   
     %add_const(03)
-    // stack:                     ind03, x03, x04, x05, x06, x07, x08, x09, ptr, x11
-    %mstore_bn254_pairing
-    // stack:                                 x04, x05, x06, x07, x08, x09, ptr, x11
+    // stack:                     addr03, x03, x04, x05, x06, x07, x08, x09, addr, x11
+    %swap_mstore
+    // stack:                                 x04, x05, x06, x07, x08, x09, addr, x11
     DUP7   
     %add_const(04)
-    // stack:                          ind04, x04, x05, x06, x07, x08, x09, ptr, x11
-    %mstore_bn254_pairing
-    // stack:                                      x05, x06, x07, x08, x09, ptr, x11
+    // stack:                          addr04, x04, x05, x06, x07, x08, x09, addr, x11
+    %swap_mstore
+    // stack:                                      x05, x06, x07, x08, x09, addr, x11
     DUP6   
     %add_const(05)
-    // stack:                               ind05, x05, x06, x07, x08, x09, ptr, x11
-    %mstore_bn254_pairing
-    // stack:                                           x06, x07, x08, x09, ptr, x11
+    // stack:                               addr05, x05, x06, x07, x08, x09, addr, x11
+    %swap_mstore
+    // stack:                                           x06, x07, x08, x09, addr, x11
     DUP5   
     %add_const(06)
-    // stack:                                    ind06, x06, x07, x08, x09, ptr, x11
-    %mstore_bn254_pairing
-    // stack:                                                x07, x08, x09, ptr, x11
+    // stack:                                    addr06, x06, x07, x08, x09, addr, x11
+    %swap_mstore
+    // stack:                                                x07, x08, x09, addr, x11
     DUP4   
     %add_const(07)
-    // stack:                                         ind07, x07, x08, x09, ptr, x11
-    %mstore_bn254_pairing
-    // stack:                                                     x08, x09, ptr, x11
+    // stack:                                         addr07, x07, x08, x09, addr, x11
+    %swap_mstore
+    // stack:                                                     x08, x09, addr, x11
     DUP3   
     %add_const(08)
-    // stack:                                              ind08, x08, x09, ptr, x11
-    %mstore_bn254_pairing
-    // stack:                                                          x09, ptr, x11
+    // stack:                                              addr08, x08, x09, addr, x11
+    %swap_mstore
+    // stack:                                                          x09, addr, x11
     DUP2   
     %add_const(09)
-    // stack:                                                   ind09, x09, ptr, x11
-    %mstore_bn254_pairing
-    // stack:                                                               ptr, x11
+    // stack:                                                   addr09, x09, addr, x11
+    %swap_mstore
+    // stack:                                                               addr, x11
     %add_const(11)
-    // stack:                                                             ind11, x11
-    %mstore_bn254_pairing
+    // stack:                                                             addr11, x11
+    %swap_mstore
     // stack:                                                            
 %endmacro
 
 /// moves fp254_12 from src..src+12 to dest..dest+12
-/// these should not overlap. leaves dest on stack
+/// these should not overlap. leaves scaled DEST on stack
 %macro move_fp254_12
     // stack:              src, dest
-    DUP1  
-    // stack:       ind00, src, dest
-    %mload_bn254_pairing
-    // stack:         x00, src, dest
+    PUSH @SEGMENT_BN_PAIRING
+    GET_CONTEXT
+    %build_address_no_offset
+    DUP1
+    // stack: base_addr, base_addr, src, dest
+    SWAP3 ADD
+    // stack: DEST, src, base_addr
+    SWAP2 ADD
+    // stack:              SRC, DEST
+    DUP1
+    // stack:       addr00, SRC, DEST
+    MLOAD_GENERAL
+    // stack:         x00, SRC, DEST
     DUP3
-    // stack: ind00', x00, src, dest
-    %mstore_bn254_pairing
-    // stack:              src, dest
-    DUP1  
+    // stack: addr00', x00, SRC, DEST
+    %swap_mstore
+    // stack:              SRC, DEST
+    DUP1
     %add_const(1)
-    // stack:       ind01, src, dest
-    %mload_bn254_pairing
-    // stack:         x01, src, dest
-    DUP3  
+    // stack:       addr01, SRC, DEST
+    MLOAD_GENERAL
+    // stack:         x01, SRC, DEST
+    DUP3
     %add_const(1)
-    // stack: ind01', x01, src, dest
-    %mstore_bn254_pairing
-    // stack:              src, dest
-    DUP1  
+    // stack: addr01', x01, SRC, DEST
+    %swap_mstore
+    // stack:              SRC, DEST
+    DUP1
     %add_const(2)
-    // stack:       ind02, src, dest
-    %mload_bn254_pairing
-    // stack:         x02, src, dest
-    DUP3  
+    // stack:       addr02, SRC, DEST
+    MLOAD_GENERAL
+    // stack:         x02, SRC, DEST
+    DUP3
     %add_const(2)
-    // stack: ind02', x02, src, dest
-    %mstore_bn254_pairing
-    // stack:              src, dest
-    DUP1  
+    // stack: addr02', x02, SRC, DEST
+    %swap_mstore
+    // stack:              SRC, DEST
+    DUP1
     %add_const(3)
-    // stack:       ind03, src, dest
-    %mload_bn254_pairing
-    // stack:         x03, src, dest
-    DUP3  
+    // stack:       addr03, SRC, DEST
+    MLOAD_GENERAL
+    // stack:         x03, SRC, DEST
+    DUP3
     %add_const(3)
-    // stack: ind03', x03, src, dest
-    %mstore_bn254_pairing
-    // stack:              src, dest
-    DUP1  
+    // stack: addr03', x03, SRC, DEST
+    %swap_mstore
+    // stack:              SRC, DEST
+    DUP1
     %add_const(4)
-    // stack:       ind04, src, dest
-    %mload_bn254_pairing
-    // stack:         x04, src, dest
+    // stack:       addr04, SRC, DEST
+    MLOAD_GENERAL
+    // stack:         x04, SRC, DEST
     DUP3 
     %add_const(4)
-    // stack: ind04', x04, src, dest
-    %mstore_bn254_pairing
-    // stack:              src, dest
-    DUP1  
+    // stack: addr04', x04, SRC, DEST
+    %swap_mstore
+    // stack:              SRC, DEST
+    DUP1
     %add_const(5)
-    // stack:       ind05, src, dest
-    %mload_bn254_pairing
-    // stack:         x05, src, dest
-    DUP3  
+    // stack:       addr05, SRC, DEST
+    MLOAD_GENERAL
+    // stack:         x05, SRC, DEST
+    DUP3
     %add_const(5)
-    // stack: ind05', x05, src, dest
-    %mstore_bn254_pairing
-    // stack:              src, dest
-    DUP1  
+    // stack: addr05', x05, SRC, DEST
+    %swap_mstore
+    // stack:              SRC, DEST
+    DUP1
     %add_const(6)
-    // stack:       ind06, src, dest
-    %mload_bn254_pairing
-    // stack:         x06, src, dest
-    DUP3  
+    // stack:       addr06, SRC, DEST
+    MLOAD_GENERAL
+    // stack:         x06, SRC, DEST
+    DUP3
     %add_const(6)
-    // stack: ind06', x06, src, dest
-    %mstore_bn254_pairing
-    // stack:              src, dest
-    DUP1  
+    // stack: addr06', x06, SRC, DEST
+    %swap_mstore
+    // stack:              SRC, DEST
+    DUP1
     %add_const(7)
-    // stack:       ind07, src, dest
-    %mload_bn254_pairing
-    // stack:         x07, src, dest
-    DUP3  
+    // stack:       addr07, SRC, DEST
+    MLOAD_GENERAL
+    // stack:         x07, SRC, DEST
+    DUP3
     %add_const(7)
-    // stack: ind07', x07, src, dest
-    %mstore_bn254_pairing
-    // stack:              src, dest
-    DUP1  
+    // stack: addr07', x07, SRC, DEST
+    %swap_mstore
+    // stack:              SRC, DEST
+    DUP1
     %add_const(8)
-    // stack:       ind08, src, dest
-    %mload_bn254_pairing
-    // stack:         x08, src, dest
-    DUP3  
+    // stack:       addr08, SRC, DEST
+    MLOAD_GENERAL
+    // stack:         x08, SRC, DEST
+    DUP3
     %add_const(8)
-    // stack: ind08', x08, src, dest
-    %mstore_bn254_pairing
-    // stack:              src, dest
+    // stack: addr08', x08, SRC, DEST
+    %swap_mstore
+    // stack:              SRC, DEST
     DUP1 
     %add_const(9)
-    // stack:       ind09, src, dest
-    %mload_bn254_pairing
-    // stack:         x09, src, dest
-    DUP3  
+    // stack:       addr09, SRC, DEST
+    MLOAD_GENERAL
+    // stack:         x09, SRC, DEST
+    DUP3
     %add_const(9)
-    // stack: ind09', x09, src, dest
-    %mstore_bn254_pairing
-    // stack:              src, dest
-    DUP1  
+    // stack: addr09', x09, SRC, DEST
+    %swap_mstore
+    // stack:              SRC, DEST
+    DUP1
     %add_const(10)
-    // stack:       ind10, src, dest
-    %mload_bn254_pairing
-    // stack:         x10, src, dest
-    DUP3  
+    // stack:       addr10, SRC, DEST
+    MLOAD_GENERAL
+    // stack:         x10, SRC, DEST
+    DUP3
     %add_const(10)
-    // stack: ind10', x10, src, dest
-    %mstore_bn254_pairing
-    // stack:              src, dest
+    // stack: addr10', x10, SRC, DEST
+    %swap_mstore
+    // stack:              SRC, DEST
     %add_const(11)
-    // stack:            ind11, dest
-    %mload_bn254_pairing
-    // stack:              x11, dest
-    DUP2  
+    // stack:            addr11, DEST
+    MLOAD_GENERAL
+    // stack:              x11, DEST
+    DUP2
     %add_const(11)
-    // stack:      ind11', x11, dest
-    %mstore_bn254_pairing
+    // stack:      addr11', x11, DEST
+    %swap_mstore
 %endmacro
 
 %macro assert_eq_unit_fp254_12
     %assert_eq_const(1)
-    %assert_zero
-    %assert_zero
-    %assert_zero
-    %assert_zero
-    %assert_zero
-    %assert_zero
-    %assert_zero
-    %assert_zero
-    %assert_zero
-    %assert_zero
+    %rep 10
+        OR
+    %endrep
     %assert_zero
 %endmacro

--- a/evm/src/cpu/kernel/asm/hash/blake2/addresses.asm
+++ b/evm/src/cpu/kernel/asm/hash/blake2/addresses.asm
@@ -2,11 +2,7 @@
 // It is ready to be used, i.e. already containing the current context
 // and SEGMENT_KERNEL_GENERAL.
 %macro blake2_hash_value_addr
-    PUSH @SEGMENT_KERNEL_GENERAL
-    // stack: segment
-    GET_CONTEXT
-    // stack: context, segment
-    %build_address_no_offset
+    %build_current_general_address_no_offset
     DUP1
     MLOAD_GENERAL
     // stack: num_blocks, addr

--- a/evm/src/cpu/kernel/asm/hash/sha2/compression.asm
+++ b/evm/src/cpu/kernel/asm/hash/sha2/compression.asm
@@ -4,9 +4,7 @@
     // stack: num_blocks
     %mul_const(320)
     %add_const(2)
-    PUSH @SEGMENT_KERNEL_GENERAL
-    GET_CONTEXT
-    %build_address
+    %build_current_general_address
 %endmacro
 
 global sha2_compression:

--- a/evm/src/cpu/kernel/asm/hash/sha2/main.asm
+++ b/evm/src/cpu/kernel/asm/hash/sha2/main.asm
@@ -1,8 +1,6 @@
 global sha2:
     // stack: virt, num_bytes, retdest
-    PUSH @SEGMENT_KERNEL_GENERAL
-    GET_CONTEXT
-    %build_address
+    %build_current_general_address
     // stack: addr, num_bytes, retdest
     DUP1 SWAP2
     // stack: num_bytes, addr, addr, retdest

--- a/evm/src/cpu/kernel/asm/hash/sha2/message_schedule.asm
+++ b/evm/src/cpu/kernel/asm/hash/sha2/message_schedule.asm
@@ -3,9 +3,7 @@
     // stack: num_blocks
     %mul_const(64)
     %add_const(2)
-    PUSH @SEGMENT_KERNEL_GENERAL
-    GET_CONTEXT
-    %build_address
+    %build_current_general_address
 %endmacro
 
 // Precondition: stack contains address of one message block, followed by output address
@@ -188,9 +186,7 @@ global sha2_gen_all_message_schedules:
     // stack: num_blocks, output_addr, output_addr, retdest
     PUSH 1
     // stack: cur_offset = 1, counter = num_blocks, output_addr, output_addr, retdest
-    PUSH @SEGMENT_KERNEL_GENERAL
-    GET_CONTEXT
-    %build_address
+    %build_current_general_address
     // stack: cur_addr, counter, output_addr, output_addr, retdest
 gen_all_message_schedules_loop:
     // stack: cur_addr, counter, cur_output_addr, output_addr, retdest

--- a/evm/src/cpu/kernel/asm/hash/sha2/write_length.asm
+++ b/evm/src/cpu/kernel/asm/hash/sha2/write_length.asm
@@ -1,8 +1,6 @@
 %macro sha2_write_length
     // stack: last_addr_offset, length
-    PUSH @SEGMENT_KERNEL_GENERAL
-    GET_CONTEXT
-    %build_address
+    %build_current_general_address
     SWAP1
     // stack: length, last_addr
     DUP1

--- a/evm/src/cpu/kernel/asm/memory/core.asm
+++ b/evm/src/cpu/kernel/asm/memory/core.asm
@@ -127,9 +127,7 @@
 // Load a single value from the kernel general memory, in the current context (not the kernel's context).
 %macro mload_current_general_no_offset
     // stack:
-    PUSH @SEGMENT_KERNEL_GENERAL
-    GET_CONTEXT
-    %build_address_no_offset
+    %build_current_general_address_no_offset
     MLOAD_GENERAL
     // stack: value
 %endmacro
@@ -137,11 +135,7 @@
 // Load a big-endian u32 from kernel general memory in the current context.
 %macro mload_current_general_u32
     // stack: offset
-    PUSH @SEGMENT_KERNEL_GENERAL
-    // stack: segment, offset
-    GET_CONTEXT
-    // stack: context, segment, offset
-    %build_address
+    %build_current_general_address
     %mload_u32
     // stack: value
 %endmacro
@@ -149,11 +143,7 @@
 // Load a little-endian u32 from kernel general memory in the current context.
 %macro mload_current_general_u32_LE
     // stack: offset
-    PUSH @SEGMENT_KERNEL_GENERAL
-    // stack: segment, offset
-    GET_CONTEXT
-    // stack: context, segment, offset
-    %build_address
+    %build_current_general_address
     %mload_u32_LE
     // stack: value
 %endmacro
@@ -161,11 +151,7 @@
 // Load a little-endian u64 from kernel general memory in the current context.
 %macro mload_current_general_u64_LE
     // stack: offset
-    PUSH @SEGMENT_KERNEL_GENERAL
-    // stack: segment, offset
-    GET_CONTEXT
-    // stack: context, segment, offset
-    %build_address
+    %build_current_general_address
     %mload_u64_LE
     // stack: value
 %endmacro
@@ -173,11 +159,7 @@
 // Load a u256 from kernel general memory in the current context.
 %macro mload_current_general_u256
     // stack: offset
-    PUSH @SEGMENT_KERNEL_GENERAL
-    // stack: segment, offset
-    GET_CONTEXT
-    // stack: context, segment, offset
-    %build_address
+    %build_current_general_address
     %mload_u256
     // stack: value
 %endmacro
@@ -185,11 +167,7 @@
 // Store a single value to kernel general memory in the current context.
 %macro mstore_current_general
     // stack: offset, value
-    PUSH @SEGMENT_KERNEL_GENERAL
-    // stack: segment, offset, value
-    GET_CONTEXT
-    // stack: context, segment, offset, value
-    %build_address
+    %build_current_general_address
     SWAP1
     MSTORE_GENERAL
     // stack: (empty)
@@ -198,11 +176,7 @@
 // Store a single value to kernel general memory in the current context.
 %macro mstore_current_general_no_offset
     // stack: value
-    PUSH @SEGMENT_KERNEL_GENERAL
-    // stack: segment, value
-    GET_CONTEXT
-    // stack: context, segment, value
-    %build_address_no_offset
+    %build_current_general_address_no_offset
     SWAP1
     MSTORE_GENERAL
     // stack: (empty)
@@ -219,11 +193,7 @@
 // Store a big-endian u32 to kernel general memory in the current context.
 %macro mstore_current_general_u32
     // stack: offset, value
-    PUSH @SEGMENT_KERNEL_GENERAL
-    // stack: segment, offset, value
-    GET_CONTEXT
-    // stack: context, segment, offset, value
-    %build_address
+    %build_current_general_address
     %mstore_u32
     // stack: (empty)
 %endmacro

--- a/evm/src/cpu/kernel/asm/util/basic_macros.asm
+++ b/evm/src/cpu/kernel/asm/util/basic_macros.asm
@@ -440,6 +440,22 @@
     // stack: addr
 %endmacro
 
+%macro build_current_general_address
+    // stack: offset
+    PUSH @SEGMENT_KERNEL_GENERAL
+    GET_CONTEXT
+    %build_address
+    // stack: addr
+%endmacro
+
+%macro build_current_general_address_no_offset
+    // stack:
+    PUSH @SEGMENT_KERNEL_GENERAL
+    GET_CONTEXT
+    %build_address_no_offset
+    // stack: addr (offset == 0)
+%endmacro
+
 %macro build_kernel_address
     // stack: seg, off
     ADD

--- a/evm/src/cpu/kernel/interpreter.rs
+++ b/evm/src/cpu/kernel/interpreter.rs
@@ -566,6 +566,14 @@ impl<'a> Interpreter<'a> {
                 .contexts
                 .push(MemoryContextState::default());
         }
+        self.generation_state.memory.set(
+            MemoryAddress::new(
+                context,
+                Segment::ContextMetadata,
+                ContextMetadata::CodeSize.unscale(),
+            ),
+            code.len().into(),
+        );
         self.generation_state.memory.contexts[context].segments[Segment::Code.unscale()].content =
             code.into_iter().map(U256::from).collect();
     }
@@ -584,20 +592,8 @@ impl<'a> Interpreter<'a> {
             .collect()
     }
 
-    pub(crate) fn set_jumpdest_bits(&mut self, context: usize, jumpdest_bits: Vec<bool>) {
-        self.generation_state.memory.contexts[context].segments[Segment::JumpdestBits.unscale()]
-            .content = jumpdest_bits.iter().map(|&x| u256_from_bool(x)).collect();
-        self.generation_state
-            .set_proofs_and_jumpdests(HashMap::from([(
-                context,
-                BTreeSet::from_iter(
-                    jumpdest_bits
-                        .into_iter()
-                        .enumerate()
-                        .filter(|&(_, x)| x)
-                        .map(|(i, _)| i),
-                ),
-            )]));
+    pub(crate) fn set_jumpdest_analysis_inputs(&mut self, jumps: HashMap<usize, BTreeSet<usize>>) {
+        self.generation_state.set_jumpdest_analysis_inputs(jumps);
     }
 
     pub(crate) fn incr(&mut self, n: usize) {

--- a/evm/src/cpu/kernel/tests/core/jumpdest_analysis.rs
+++ b/evm/src/cpu/kernel/tests/core/jumpdest_analysis.rs
@@ -1,3 +1,5 @@
+use std::collections::{BTreeSet, HashMap};
+
 use anyhow::Result;
 use ethereum_types::U256;
 
@@ -37,10 +39,84 @@ fn test_jumpdest_analysis() -> Result<()> {
     ];
     let mut interpreter = Interpreter::new_with_kernel(jumpdest_analysis, initial_stack);
     interpreter.set_code(CONTEXT, code);
-    interpreter.set_jumpdest_bits(CONTEXT, jumpdest_bits);
+    interpreter.set_jumpdest_analysis_inputs(HashMap::from([(
+        3,
+        BTreeSet::from_iter(
+            jumpdest_bits
+                .iter()
+                .enumerate()
+                .filter(|&(_, &x)| x)
+                .map(|(i, _)| i),
+        ),
+    )]));
+
+    assert_eq!(
+        interpreter.generation_state.jumpdest_table,
+        // Context 3 has jumpdest 1, 5, 7. All have proof 0 and hence
+        // the list [proof_0, jumpdest_0, ... ] is [0, 1, 0, 5, 0, 7]
+        Some(HashMap::from([(3, vec![0, 1, 0, 5, 0, 7])]))
+    );
 
     interpreter.run()?;
     assert_eq!(interpreter.stack(), vec![]);
+
+    assert_eq!(jumpdest_bits, interpreter.get_jumpdest_bits(3));
+
+    Ok(())
+}
+
+#[test]
+fn test_packed_verification() -> Result<()> {
+    let jumpdest_analysis = KERNEL.global_labels["jumpdest_analysis"];
+    const CONTEXT: usize = 3; // arbitrary
+
+    let add = get_opcode("ADD");
+    let jumpdest = get_opcode("JUMPDEST");
+
+    // The last push(i=0) is 0x5f which is not a valid opcode. However, this
+    // is still meaningful for the test and makes things easier
+    let mut code: Vec<u8> = std::iter::once(add)
+        .chain(
+            (0..=31)
+                .rev()
+                .map(get_push_opcode)
+                .chain(std::iter::once(jumpdest)),
+        )
+        .collect();
+
+    let jumpdest_bits: Vec<bool> = std::iter::repeat(false)
+        .take(33)
+        .chain(std::iter::once(true))
+        .collect();
+
+    // Contract creation transaction.
+    let initial_stack = vec![
+        0xDEADBEEFu32.into(),
+        code.len().into(),
+        U256::from(CONTEXT) << CONTEXT_SCALING_FACTOR,
+    ];
+    let mut interpreter = Interpreter::new_with_kernel(jumpdest_analysis, initial_stack.clone());
+    interpreter.set_code(CONTEXT, code.clone());
+    interpreter.generation_state.jumpdest_table = Some(HashMap::from([(3, vec![1, 33])]));
+
+    interpreter.run()?;
+
+    assert_eq!(jumpdest_bits, interpreter.get_jumpdest_bits(CONTEXT));
+
+    // If we add 1 to each opcode the jumpdest at position 32 is never a valid jumpdest
+    for i in 1..=32 {
+        code[i] += 1;
+        let mut interpreter =
+            Interpreter::new_with_kernel(jumpdest_analysis, initial_stack.clone());
+        interpreter.set_code(CONTEXT, code.clone());
+        interpreter.generation_state.jumpdest_table = Some(HashMap::from([(3, vec![1, 33])]));
+
+        interpreter.run()?;
+
+        assert!(interpreter.get_jumpdest_bits(CONTEXT).is_empty());
+
+        code[i] -= 1;
+    }
 
     Ok(())
 }

--- a/evm/src/generation/mod.rs
+++ b/evm/src/generation/mod.rs
@@ -348,7 +348,7 @@ fn simulate_cpu_between_labels_and_get_user_jumps<F: Field>(
     final_label: &str,
     state: &mut GenerationState<F>,
 ) -> Option<HashMap<usize, BTreeSet<usize>>> {
-    if state.jumpdest_proofs.is_some() {
+    if state.jumpdest_table.is_some() {
         None
     } else {
         const JUMP_OPCODE: u8 = 0x56;

--- a/evm/src/generation/prover_input.rs
+++ b/evm/src/generation/prover_input.rs
@@ -169,10 +169,10 @@ impl<F: Field> GenerationState<F> {
     // Subsequent calls return one limb at a time, in order (first remainder and then quotient).
     fn run_bignum_modmul(&mut self) -> Result<U256, ProgramError> {
         if self.bignum_modmul_result_limbs.is_empty() {
-            let len = stack_peek(self, 1).map(u256_to_usize)??;
-            let a_start_loc = stack_peek(self, 2).map(u256_to_usize)??;
-            let b_start_loc = stack_peek(self, 3).map(u256_to_usize)??;
-            let m_start_loc = stack_peek(self, 4).map(u256_to_usize)??;
+            let len = stack_peek(self, 2).map(u256_to_usize)??;
+            let a_start_loc = stack_peek(self, 3).map(u256_to_usize)??;
+            let b_start_loc = stack_peek(self, 4).map(u256_to_usize)??;
+            let m_start_loc = stack_peek(self, 5).map(u256_to_usize)??;
 
             let (remainder, quotient) =
                 self.bignum_modmul(len, a_start_loc, b_start_loc, m_start_loc);

--- a/evm/src/generation/prover_input.rs
+++ b/evm/src/generation/prover_input.rs
@@ -1,5 +1,5 @@
 use std::cmp::min;
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 use std::mem::transmute;
 use std::str::FromStr;
 
@@ -251,38 +251,39 @@ impl<F: Field> GenerationState<F> {
 
     /// Returns the next used jump address.
     fn run_next_jumpdest_table_address(&mut self) -> Result<U256, ProgramError> {
-        let context = self.registers.context;
-        let code_len = u256_to_usize(self.get_code_len()?.into());
+        let context = u256_to_usize(stack_peek(self, 0)? >> CONTEXT_SCALING_FACTOR)?;
+        let code_len = u256_to_usize(self.get_current_code_len()?.into());
 
-        if self.jumpdest_proofs.is_none() {
-            self.generate_jumpdest_proofs()?;
+        if self.jumpdest_table.is_none() {
+            self.generate_jumpdest_table()?;
         }
 
-        let Some(jumpdest_proofs) = &mut self.jumpdest_proofs else {
+        let Some(jumpdest_table) = &mut self.jumpdest_table else {
             return Err(ProgramError::ProverInputError(
                 ProverInputError::InvalidJumpdestSimulation,
             ));
         };
 
-        if let Some(ctx_jumpdest_proofs) = jumpdest_proofs.get_mut(&self.registers.context)
-            && let Some(next_jumpdest_address) = ctx_jumpdest_proofs.pop()
+        if let Some(ctx_jumpdest_table) = jumpdest_table.get_mut(&context)
+            && let Some(next_jumpdest_address) = ctx_jumpdest_table.pop()
         {
             Ok((next_jumpdest_address + 1).into())
         } else {
-            self.jumpdest_proofs = None;
+            self.jumpdest_table = None;
             Ok(U256::zero())
         }
     }
 
     /// Returns the proof for the last jump address.
     fn run_next_jumpdest_table_proof(&mut self) -> Result<U256, ProgramError> {
-        let Some(jumpdest_proofs) = &mut self.jumpdest_proofs else {
+        let context = u256_to_usize(stack_peek(self, 1)? >> CONTEXT_SCALING_FACTOR)?;
+        let Some(jumpdest_table) = &mut self.jumpdest_table else {
             return Err(ProgramError::ProverInputError(
                 ProverInputError::InvalidJumpdestSimulation,
             ));
         };
-        if let Some(ctx_jumpdest_proofs) = jumpdest_proofs.get_mut(&self.registers.context)
-            && let Some(next_jumpdest_proof) = ctx_jumpdest_proofs.pop()
+        if let Some(ctx_jumpdest_table) = jumpdest_table.get_mut(&context)
+            && let Some(next_jumpdest_proof) = ctx_jumpdest_table.pop()
         {
             Ok(next_jumpdest_proof.into())
         } else {
@@ -295,7 +296,7 @@ impl<F: Field> GenerationState<F> {
 
 impl<F: Field> GenerationState<F> {
     /// Simulate the user's code and store all the jump addresses with their respective contexts.
-    fn generate_jumpdest_proofs(&mut self) -> Result<(), ProgramError> {
+    fn generate_jumpdest_table(&mut self) -> Result<(), ProgramError> {
         let checkpoint = self.checkpoint();
         let memory = self.memory.clone();
 
@@ -309,7 +310,7 @@ impl<F: Field> GenerationState<F> {
             "terminate_common",
             self,
         ) else {
-            self.jumpdest_proofs = Some(HashMap::new());
+            self.jumpdest_table = Some(HashMap::new());
             return Ok(());
         };
 
@@ -318,18 +319,18 @@ impl<F: Field> GenerationState<F> {
         self.memory = memory;
 
         // Find proofs for all contexts
-        self.set_proofs_and_jumpdests(jumpdest_table);
+        self.set_jumpdest_analysis_inputs(jumpdest_table);
 
         Ok(())
     }
 
     /// Given a HashMap containing the contexts and the jumpdest addresses, compute their respective proofs,
     /// by calling `get_proofs_and_jumpdests`
-    pub(crate) fn set_proofs_and_jumpdests(
+    pub(crate) fn set_jumpdest_analysis_inputs(
         &mut self,
-        jumpdest_table: HashMap<usize, std::collections::BTreeSet<usize>>,
+        jumpdest_table: HashMap<usize, BTreeSet<usize>>,
     ) {
-        self.jumpdest_proofs = Some(HashMap::from_iter(jumpdest_table.into_iter().map(
+        self.jumpdest_table = Some(HashMap::from_iter(jumpdest_table.into_iter().map(
             |(ctx, jumpdest_table)| {
                 let code = self.get_code(ctx).unwrap();
                 if let Some(&largest_address) = jumpdest_table.last() {
@@ -347,26 +348,40 @@ impl<F: Field> GenerationState<F> {
     }
 
     fn get_code(&self, context: usize) -> Result<Vec<u8>, ProgramError> {
-        let code_len = self.get_code_len()?;
+        let code_len = self.get_code_len(context)?;
         let code = (0..code_len)
             .map(|i| {
-                u256_to_u8(self.memory.get(MemoryAddress::new(
-                    self.registers.context,
-                    Segment::Code,
-                    i,
-                )))
+                u256_to_u8(
+                    self.memory
+                        .get(MemoryAddress::new(context, Segment::Code, i)),
+                )
             })
             .collect::<Result<Vec<u8>, _>>()?;
         Ok(code)
     }
 
-    fn get_code_len(&self) -> Result<usize, ProgramError> {
+    fn set_code_len(&mut self, len: usize) {
+        self.memory.set(
+            MemoryAddress::new(
+                self.registers.context,
+                Segment::ContextMetadata,
+                ContextMetadata::CodeSize.unscale(),
+            ),
+            len.into(),
+        )
+    }
+
+    fn get_code_len(&self, context: usize) -> Result<usize, ProgramError> {
         let code_len = u256_to_usize(self.memory.get(MemoryAddress::new(
-            self.registers.context,
+            context,
             Segment::ContextMetadata,
             ContextMetadata::CodeSize.unscale(),
         )))?;
         Ok(code_len)
+    }
+
+    fn get_current_code_len(&self) -> Result<usize, ProgramError> {
+        self.get_code_len(self.registers.context)
     }
 
     fn set_jumpdest_bits(&mut self, code: &[u8]) {

--- a/evm/src/generation/state.rs
+++ b/evm/src/generation/state.rs
@@ -55,7 +55,7 @@ pub(crate) struct GenerationState<F: Field> {
     /// jump destinations with its corresponding "proof". A "proof" for a jump destination is
     /// either 0 or an address i > 32 in the code (not necessarily pointing to an opcode) such that
     /// for every j in [i, i+32] it holds that code[j] < 0x7f - j + i.
-    pub(crate) jumpdest_proofs: Option<HashMap<usize, Vec<usize>>>,
+    pub(crate) jumpdest_table: Option<HashMap<usize, Vec<usize>>>,
 }
 
 impl<F: Field> GenerationState<F> {
@@ -97,7 +97,7 @@ impl<F: Field> GenerationState<F> {
                 txn_root_ptr: 0,
                 receipt_root_ptr: 0,
             },
-            jumpdest_proofs: None,
+            jumpdest_table: None,
         };
         let trie_root_ptrs = state.preinitialize_mpts(&inputs.tries);
 
@@ -189,7 +189,7 @@ impl<F: Field> GenerationState<F> {
                 txn_root_ptr: 0,
                 receipt_root_ptr: 0,
             },
-            jumpdest_proofs: None,
+            jumpdest_table: None,
         }
     }
 }


### PR DESCRIPTION
Brings latest changes from `main` before final freeze of the `audit/rc2` branch.

Includes:
- pairing precompile optimization (#1476 in the continuation of #1477, #1480, #1482)
- fix `jumpdest_analysis` edge case