### PR TITLE
Fix no-std tests and add corresponding jobs in the CI

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -70,7 +70,7 @@ jobs:
           RUST_BACKTRACE: 1
 
   wasm:
-    name: wasm32 compatibility
+    name: Check wasm32 compatibility
     runs-on: ubuntu-latest
     timeout-minutes: 30
     if: "! contains(toJSON(github.event.commits.*.message), '[skip-ci]')"
@@ -106,7 +106,7 @@ jobs:
           RUST_BACKTRACE: 1
 
   no_std:
-    name: Run tests in no-std
+    name: Test Suite in no-std
     runs-on: ubuntu-latest
     timeout-minutes: 30
     if: "! contains(toJSON(github.event.commits.*.message), '[skip-ci]')"

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -69,23 +69,7 @@ jobs:
           CARGO_INCREMENTAL: 1
           RUST_BACKTRACE: 1
 
-      - name: Run cargo test in plonky2 subdirectory (no-std)
-        run: cargo test --manifest-path plonky2/Cargo.toml --no-default-features
-        env:
-          RUSTFLAGS: -Copt-level=3 -Cdebug-assertions -Coverflow-checks=y -Cdebuginfo=0
-          RUST_LOG: 1
-          CARGO_INCREMENTAL: 1
-          RUST_BACKTRACE: 1
-
-      - name: Run cargo test in starky subdirectory (no-std)
-        run: cargo test --manifest-path starky/Cargo.toml --no-default-features
-        env:
-          RUSTFLAGS: -Copt-level=3 -Cdebug-assertions -Coverflow-checks=y -Cdebuginfo=0
-          RUST_LOG: 1
-          CARGO_INCREMENTAL: 1
-          RUST_BACKTRACE: 1
-
-  wasm32:
+  wasm:
     name: wasm32 compatibility
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -105,7 +89,7 @@ jobs:
         with:
             cache-on-failure: true
 
-      - name: Check in plonky2 subdirectory
+      - name: Check in plonky2 subdirectory for wasm targets
         run: cargo check --manifest-path plonky2/Cargo.toml --target wasm32-unknown-unknown --no-default-features
         env:
           RUSTFLAGS: -Copt-level=3 -Cdebug-assertions -Coverflow-checks=y -Cdebuginfo=0
@@ -113,8 +97,43 @@ jobs:
           CARGO_INCREMENTAL: 1
           RUST_BACKTRACE: 1
 
-      - name: Check in starky subdirectory
+      - name: Check in starky subdirectory for wasm targets
         run: cargo check --manifest-path starky/Cargo.toml --target wasm32-unknown-unknown --no-default-features
+        env:
+          RUSTFLAGS: -Copt-level=3 -Cdebug-assertions -Coverflow-checks=y -Cdebuginfo=0
+          RUST_LOG: 1
+          CARGO_INCREMENTAL: 1
+          RUST_BACKTRACE: 1
+
+  no_std:
+    name: Run tests in no-std
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    if: "! contains(toJSON(github.event.commits.*.message), '[skip-ci]')"
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+
+      - name: Install nightly toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: nightly-2024-02-01
+
+      - name: Set up rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+            cache-on-failure: true
+
+      - name: Run cargo test in plonky2 subdirectory (no-std)
+        run: cargo test --manifest-path plonky2/Cargo.toml --no-default-features
+        env:
+          RUSTFLAGS: -Copt-level=3 -Cdebug-assertions -Coverflow-checks=y -Cdebuginfo=0
+          RUST_LOG: 1
+          CARGO_INCREMENTAL: 1
+          RUST_BACKTRACE: 1
+
+      - name: Run cargo test in starky subdirectory (no-std)
+        run: cargo test --manifest-path starky/Cargo.toml --no-default-features
         env:
           RUSTFLAGS: -Copt-level=3 -Cdebug-assertions -Coverflow-checks=y -Cdebuginfo=0
           RUST_LOG: 1

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -69,6 +69,22 @@ jobs:
           CARGO_INCREMENTAL: 1
           RUST_BACKTRACE: 1
 
