### PR TITLE
Pin nightly version to 2024-02-01

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -28,7 +28,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install nightly toolchain
-        uses: dtolnay/rust-toolchain@nightly-2024-02-01
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: nightly-2024-02-01
 
       - name: Set up rust cache
         uses: Swatinem/rust-cache@v2
@@ -77,8 +79,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install nightly toolchain
-        uses: dtolnay/rust-toolchain@nightly-2024-02-01
+        uses: dtolnay/rust-toolchain@master
         with:
+          toolchain: nightly-2024-02-01
           targets: wasm32-unknown-unknown
 
       - name: Set up rust cache
@@ -112,8 +115,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install nightly toolchain
-        uses: dtolnay/rust-toolchain@nightly-2024-02-01
+        uses: dtolnay/rust-toolchain@master
         with:
+          toolchain: nightly-2024-02-01
           components: rustfmt, clippy
 
       - name: Set up rust cache

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install nightly toolchain
-        uses: dtolnay/rust-toolchain@nightly
+        uses: dtolnay/rust-toolchain@nightly-2024-02-01
 
       - name: Set up rust cache
         uses: Swatinem/rust-cache@v2
@@ -77,7 +77,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install nightly toolchain
-        uses: dtolnay/rust-toolchain@nightly
+        uses: dtolnay/rust-toolchain@nightly-2024-02-01
         with:
           targets: wasm32-unknown-unknown
 
@@ -112,7 +112,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install nightly toolchain
-        uses: dtolnay/rust-toolchain@nightly
+        uses: dtolnay/rust-toolchain@nightly-2024-02-01
         with:
           components: rustfmt, clippy
 

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,1 +1,1 @@
-nightly
+nightly-2024-02-01


### PR DESCRIPTION
Overnight nightly changes broke compilation because of the `stdsimd` feature.

See: 
- https://github.com/0xPolygonZero/plonky2/actions/runs/7800550002/job/21273621246
- https://github.com/tkaitchuck/aHash/issues/200

This pins the nightly version to 2024-02-01.