### PR TITLE
Cleanup imports

### DIFF
--- a/evm/src/all_stark.rs
+++ b/evm/src/all_stark.rs
@@ -1,4 +1,4 @@
-use std::iter;
+use core::iter;
 
 use itertools::Itertools;
 use plonky2::field::extension::Extendable;

--- a/evm/src/arithmetic/arithmetic_stark.rs
+++ b/evm/src/arithmetic/arithmetic_stark.rs
@@ -1,5 +1,5 @@
-use std::marker::PhantomData;
-use std::ops::Range;
+use core::marker::PhantomData;
+use core::ops::Range;
 
 use plonky2::field::extension::{Extendable, FieldExtension};
 use plonky2::field::packed::PackedField;

--- a/evm/src/arithmetic/byte.rs
+++ b/evm/src/arithmetic/byte.rs
@@ -60,7 +60,7 @@
 //!    y * 256 ∈ {0, 256, 512, ..., 2^16 - 256}
 //! 8. Hence y ∈ {0, 1, ..., 255}
 
-use std::ops::Range;
+use core::ops::Range;
 
 use ethereum_types::U256;
 use plonky2::field::extension::Extendable;

--- a/evm/src/arithmetic/columns.rs
+++ b/evm/src/arithmetic/columns.rs
@@ -1,6 +1,6 @@
 //! Arithmetic unit
 
-use std::ops::Range;
+use core::ops::Range;
 
 pub(crate) const LIMB_BITS: usize = 16;
 const EVM_REGISTER_BITS: usize = 256;

--- a/evm/src/arithmetic/divmod.rs
+++ b/evm/src/arithmetic/divmod.rs
@@ -2,7 +2,7 @@
 //!
 //! The logic for verifying them is detailed in the `modular` submodule.
 
-use std::ops::Range;
+use core::ops::Range;
 
 use ethereum_types::U256;
 use plonky2::field::extension::Extendable;

--- a/evm/src/arithmetic/modular.rs
+++ b/evm/src/arithmetic/modular.rs
@@ -108,7 +108,7 @@
 //!   only require 96 columns, or 80 if the output doesn't need to be
 //!   reduced.
 
-use std::ops::Range;
+use core::ops::Range;
 
 use ethereum_types::U256;
 use num::bigint::Sign;

--- a/evm/src/arithmetic/utils.rs
+++ b/evm/src/arithmetic/utils.rs
@@ -1,4 +1,4 @@
-use std::ops::{Add, AddAssign, Mul, Neg, Range, Shr, Sub, SubAssign};
+use core::ops::{Add, AddAssign, Mul, Neg, Range, Shr, Sub, SubAssign};
 
 use ethereum_types::U256;
 use plonky2::field::extension::Extendable;

--- a/evm/src/byte_packing/byte_packing_stark.rs
+++ b/evm/src/byte_packing/byte_packing_stark.rs
@@ -25,7 +25,7 @@
 //! This means that the higher-order bytes will be thrown away during the process, if the value
 //! is greater than 256^length, and as a result a different value will be stored in memory.
 
-use std::marker::PhantomData;
+use core::marker::PhantomData;
 
 use itertools::Itertools;
 use plonky2::field::extension::{Extendable, FieldExtension};

--- a/evm/src/constraint_consumer.rs
+++ b/evm/src/constraint_consumer.rs
@@ -1,4 +1,4 @@
-use std::marker::PhantomData;
+use core::marker::PhantomData;
 
 use plonky2::field::extension::Extendable;
 use plonky2::field::packed::PackedField;

--- a/evm/src/cpu/columns/general.rs
+++ b/evm/src/cpu/columns/general.rs
@@ -1,6 +1,6 @@
-use std::borrow::{Borrow, BorrowMut};
-use std::fmt::{Debug, Formatter};
-use std::mem::{size_of, transmute};
+use core::borrow::{Borrow, BorrowMut};
+use core::fmt::{Debug, Formatter};
+use core::mem::{size_of, transmute};
 
 /// General purpose columns, which can have different meanings depending on what CTL or other
 /// operation is occurring at this row.

