### PR TITLE
Make CTLs more generic

### DIFF
--- a/evm/src/arithmetic/arithmetic_stark.rs
+++ b/evm/src/arithmetic/arithmetic_stark.rs
@@ -110,7 +110,7 @@ pub(crate) fn ctl_arithmetic_rows<F: Field>() -> TableWithColumns<F> {
     // corresponding to a 256-bit input or output register (also `ops`
     // is used as the operation filter).
     TableWithColumns::new(
-        Table::Arithmetic,
+        *Table::Arithmetic,
         cpu_arith_data_link(&all_combined_cols, &REGISTER_MAP),
         filter,
     )

--- a/evm/src/cpu/cpu_stark.rs
+++ b/evm/src/cpu/cpu_stark.rs
@@ -108,7 +108,7 @@ pub(crate) fn ctl_arithmetic_base_rows<F: Field>() -> TableWithColumns<F> {
         F::ONE,
     );
     TableWithColumns::new(
-        Table::Cpu,
+        *Table::Cpu,
         columns,
         Some(Filter::new(
             vec![(Column::single(COL_MAP.op.push_prover_input), col_bit)],

--- a/evm/src/fixed_recursive_verifier.rs
+++ b/evm/src/fixed_recursive_verifier.rs
@@ -574,7 +574,7 @@ where
             vec![vec![builder.zero(); stark_config.num_challenges]; NUM_TABLES];
 
         // Memory
-        extra_looking_sums[*Table::Memory as usize] = (0..stark_config.num_challenges)
+        extra_looking_sums[*Table::Memory] = (0..stark_config.num_challenges)
             .map(|c| {
                 get_memory_extra_looking_sum_circuit(
                     &mut builder,

--- a/evm/src/fixed_recursive_verifier.rs
+++ b/evm/src/fixed_recursive_verifier.rs
@@ -419,49 +419,49 @@ where
         let arithmetic = RecursiveCircuitsForTable::new(
             Table::Arithmetic,
             &all_stark.arithmetic_stark,
-            degree_bits_ranges[Table::Arithmetic as usize].clone(),
+            degree_bits_ranges[*Table::Arithmetic].clone(),
             &all_stark.cross_table_lookups,
             stark_config,
         );
         let byte_packing = RecursiveCircuitsForTable::new(
             Table::BytePacking,
             &all_stark.byte_packing_stark,
-            degree_bits_ranges[Table::BytePacking as usize].clone(),
+            degree_bits_ranges[*Table::BytePacking].clone(),
             &all_stark.cross_table_lookups,
             stark_config,
         );
         let cpu = RecursiveCircuitsForTable::new(
             Table::Cpu,
             &all_stark.cpu_stark,
-            degree_bits_ranges[Table::Cpu as usize].clone(),
+            degree_bits_ranges[*Table::Cpu].clone(),
             &all_stark.cross_table_lookups,
             stark_config,
         );
         let keccak = RecursiveCircuitsForTable::new(
             Table::Keccak,
             &all_stark.keccak_stark,
-            degree_bits_ranges[Table::Keccak as usize].clone(),
+            degree_bits_ranges[*Table::Keccak].clone(),
             &all_stark.cross_table_lookups,
             stark_config,
         );
         let keccak_sponge = RecursiveCircuitsForTable::new(
             Table::KeccakSponge,
             &all_stark.keccak_sponge_stark,
-            degree_bits_ranges[Table::KeccakSponge as usize].clone(),
+            degree_bits_ranges[*Table::KeccakSponge].clone(),
             &all_stark.cross_table_lookups,
             stark_config,
         );
         let logic = RecursiveCircuitsForTable::new(
             Table::Logic,
             &all_stark.logic_stark,
-            degree_bits_ranges[Table::Logic as usize].clone(),
+            degree_bits_ranges[*Table::Logic].clone(),
             &all_stark.cross_table_lookups,
             stark_config,
         );
         let memory = RecursiveCircuitsForTable::new(
             Table::Memory,
             &all_stark.memory_stark,
-            degree_bits_ranges[Table::Memory as usize].clone(),
+            degree_bits_ranges[*Table::Memory].clone(),
             &all_stark.cross_table_lookups,
             stark_config,
         );
@@ -574,7 +574,7 @@ where
             vec![vec![builder.zero(); stark_config.num_challenges]; NUM_TABLES];
 
         // Memory
-        extra_looking_sums[Table::Memory as usize] = (0..stark_config.num_challenges)
+        extra_looking_sums[*Table::Memory as usize] = (0..stark_config.num_challenges)
             .map(|c| {
                 get_memory_extra_looking_sum_circuit(
                     &mut builder,

--- a/evm/src/fixed_recursive_verifier.rs
+++ b/evm/src/fixed_recursive_verifier.rs
@@ -585,7 +585,7 @@ where
             .collect_vec();
 
         // Verify the CTL checks.
-        verify_cross_table_lookups_circuit::<F, D>(
+        verify_cross_table_lookups_circuit::<F, D, NUM_TABLES>(
             &mut builder,
             all_cross_table_lookups(),
             pis.map(|p| p.ctl_zs_first),

--- a/evm/src/prover.rs
+++ b/evm/src/prover.rs
@@ -131,7 +131,7 @@ where
     let ctl_data_per_table = timed!(
         timing,
         "compute CTL data",
-        cross_table_lookup_data::<F, D>(
+        cross_table_lookup_data::<F, D, NUM_TABLES>(
             &trace_poly_values,
             &all_stark.cross_table_lookups,
             &ctl_challenges,

--- a/evm/src/recursive_verifier.rs
+++ b/evm/src/recursive_verifier.rs
@@ -232,7 +232,7 @@ where
     let (total_num_helpers, num_ctl_zs, num_helpers_by_ctl) =
         CrossTableLookup::num_ctl_helpers_zs_all(
             cross_table_lookups,
-            table as usize,
+            *table,
             inner_config.num_challenges,
             stark.constraint_degree(),
         );
@@ -266,7 +266,7 @@ where
     };
 
     let ctl_vars = CtlCheckVarsTarget::from_proof(
-        table as usize,
+        *table,
         &proof_target,
         cross_table_lookups,
         &ctl_challenges_target,

--- a/evm/src/recursive_verifier.rs
+++ b/evm/src/recursive_verifier.rs
@@ -232,7 +232,7 @@ where
     let (total_num_helpers, num_ctl_zs, num_helpers_by_ctl) =
         CrossTableLookup::num_ctl_helpers_zs_all(
             cross_table_lookups,
-            table,
+            table as usize,
             inner_config.num_challenges,
             stark.constraint_degree(),
         );
@@ -266,7 +266,7 @@ where
     };
 
     let ctl_vars = CtlCheckVarsTarget::from_proof(
-        table,
+        table as usize,
         &proof_target,
         cross_table_lookups,
         &ctl_challenges_target,

--- a/evm/src/verifier.rs
+++ b/evm/src/verifier.rs
@@ -138,7 +138,7 @@ where
         .map(|i| get_memory_extra_looking_sum(&public_values, ctl_challenges.challenges[i]))
         .collect_vec();
 
-    verify_cross_table_lookups::<F, D>(
+    verify_cross_table_lookups::<F, D, NUM_TABLES>(
         cross_table_lookups,
         all_proof
             .stark_proofs


### PR DESCRIPTION
Make CTLs generic in the number of tables they are working on, instead of being pegged to the `Table` enum with `NUM_TABLES` variants, in preparation for the code migration.