+      - name: Run cargo test in plonky2 subdirectory (no-std)
+        run: cargo test --manifest-path plonky2/Cargo.toml --no-default-features
+        env:
+          RUSTFLAGS: -Copt-level=3 -Cdebug-assertions -Coverflow-checks=y -Cdebuginfo=0
+          RUST_LOG: 1
+          CARGO_INCREMENTAL: 1
+          RUST_BACKTRACE: 1
+
+      - name: Run cargo test in starky subdirectory (no-std)
+        run: cargo test --manifest-path starky/Cargo.toml --no-default-features
+        env:
+          RUSTFLAGS: -Copt-level=3 -Cdebug-assertions -Coverflow-checks=y -Cdebuginfo=0
+          RUST_LOG: 1
+          CARGO_INCREMENTAL: 1
+          RUST_BACKTRACE: 1
+
   wasm32:
     name: wasm32 compatibility
     runs-on: ubuntu-latest

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -125,7 +125,7 @@ jobs:
             cache-on-failure: true
 
       - name: Run cargo test in plonky2 subdirectory (no-std)
-        run: cargo test --manifest-path plonky2/Cargo.toml --no-default-features
+        run: cargo test --manifest-path plonky2/Cargo.toml --no-default-features --lib
         env:
           RUSTFLAGS: -Copt-level=3 -Cdebug-assertions -Coverflow-checks=y -Cdebuginfo=0
           RUST_LOG: 1
@@ -133,7 +133,7 @@ jobs:
           RUST_BACKTRACE: 1
 
       - name: Run cargo test in starky subdirectory (no-std)
-        run: cargo test --manifest-path starky/Cargo.toml --no-default-features
+        run: cargo test --manifest-path starky/Cargo.toml --no-default-features --lib
         env:
           RUSTFLAGS: -Copt-level=3 -Cdebug-assertions -Coverflow-checks=y -Cdebuginfo=0
           RUST_LOG: 1

--- a/plonky2/src/gadgets/interpolation.rs
+++ b/plonky2/src/gadgets/interpolation.rs
@@ -38,6 +38,9 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(not(feature = "std"))]
+    use alloc::vec::Vec;
+
     use anyhow::Result;
 
     use crate::field::extension::FieldExtension;

--- a/plonky2/src/gates/poseidon.rs
+++ b/plonky2/src/gates/poseidon.rs
@@ -532,6 +532,9 @@ impl<F: RichField + Extendable<D> + Poseidon, const D: usize> SimpleGenerator<F,
 
 #[cfg(test)]
 mod tests {
+    #[cfg(not(feature = "std"))]
+    use alloc::{vec, vec::Vec};
+
     use anyhow::Result;
 
     use crate::field::goldilocks_field::GoldilocksField;

--- a/plonky2/src/hash/path_compression.rs
+++ b/plonky2/src/hash/path_compression.rs
@@ -148,12 +148,15 @@ mod tests {
 
         assert_eq!(proofs, decompressed_proofs);
 
-        let compressed_proof_bytes = serde_cbor::to_vec(&compressed_proofs).unwrap();
-        println!(
-            "Compressed proof length: {} bytes",
-            compressed_proof_bytes.len()
-        );
-        let proof_bytes = serde_cbor::to_vec(&proofs).unwrap();
-        println!("Proof length: {} bytes", proof_bytes.len());
+        #[cfg(feature = "std")]
+        {
+            let compressed_proof_bytes = serde_cbor::to_vec(&compressed_proofs).unwrap();
+            println!(
+                "Compressed proof length: {} bytes",
+                compressed_proof_bytes.len()
+            );
+            let proof_bytes = serde_cbor::to_vec(&proofs).unwrap();
+            println!("Proof length: {} bytes", proof_bytes.len());
+        }
     }
 }