--- a/evm/src/cpu/columns/mod.rs
+++ b/evm/src/cpu/columns/mod.rs
@@ -1,7 +1,7 @@
-use std::borrow::{Borrow, BorrowMut};
-use std::fmt::Debug;
-use std::mem::{size_of, transmute};
-use std::ops::{Index, IndexMut};
+use core::borrow::{Borrow, BorrowMut};
+use core::fmt::Debug;
+use core::mem::{size_of, transmute};
+use core::ops::{Index, IndexMut};
 
 use plonky2::field::types::Field;
 

--- a/evm/src/cpu/columns/ops.rs
+++ b/evm/src/cpu/columns/ops.rs
@@ -1,6 +1,6 @@
-use std::borrow::{Borrow, BorrowMut};
-use std::mem::{size_of, transmute};
-use std::ops::{Deref, DerefMut};
+use core::borrow::{Borrow, BorrowMut};
+use core::mem::{size_of, transmute};
+use core::ops::{Deref, DerefMut};
 
 use crate::util::transmute_no_compile_time_size_checks;
 

--- a/evm/src/cpu/cpu_stark.rs
+++ b/evm/src/cpu/cpu_stark.rs
@@ -1,6 +1,6 @@
-use std::borrow::Borrow;
-use std::iter::repeat;
-use std::marker::PhantomData;
+use core::borrow::Borrow;
+use core::iter::repeat;
+use core::marker::PhantomData;
 
 use itertools::Itertools;
 use plonky2::field::extension::{Extendable, FieldExtension};

