### PR TITLE
Remove `StarkProofWithMetadata`

### DIFF
--- a/evm/src/cross_table_lookup.rs
+++ b/evm/src/cross_table_lookup.rs
@@ -60,7 +60,7 @@ use crate::lookup::{
     eval_helper_columns, eval_helper_columns_circuit, get_helper_cols, Column, ColumnFilter,
     Filter, GrandProductChallenge,
 };
-use crate::proof::{StarkProofTarget, StarkProofWithMetadata};
+use crate::proof::{StarkProof, StarkProofTarget};
 use crate::stark::Stark;
 
 /// An alias for `usize`, to represent the index of a STARK table in a multi-STARK setting.
@@ -503,7 +503,7 @@ impl<'a, F: RichField + Extendable<D>, const D: usize>
 {
     /// Extracts the `CtlCheckVars` for each STARK.
     pub(crate) fn from_proofs<C: GenericConfig<D, F = F>, const N: usize>(
-        proofs: &[StarkProofWithMetadata<F, C, D>; N],
+        proofs: &[StarkProof<F, C, D>; N],
         cross_table_lookups: &'a [CrossTableLookup<F>],
         ctl_challenges: &'a GrandProductChallengeSet<F>,
         num_lookup_columns: &[usize; N],
@@ -520,8 +520,8 @@ impl<'a, F: RichField + Extendable<D>, const D: usize>
         let mut ctl_zs = proofs
             .iter()
             .zip(num_lookup_columns)
-            .map(|(p, &num_lookup)| {
-                let openings = &p.proof.openings;
+            .map(|(proof, &num_lookup)| {
+                let openings = &proof.openings;
 
                 let ctl_zs = &openings.auxiliary_polys[num_lookup..];
                 let ctl_zs_next = &openings.auxiliary_polys_next[num_lookup..];

--- a/evm/src/fixed_recursive_verifier.rs
+++ b/evm/src/fixed_recursive_verifier.rs
@@ -42,7 +42,7 @@ use crate::generation::GenerationInputs;
 use crate::get_challenges::observe_public_values_target;
 use crate::proof::{
     AllProof, BlockHashesTarget, BlockMetadataTarget, ExtraBlockData, ExtraBlockDataTarget,
-    PublicValues, PublicValuesTarget, StarkProofWithMetadata, TrieRoots, TrieRootsTarget,
+    PublicValues, PublicValuesTarget, StarkProof, TrieRoots, TrieRootsTarget,
 };
 use crate::prover::{check_abort_signal, prove};
 use crate::recursive_verifier::{
@@ -1005,7 +1005,7 @@ where
 
         for table in 0..NUM_TABLES {
             let stark_proof = &all_proof.stark_proofs[table];
-            let original_degree_bits = stark_proof.proof.recover_degree_bits(config);
+            let original_degree_bits = stark_proof.recover_degree_bits(config);
             let table_circuits = &self.by_table[table];
             let shrunk_proof = table_circuits
                 .by_stark_size
@@ -1113,7 +1113,7 @@ where
             let (table_circuit, index_verifier_data) = &table_circuits[table];
 
             let stark_proof = &all_proof.stark_proofs[table];
-            let original_degree_bits = stark_proof.proof.recover_degree_bits(config);
+            let original_degree_bits = stark_proof.recover_degree_bits(config);
 
             let shrunk_proof = table_circuit.shrink(stark_proof, &all_proof.ctl_challenges)?;
             root_inputs.set_target(
@@ -1635,12 +1635,10 @@ where
 
     pub fn shrink(
         &self,
-        stark_proof_with_metadata: &StarkProofWithMetadata<F, C, D>,
+        stark_proof: &StarkProof<F, C, D>,
         ctl_challenges: &GrandProductChallengeSet<F>,
     ) -> anyhow::Result<ProofWithPublicInputs<F, C, D>> {
-        let mut proof = self
-            .initial_wrapper
-            .prove(stark_proof_with_metadata, ctl_challenges)?;
+        let mut proof = self.initial_wrapper.prove(stark_proof, ctl_challenges)?;
         for wrapper_circuit in &self.shrinking_wrappers {
             proof = wrapper_circuit.prove(&proof)?;
         }

--- a/evm/src/get_challenges.rs
+++ b/evm/src/get_challenges.rs
@@ -199,7 +199,7 @@ impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize> A
         let mut challenger = Challenger::<F, C::Hasher>::new();
 
         for proof in &self.stark_proofs {
-            challenger.observe_cap(&proof.proof.trace_cap);
+            challenger.observe_cap(&proof.trace_cap);
         }
 
         observe_public_values::<F, C, D>(&mut challenger, &self.public_values)?;
@@ -210,9 +210,7 @@ impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize> A
         Ok(AllProofChallenges {
             stark_challenges: core::array::from_fn(|i| {
                 challenger.compact();
-                self.stark_proofs[i]
-                    .proof
-                    .get_challenges(&mut challenger, config)
+                self.stark_proofs[i].get_challenges(&mut challenger, config)
             }),
             ctl_challenges,
         })

--- a/evm/src/proof.rs
+++ b/evm/src/proof.rs
@@ -26,7 +26,7 @@ use crate::util::{get_h160, get_h256, h2u};
 #[derive(Debug, Clone)]
 pub struct AllProof<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize> {
     /// Proofs for all the different STARK modules.
-    pub stark_proofs: [StarkProofWithMetadata<F, C, D>; NUM_TABLES],
+    pub stark_proofs: [StarkProof<F, C, D>; NUM_TABLES],
     /// Cross-table lookup challenges.
     pub(crate) ctl_challenges: GrandProductChallengeSet<F>,
     /// Public memory values used for the recursive proofs.
@@ -36,7 +36,7 @@ pub struct AllProof<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, co
 impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize> AllProof<F, C, D> {
     /// Returns the degree (i.e. the trace length) of each STARK.
     pub fn degree_bits(&self, config: &StarkConfig) -> [usize; NUM_TABLES] {
-        core::array::from_fn(|i| self.stark_proofs[i].proof.recover_degree_bits(config))
+        core::array::from_fn(|i| self.stark_proofs[i].recover_degree_bits(config))
     }
 }
 
@@ -836,20 +836,6 @@ pub struct StarkProof<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, 
     pub openings: StarkOpeningSet<F, D>,
     /// A batch FRI argument for all openings.
     pub opening_proof: FriProof<F, C::Hasher, D>,
-}
-
-/// A `StarkProof` along with some metadata about the initial Fiat-Shamir state, which is used when
-/// creating a recursive wrapper proof around a STARK proof.
-#[derive(Debug, Clone)]
-pub struct StarkProofWithMetadata<F, C, const D: usize>
-where
-    F: RichField + Extendable<D>,
-    C: GenericConfig<D, F = F>,
-{
-    /// Initial Fiat-Shamir state.
-    pub(crate) init_challenger_state: <C::Hasher as Hasher<F>>::Permutation,
-    /// Proof for a single STARK.
-    pub(crate) proof: StarkProof<F, C, D>,
 }
 
 impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize> StarkProof<F, C, D> {

--- a/evm/src/recursive_verifier.rs
+++ b/evm/src/recursive_verifier.rs
@@ -39,8 +39,7 @@ use crate::memory::VALUE_LIMBS;
 use crate::proof::{
     BlockHashes, BlockHashesTarget, BlockMetadata, BlockMetadataTarget, ExtraBlockData,
     ExtraBlockDataTarget, PublicValues, PublicValuesTarget, StarkOpeningSetTarget, StarkProof,
-    StarkProofChallengesTarget, StarkProofTarget, StarkProofWithMetadata, TrieRoots,
-    TrieRootsTarget,
+    StarkProofChallengesTarget, StarkProofTarget, TrieRoots, TrieRootsTarget,
 };
 use crate::stark::Stark;
 use crate::util::{h256_limbs, h2u, u256_limbs, u256_to_u32, u256_to_u64};
@@ -147,7 +146,7 @@ where
 
     pub(crate) fn prove(
         &self,
-        proof_with_metadata: &StarkProofWithMetadata<F, C, D>,
+        proof: &StarkProof<F, C, D>,
         ctl_challenges: &GrandProductChallengeSet<F>,
     ) -> Result<ProofWithPublicInputs<F, C, D>> {
         let mut inputs = PartialWitness::new();
@@ -155,7 +154,7 @@ where
         set_stark_proof_target(
             &mut inputs,
             &self.stark_proof_target,
-            &proof_with_metadata.proof,
+            proof,
             self.zero_target,
         );
 
@@ -168,11 +167,6 @@ where
             inputs.set_target(challenge_target.beta, challenge.beta);
             inputs.set_target(challenge_target.gamma, challenge.gamma);
         }
-
-        inputs.set_target_arr(
-            self.init_challenger_state_target.as_ref(),
-            proof_with_metadata.init_challenger_state.as_ref(),
-        );
 
         self.circuit.prove(inputs)
     }

--- a/evm/src/verifier.rs
+++ b/evm/src/verifier.rs
@@ -72,7 +72,7 @@ where
 
     verify_stark_proof_with_challenges(
         arithmetic_stark,
-        &all_proof.stark_proofs[Table::Arithmetic as usize].proof,
+        &all_proof.stark_proofs[Table::Arithmetic as usize],
         &stark_challenges[Table::Arithmetic as usize],
         &ctl_vars_per_table[Table::Arithmetic as usize],
         &ctl_challenges,
@@ -80,7 +80,7 @@ where
     )?;
     verify_stark_proof_with_challenges(
         byte_packing_stark,
-        &all_proof.stark_proofs[Table::BytePacking as usize].proof,
+        &all_proof.stark_proofs[Table::BytePacking as usize],
         &stark_challenges[Table::BytePacking as usize],
         &ctl_vars_per_table[Table::BytePacking as usize],
         &ctl_challenges,
@@ -88,7 +88,7 @@ where
     )?;
     verify_stark_proof_with_challenges(
         cpu_stark,
-        &all_proof.stark_proofs[Table::Cpu as usize].proof,
+        &all_proof.stark_proofs[Table::Cpu as usize],
         &stark_challenges[Table::Cpu as usize],
         &ctl_vars_per_table[Table::Cpu as usize],
         &ctl_challenges,
@@ -96,7 +96,7 @@ where
     )?;
     verify_stark_proof_with_challenges(
         keccak_stark,
-        &all_proof.stark_proofs[Table::Keccak as usize].proof,
+        &all_proof.stark_proofs[Table::Keccak as usize],
         &stark_challenges[Table::Keccak as usize],
         &ctl_vars_per_table[Table::Keccak as usize],
         &ctl_challenges,
@@ -104,7 +104,7 @@ where
     )?;
     verify_stark_proof_with_challenges(
         keccak_sponge_stark,
-        &all_proof.stark_proofs[Table::KeccakSponge as usize].proof,
+        &all_proof.stark_proofs[Table::KeccakSponge as usize],
         &stark_challenges[Table::KeccakSponge as usize],
         &ctl_vars_per_table[Table::KeccakSponge as usize],
         &ctl_challenges,
@@ -112,7 +112,7 @@ where
     )?;
     verify_stark_proof_with_challenges(
         logic_stark,
-        &all_proof.stark_proofs[Table::Logic as usize].proof,
+        &all_proof.stark_proofs[Table::Logic as usize],
         &stark_challenges[Table::Logic as usize],
         &ctl_vars_per_table[Table::Logic as usize],
         &ctl_challenges,
@@ -120,7 +120,7 @@ where
     )?;
     verify_stark_proof_with_challenges(
         memory_stark,
-        &all_proof.stark_proofs[Table::Memory as usize].proof,
+        &all_proof.stark_proofs[Table::Memory as usize],
         &stark_challenges[Table::Memory as usize],
         &ctl_vars_per_table[Table::Memory as usize],
         &ctl_challenges,
@@ -142,7 +142,7 @@ where
         cross_table_lookups,
         all_proof
             .stark_proofs
-            .map(|p| p.proof.openings.ctl_zs_first),
+            .map(|proof| proof.openings.ctl_zs_first),
         extra_looking_sums,
         config,
     )


### PR DESCRIPTION
`StarkProofWithMetadata` exists to combine a `proof` and a `init_challenger_state`. The latter is never used, and would be useful if we were proving each table in parallel after generating the CTL data, which we are not (they are proven sequentially).

This PR removes `StarkProofWithMetadata` and `StarkProofWithMetadataTarget`, and replaces them with the regular `StarkProof` and `StarkProofTarget`.