--- a/plonky2/src/hash/poseidon.rs
+++ b/plonky2/src/hash/poseidon.rs
@@ -753,6 +753,9 @@ impl<F: RichField> AlgebraicHasher<F> for PoseidonHash {
 
 #[cfg(test)]
 pub(crate) mod test_helpers {
+    #[cfg(not(feature = "std"))]
+    use alloc::vec::Vec;
+
     use crate::field::types::Field;
     use crate::hash::poseidon::{Poseidon, SPONGE_WIDTH};
 

--- a/plonky2/src/hash/poseidon_goldilocks.rs
+++ b/plonky2/src/hash/poseidon_goldilocks.rs
@@ -444,6 +444,9 @@ mod poseidon12_mds {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(not(feature = "std"))]
+    use alloc::{vec, vec::Vec};
+
     use crate::field::goldilocks_field::GoldilocksField as F;
     use crate::field::types::{Field, PrimeField64};
     use crate::hash::poseidon::test_helpers::{check_consistency, check_test_vectors};

--- a/plonky2/src/iop/challenger.rs
+++ b/plonky2/src/iop/challenger.rs
@@ -293,6 +293,9 @@ impl<F: RichField + Extendable<D>, H: AlgebraicHasher<F>, const D: usize>
 
 #[cfg(test)]
 mod tests {
+    #[cfg(not(feature = "std"))]
+    use alloc::vec::Vec;
+
     use crate::field::types::Sample;
     use crate::iop::challenger::{Challenger, RecursiveChallenger};
     use crate::iop::generator::generate_partial_witness;

--- a/plonky2/src/plonk/proof.rs
+++ b/plonky2/src/plonk/proof.rs
@@ -451,7 +451,10 @@ impl<const D: usize> OpeningSetTarget<D> {
 
 #[cfg(test)]
 mod tests {
-    use alloc::sync::Arc;
+    #[cfg(not(feature = "std"))]
+    use alloc::{sync::Arc, vec};
+    #[cfg(feature = "std")]
+    use std::sync::Arc;
 
     use anyhow::Result;
     use itertools::Itertools;

--- a/plonky2/src/recursion/conditional_recursive_verifier.rs
+++ b/plonky2/src/recursion/conditional_recursive_verifier.rs
@@ -336,6 +336,9 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(not(feature = "std"))]
+    use alloc::vec;
+
     use anyhow::Result;
     use hashbrown::HashMap;
 

--- a/plonky2/src/recursion/cyclic_recursion.rs
+++ b/plonky2/src/recursion/cyclic_recursion.rs
@@ -198,6 +198,9 @@ where
 
 #[cfg(test)]
 mod tests {
+    #[cfg(not(feature = "std"))]
+    use alloc::vec;
+
     use anyhow::Result;
 
     use crate::field::extension::Extendable;

--- a/plonky2/src/recursion/recursive_verifier.rs
+++ b/plonky2/src/recursion/recursive_verifier.rs
@@ -191,7 +191,10 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
 
 #[cfg(test)]
 mod tests {
-    use alloc::sync::Arc;
+    #[cfg(not(feature = "std"))]
+    use alloc::{sync::Arc, vec};
+    #[cfg(feature = "std")]
+    use std::sync::Arc;
 
     use anyhow::Result;
     use itertools::Itertools;
@@ -690,12 +693,17 @@ mod tests {
         let proof_from_bytes = ProofWithPublicInputs::from_bytes(proof_bytes, common_data)?;
         assert_eq!(proof, &proof_from_bytes);
 
+        #[cfg(feature = "std")]
         let now = std::time::Instant::now();
+
         let compressed_proof = proof.clone().compress(&vd.circuit_digest, common_data)?;
         let decompressed_compressed_proof = compressed_proof
             .clone()
             .decompress(&vd.circuit_digest, common_data)?;
+
+        #[cfg(feature = "std")]
         info!("{:.4}s to compress proof", now.elapsed().as_secs_f64());
+
         assert_eq!(proof, &decompressed_compressed_proof);
 
         let compressed_proof_bytes = compressed_proof.to_bytes();

--- a/plonky2/src/util/mod.rs
+++ b/plonky2/src/util/mod.rs
@@ -1,5 +1,6 @@
 //! Utility module for helper methods and plonky2 serialization logic.
 
+#[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 
 use plonky2_maybe_rayon::*;
@@ -41,6 +42,10 @@ pub(crate) const fn reverse_bits(n: usize, num_bits: usize) -> usize {
 
 #[cfg(test)]
 mod tests {
+
+    #[cfg(not(feature = "std"))]
+    use alloc::vec;
+
     use super::*;
 
     #[test]

--- a/plonky2/src/util/partial_products.rs
+++ b/plonky2/src/util/partial_products.rs
@@ -108,6 +108,9 @@ pub(crate) fn check_partial_products_circuit<F: RichField + Extendable<D>, const
 
 #[cfg(test)]
 mod tests {
+    #[cfg(not(feature = "std"))]
+    use alloc::vec;
+
     use super::*;
     use crate::field::goldilocks_field::GoldilocksField;
 


### PR DESCRIPTION
We currently do check that `plonky` and `starky` crates compile well in `no-std` for WASM targets, but it'd be nice to also make sure we can actually run their test suites in `no-std` to make sure the internal logic isn't broken.\

This PR fixes a bunch of missing conditional imports to make tests pass in `no-std`, and adds two more CI jobs for testing the two mentioned crates.