--- a/evm/src/cpu/kernel/assembler.rs
+++ b/evm/src/cpu/kernel/assembler.rs
@@ -430,12 +430,8 @@ fn push_target_size(target: &PushTarget) -> u8 {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
-
-    use itertools::Itertools;
-
+    use super::*;
     use crate::cpu::kernel::assembler::*;
-    use crate::cpu::kernel::ast::*;
     use crate::cpu::kernel::parser::parse;
 
     #[test]

--- a/evm/src/cpu/kernel/constants/exc_bitfields.rs
+++ b/evm/src/cpu/kernel/constants/exc_bitfields.rs
@@ -1,4 +1,4 @@
-use std::ops::RangeInclusive;
+use core::ops::RangeInclusive;
 
 use ethereum_types::U256;
 

--- a/evm/src/cpu/kernel/constants/trie_type.rs
+++ b/evm/src/cpu/kernel/constants/trie_type.rs
@@ -1,4 +1,4 @@
-use std::ops::Deref;
+use core::ops::Deref;
 
 use eth_trie_utils::partial_trie::HashedPartialTrie;
 

--- a/evm/src/cpu/kernel/interpreter.rs
+++ b/evm/src/cpu/kernel/interpreter.rs
@@ -1,8 +1,8 @@
 //! An EVM interpreter for testing and debugging purposes.
 
 use core::cmp::Ordering;
+use core::ops::Range;
 use std::collections::{BTreeSet, HashMap, HashSet};
-use std::ops::Range;
 
 use anyhow::bail;
 use eth_trie_utils::partial_trie::PartialTrie;

--- a/evm/src/cpu/kernel/interpreter.rs
+++ b/evm/src/cpu/kernel/interpreter.rs
@@ -1664,15 +1664,8 @@ pub(crate) use unpack_address;
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
-
-    use ethereum_types::U256;
-
-    use crate::cpu::kernel::constants::context_metadata::ContextMetadata;
-    use crate::cpu::kernel::interpreter::{run, Interpreter};
+    use super::*;
     use crate::memory::segments::Segment;
-    use crate::witness::memory::MemoryAddress;
-    use crate::witness::operation::CONTEXT_SCALING_FACTOR;
 
     #[test]
     fn test_run() -> anyhow::Result<()> {

--- a/evm/src/cpu/kernel/stack/permutations.rs
+++ b/evm/src/cpu/kernel/stack/permutations.rs
@@ -19,8 +19,8 @@
 //!
 //! We typically represent a `(0 i)` transposition as a single scalar `i`.
 
+use core::hash::Hash;
 use std::collections::{HashMap, HashSet};
-use std::hash::Hash;
 
 use crate::cpu::kernel::stack::stack_manipulation::{StackItem, StackOp};
 

--- a/evm/src/cpu/kernel/stack/stack_manipulation.rs
+++ b/evm/src/cpu/kernel/stack/stack_manipulation.rs
@@ -1,7 +1,7 @@
-use std::cmp::Ordering;
+use core::cmp::Ordering;
+use core::hash::Hash;
 use std::collections::hash_map::Entry::{Occupied, Vacant};
 use std::collections::{BinaryHeap, HashMap};
-use std::hash::Hash;
 
 use itertools::Itertools;
 

--- a/evm/src/cpu/kernel/tests/bignum/mod.rs
+++ b/evm/src/cpu/kernel/tests/bignum/mod.rs
@@ -1,4 +1,4 @@
-use std::cmp::Ordering;
+use core::cmp::Ordering;
 use std::fs::File;
 use std::io::{BufRead, BufReader};
 use std::path::PathBuf;

--- a/evm/src/cpu/kernel/utils.rs
+++ b/evm/src/cpu/kernel/utils.rs
@@ -1,4 +1,4 @@
-use std::fmt::Debug;
+use core::fmt::Debug;
 
 use ethereum_types::U256;
 use plonky2_util::ceil_div_usize;

--- a/evm/src/cpu/membus.rs
+++ b/evm/src/cpu/membus.rs
@@ -11,7 +11,7 @@ pub(crate) const NUM_GP_CHANNELS: usize = 3;
 
 /// Indices for code and general purpose memory channels.
 pub mod channel_indices {
-    use std::ops::Range;
+    use core::ops::Range;
 
     pub(crate) const CODE: usize = 0;
     pub(crate) const GP: Range<usize> = CODE + 1..(CODE + 1) + super::NUM_GP_CHANNELS;

--- a/evm/src/cpu/stack.rs
+++ b/evm/src/cpu/stack.rs
@@ -1,4 +1,4 @@
-use std::cmp::max;
+use core::cmp::max;
 
 use itertools::izip;
 use plonky2::field::extension::Extendable;

--- a/evm/src/cross_table_lookup.rs
+++ b/evm/src/cross_table_lookup.rs
@@ -27,10 +27,10 @@
 //! is similar, but we provide not only `local_values` but also `next_values` -- corresponding to
 //! the current and next row values -- when computing the linear combinations.
 
-use std::borrow::Borrow;
-use std::cmp::min;
-use std::fmt::Debug;
-use std::iter::repeat;
+use core::borrow::Borrow;
+use core::cmp::min;
+use core::fmt::Debug;
+use core::iter::repeat;
 
 use anyhow::{ensure, Result};
 use hashbrown::HashMap;

--- a/evm/src/curve_pairings.rs
+++ b/evm/src/curve_pairings.rs
@@ -1,4 +1,4 @@
-use std::ops::{Add, Mul, Neg};
+use core::ops::{Add, Mul, Neg};
 
 use ethereum_types::U256;
 use rand::distributions::Standard;

--- a/evm/src/extension_tower.rs
+++ b/evm/src/extension_tower.rs
@@ -1,5 +1,5 @@
-use std::fmt::Debug;
-use std::ops::{Add, Div, Mul, Neg, Sub};
+use core::fmt::Debug;
+use core::ops::{Add, Div, Mul, Neg, Sub};
 
 use ethereum_types::{U256, U512};
 use rand::distributions::{Distribution, Standard};

--- a/evm/src/fixed_recursive_verifier.rs
+++ b/evm/src/fixed_recursive_verifier.rs
@@ -1,6 +1,6 @@
 use core::mem::{self, MaybeUninit};
+use core::ops::Range;
 use std::collections::BTreeMap;
-use std::ops::Range;
 use std::path::Path;
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;

--- a/evm/src/generation/mpt.rs
+++ b/evm/src/generation/mpt.rs
@@ -1,5 +1,5 @@
+use core::ops::Deref;
 use std::collections::HashMap;
-use std::ops::Deref;
 
 use bytes::Bytes;
 use eth_trie_utils::nibbles::Nibbles;

--- a/evm/src/generation/prover_input.rs
+++ b/evm/src/generation/prover_input.rs
@@ -1,6 +1,6 @@
-use std::cmp::min;
+use core::cmp::min;
+use core::mem::transmute;
 use std::collections::{BTreeSet, HashMap};
-use std::mem::transmute;
 use std::str::FromStr;
 
 use anyhow::{bail, Error};

--- a/evm/src/keccak/keccak_stark.rs
+++ b/evm/src/keccak/keccak_stark.rs
@@ -1,4 +1,4 @@
-use std::marker::PhantomData;
+use core::marker::PhantomData;
 
 use itertools::Itertools;
 use plonky2::field::extension::{Extendable, FieldExtension};

--- a/evm/src/keccak/keccak_stark.rs
+++ b/evm/src/keccak/keccak_stark.rs
@@ -622,21 +622,17 @@ impl<F: RichField + Extendable<D>, const D: usize> Stark<F, D> for KeccakStark<F
 mod tests {
     use anyhow::Result;
     use env_logger::{try_init_from_env, Env, DEFAULT_FILTER_ENV};
-    use plonky2::field::polynomial::PolynomialValues;
-    use plonky2::field::types::{Field, PrimeField64};
+    use plonky2::field::types::PrimeField64;
     use plonky2::fri::oracle::PolynomialBatch;
     use plonky2::iop::challenger::Challenger;
     use plonky2::plonk::config::{GenericConfig, PoseidonGoldilocksConfig};
-    use plonky2::timed;
-    use plonky2::util::timing::TimingTree;
     use tiny_keccak::keccakf;
 
+    use super::*;
     use crate::config::StarkConfig;
     use crate::cross_table_lookup::{
-        Column, CtlData, CtlZData, Filter, GrandProductChallenge, GrandProductChallengeSet,
+        CtlData, CtlZData, GrandProductChallenge, GrandProductChallengeSet,
     };
-    use crate::keccak::columns::reg_output_limb;
-    use crate::keccak::keccak_stark::{KeccakStark, NUM_INPUTS, NUM_ROUNDS};
     use crate::prover::prove_single_table;
     use crate::stark_testing::{test_stark_circuit_constraints, test_stark_low_degree};
 

--- a/evm/src/keccak_sponge/columns.rs
+++ b/evm/src/keccak_sponge/columns.rs
@@ -1,6 +1,6 @@
-use std::borrow::{Borrow, BorrowMut};
-use std::mem::{size_of, transmute};
-use std::ops::Range;
+use core::borrow::{Borrow, BorrowMut};
+use core::mem::{size_of, transmute};
+use core::ops::Range;
 
 use crate::util::{indices_arr, transmute_no_compile_time_size_checks};
 

--- a/evm/src/keccak_sponge/keccak_sponge_stark.rs
+++ b/evm/src/keccak_sponge/keccak_sponge_stark.rs
@@ -1,7 +1,7 @@
-use std::borrow::Borrow;
-use std::iter::{self, once, repeat};
-use std::marker::PhantomData;
-use std::mem::size_of;
+use core::borrow::Borrow;
+use core::iter::{self, once, repeat};
+use core::marker::PhantomData;
+use core::mem::size_of;
 
 use itertools::Itertools;
 use plonky2::field::extension::{Extendable, FieldExtension};

--- a/evm/src/keccak_sponge/keccak_sponge_stark.rs
+++ b/evm/src/keccak_sponge/keccak_sponge_stark.rs
@@ -812,20 +812,15 @@ impl<F: RichField + Extendable<D>, const D: usize> Stark<F, D> for KeccakSpongeS
 
 #[cfg(test)]
 mod tests {
-    use std::borrow::Borrow;
-
     use anyhow::Result;
-    use itertools::Itertools;
     use keccak_hash::keccak;
     use plonky2::field::goldilocks_field::GoldilocksField;
     use plonky2::field::types::PrimeField64;
     use plonky2::plonk::config::{GenericConfig, PoseidonGoldilocksConfig};
 
-    use crate::keccak_sponge::columns::KeccakSpongeColumnsView;
-    use crate::keccak_sponge::keccak_sponge_stark::{KeccakSpongeOp, KeccakSpongeStark};
+    use super::*;
     use crate::memory::segments::Segment;
     use crate::stark_testing::{test_stark_circuit_constraints, test_stark_low_degree};
-    use crate::witness::memory::MemoryAddress;
 
     #[test]
     fn test_stark_degree() -> Result<()> {

--- a/evm/src/logic.rs
+++ b/evm/src/logic.rs
@@ -1,4 +1,4 @@
-use std::marker::PhantomData;
+use core::marker::PhantomData;
 
 use ethereum_types::U256;
 use itertools::izip;
@@ -28,8 +28,8 @@ const PACKED_LEN: usize = ceil_div_usize(VAL_BITS, PACKED_LIMB_BITS);
 
 /// `LogicStark` columns.
 pub(crate) mod columns {
-    use std::cmp::min;
-    use std::ops::Range;
+    use core::cmp::min;
+    use core::ops::Range;
 
     use super::{PACKED_LEN, PACKED_LIMB_BITS, VAL_BITS};
 

--- a/evm/src/memory/memory_stark.rs
+++ b/evm/src/memory/memory_stark.rs
@@ -1,4 +1,4 @@
-use std::marker::PhantomData;
+use core::marker::PhantomData;
 
 use ethereum_types::U256;
 use itertools::Itertools;

--- a/evm/src/recursive_verifier.rs
+++ b/evm/src/recursive_verifier.rs
@@ -1,5 +1,5 @@
-use std::array::from_fn;
-use std::fmt::Debug;
+use core::array::from_fn;
+use core::fmt::Debug;
 
 use anyhow::Result;
 use ethereum_types::{BigEndianHash, H256, U256};

--- a/evm/src/util.rs
+++ b/evm/src/util.rs
@@ -1,4 +1,4 @@
-use std::mem::{size_of, transmute_copy, ManuallyDrop};
+use core::mem::{size_of, transmute_copy, ManuallyDrop};
 
 use ethereum_types::{H160, H256, U256};
 use itertools::Itertools;

--- a/evm/src/verifier.rs
+++ b/evm/src/verifier.rs
@@ -1,4 +1,4 @@
-use std::any::type_name;
+use core::any::type_name;
 
 use anyhow::{ensure, Result};
 use ethereum_types::{BigEndianHash, U256};

--- a/evm/src/witness/traces.rs
+++ b/evm/src/witness/traces.rs
@@ -1,4 +1,4 @@
-use std::mem::size_of;
+use core::mem::size_of;
 
 use itertools::Itertools;
 use plonky2::field::extension::Extendable;

--- a/evm/tests/empty_txn_list.rs
+++ b/evm/tests/empty_txn_list.rs
@@ -1,5 +1,5 @@
+use core::marker::PhantomData;
 use std::collections::HashMap;
-use std::marker::PhantomData;
 use std::time::Duration;
 
 use env_logger::{try_init_from_env, Env, DEFAULT_FILTER_ENV};


### PR DESCRIPTION
Just some import cleanup, and replacing all `std` imports by their `core` counterpart when existing for the `plonky2_evm` crate to prepare for code migration.