### PR TITLE
Fix BaseSumGenerator and BaseSplitGenerator Ids

### DIFF
--- a/plonky2/src/gadgets/split_base.rs
+++ b/plonky2/src/gadgets/split_base.rs
@@ -1,7 +1,6 @@
 use alloc::string::String;
-use alloc::format;
-use alloc::vec;
 use alloc::vec::Vec;
+use alloc::{format, vec};
 use core::borrow::Borrow;
 
 use itertools::Itertools;

--- a/plonky2/src/gadgets/split_base.rs
+++ b/plonky2/src/gadgets/split_base.rs
@@ -1,4 +1,4 @@
-use alloc::string::{String, ToString};
+use alloc::string::String;
 use alloc::vec;
 use alloc::vec::Vec;
 use core::borrow::Borrow;
@@ -91,7 +91,7 @@ impl<F: RichField + Extendable<D>, const B: usize, const D: usize> SimpleGenerat
     for BaseSumGenerator<B>
 {
     fn id(&self) -> String {
-        "BaseSumGenerator".to_string()
+        format!("BaseSumGenerator + Base: {B}")
     }
 
     fn dependencies(&self) -> Vec<Target> {

--- a/plonky2/src/gadgets/split_base.rs
+++ b/plonky2/src/gadgets/split_base.rs
@@ -1,4 +1,5 @@
 use alloc::string::String;
+use alloc::format;
 use alloc::vec;
 use alloc::vec::Vec;
 use core::borrow::Borrow;

--- a/plonky2/src/gates/base_sum.rs
+++ b/plonky2/src/gates/base_sum.rs
@@ -1,4 +1,4 @@
-use alloc::string::{String, ToString};
+use alloc::string::String;
 use alloc::vec::Vec;
 use alloc::{format, vec};
 use core::ops::Range;
@@ -179,7 +179,7 @@ impl<F: RichField + Extendable<D>, const B: usize, const D: usize> SimpleGenerat
     for BaseSplitGenerator<B>
 {
     fn id(&self) -> String {
-        "BaseSplitGenerator".to_string()
+        format!("BaseSplitGenerator + Base: {B}")
     }
 
     fn dependencies(&self) -> Vec<Target> {


### PR DESCRIPTION
`impl_generator_serializer!` matches generator Id to get correct types. You would need different Ids for different bases if you wanna use `impl_generator_serializer` for these generators with different bases.
For example if your circuit uses `BaseSplitGenerator<2>` and `BaseSplitGenerator<4>` something like the snippet below:
```
impl_generator_serializer! {
  CustomGeneratorSerializer
  BaseSplitGenerator<2>,
  BaseSplitGenerator<4>
}
```
would lead to incorrect generation of `ProverOnlyCircuitData` when reconstructed using `ProverOnlyCircuitData::from_bytes(..)`

CC: @ultrainstinct30 