### PR TITLE
Fix recursive circuit ranges in tests

### DIFF
--- a/evm/tests/log_opcode.rs
+++ b/evm/tests/log_opcode.rs
@@ -442,7 +442,7 @@ fn test_log_with_aggreg() -> anyhow::Result<()> {
     // Preprocess all circuits.
     let all_circuits = AllRecursiveCircuits::<F, C, D>::new(
         &all_stark,
-        &[16..17, 13..16, 15..18, 14..15, 10..11, 12..13, 17..20],
+        &[16..17, 12..15, 14..18, 14..15, 9..10, 12..13, 17..20],
         &config,
     );
 


### PR DESCRIPTION
Lates plonky2 optimizations broke `log_opcode` by requiring smaller circuit sizes than the ones currently specified.