### PR TITLE
Revert "Remove StarkProofWithMetadata (#1497)"

### DIFF
--- a/evm/src/cross_table_lookup.rs
+++ b/evm/src/cross_table_lookup.rs
@@ -52,7 +52,7 @@ use crate::lookup::{
     eval_helper_columns, eval_helper_columns_circuit, get_helper_cols, Column, ColumnFilter,
     Filter, GrandProductChallenge,
 };
-use crate::proof::{StarkProof, StarkProofTarget};
+use crate::proof::{StarkProofTarget, StarkProofWithMetadata};
 use crate::stark::Stark;
 
 /// An alias for `usize`, to represent the index of a STARK table in a multi-STARK setting.
@@ -494,7 +494,7 @@ impl<'a, F: RichField + Extendable<D>, const D: usize>
 {
     /// Extracts the `CtlCheckVars` for each STARK.
     pub(crate) fn from_proofs<C: GenericConfig<D, F = F>, const N: usize>(
-        proofs: &[StarkProof<F, C, D>; N],
+        proofs: &[StarkProofWithMetadata<F, C, D>; N],
         cross_table_lookups: &'a [CrossTableLookup<F>],
         ctl_challenges: &'a GrandProductChallengeSet<F>,
         num_lookup_columns: &[usize; N],
@@ -511,8 +511,8 @@ impl<'a, F: RichField + Extendable<D>, const D: usize>
         let ctl_zs = proofs
             .iter()
             .zip(num_lookup_columns)
-            .map(|(proof, &num_lookup)| {
-                let openings = &proof.openings;
+            .map(|(p, &num_lookup)| {
+                let openings = &p.proof.openings;
 
                 let ctl_zs = &openings.auxiliary_polys[num_lookup..];
                 let ctl_zs_next = &openings.auxiliary_polys_next[num_lookup..];

--- a/evm/src/fixed_recursive_verifier.rs
+++ b/evm/src/fixed_recursive_verifier.rs
@@ -40,7 +40,7 @@ use crate::generation::GenerationInputs;
 use crate::get_challenges::observe_public_values_target;
 use crate::proof::{
     AllProof, BlockHashesTarget, BlockMetadataTarget, ExtraBlockData, ExtraBlockDataTarget,
-    PublicValues, PublicValuesTarget, StarkProof, TrieRoots, TrieRootsTarget,
+    PublicValues, PublicValuesTarget, StarkProofWithMetadata, TrieRoots, TrieRootsTarget,
 };
 use crate::prover::{check_abort_signal, prove};
 use crate::recursive_verifier::{
@@ -1003,7 +1003,7 @@ where
 
         for table in 0..NUM_TABLES {
             let stark_proof = &all_proof.stark_proofs[table];
-            let original_degree_bits = stark_proof.recover_degree_bits(config);
+            let original_degree_bits = stark_proof.proof.recover_degree_bits(config);
             let table_circuits = &self.by_table[table];
             let shrunk_proof = table_circuits
                 .by_stark_size
@@ -1629,10 +1629,12 @@ where
 
     pub fn shrink(
         &self,
-        stark_proof: &StarkProof<F, C, D>,
+        stark_proof_with_metadata: &StarkProofWithMetadata<F, C, D>,
         ctl_challenges: &GrandProductChallengeSet<F>,
     ) -> anyhow::Result<ProofWithPublicInputs<F, C, D>> {
-        let mut proof = self.initial_wrapper.prove(stark_proof, ctl_challenges)?;
+        let mut proof = self
+            .initial_wrapper
+            .prove(stark_proof_with_metadata, ctl_challenges)?;
         for wrapper_circuit in &self.shrinking_wrappers {
             proof = wrapper_circuit.prove(&proof)?;
         }

--- a/evm/src/get_challenges.rs
+++ b/evm/src/get_challenges.rs
@@ -199,7 +199,7 @@ impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize> A
         let mut challenger = Challenger::<F, C::Hasher>::new();
 
         for proof in &self.stark_proofs {
-            challenger.observe_cap(&proof.trace_cap);
+            challenger.observe_cap(&proof.proof.trace_cap);
         }
 
         observe_public_values::<F, C, D>(&mut challenger, &self.public_values)?;
@@ -210,7 +210,9 @@ impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize> A
         Ok(AllProofChallenges {
             stark_challenges: core::array::from_fn(|i| {
                 challenger.compact();
-                self.stark_proofs[i].get_challenges(&mut challenger, config)
+                self.stark_proofs[i]
+                    .proof
+                    .get_challenges(&mut challenger, config)
             }),
             ctl_challenges,
         })

--- a/evm/src/proof.rs
+++ b/evm/src/proof.rs
@@ -25,7 +25,7 @@ use crate::util::{get_h160, get_h256, h2u};
 #[derive(Debug, Clone)]
 pub struct AllProof<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize> {
     /// Proofs for all the different STARK modules.
-    pub stark_proofs: [StarkProof<F, C, D>; NUM_TABLES],
+    pub stark_proofs: [StarkProofWithMetadata<F, C, D>; NUM_TABLES],
     /// Cross-table lookup challenges.
     pub(crate) ctl_challenges: GrandProductChallengeSet<F>,
     /// Public memory values used for the recursive proofs.
@@ -35,7 +35,7 @@ pub struct AllProof<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, co
 impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize> AllProof<F, C, D> {
     /// Returns the degree (i.e. the trace length) of each STARK.
     pub fn degree_bits(&self, config: &StarkConfig) -> [usize; NUM_TABLES] {
-        core::array::from_fn(|i| self.stark_proofs[i].recover_degree_bits(config))
+        core::array::from_fn(|i| self.stark_proofs[i].proof.recover_degree_bits(config))
     }
 }
 
@@ -835,6 +835,20 @@ pub struct StarkProof<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, 
     pub openings: StarkOpeningSet<F, D>,
     /// A batch FRI argument for all openings.
     pub opening_proof: FriProof<F, C::Hasher, D>,
+}
+
+/// A `StarkProof` along with some metadata about the initial Fiat-Shamir state, which is used when
+/// creating a recursive wrapper proof around a STARK proof.
+#[derive(Debug, Clone)]
+pub struct StarkProofWithMetadata<F, C, const D: usize>
+where
+    F: RichField + Extendable<D>,
+    C: GenericConfig<D, F = F>,
+{
+    /// Initial Fiat-Shamir state.
+    pub(crate) init_challenger_state: <C::Hasher as Hasher<F>>::Permutation,
+    /// Proof for a single STARK.
+    pub(crate) proof: StarkProof<F, C, D>,
 }
 
 impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize> StarkProof<F, C, D> {

--- a/evm/src/prover.rs
+++ b/evm/src/prover.rs
@@ -32,7 +32,7 @@ use crate::evaluation_frame::StarkEvaluationFrame;
 use crate::generation::{generate_traces, GenerationInputs};
 use crate::get_challenges::observe_public_values;
 use crate::lookup::{lookup_helper_columns, Lookup, LookupCheckVars};
-use crate::proof::{AllProof, PublicValues, StarkOpeningSet, StarkProof};
+use crate::proof::{AllProof, PublicValues, StarkOpeningSet, StarkProof, StarkProofWithMetadata};
 use crate::stark::Stark;
 use crate::vanishing_poly::eval_vanishing_poly;
 #[cfg(test)]
@@ -187,7 +187,7 @@ fn prove_with_commitments<F, C, const D: usize>(
     ctl_challenges: &GrandProductChallengeSet<F>,
     timing: &mut TimingTree,
     abort_signal: Option<Arc<AtomicBool>>,
-) -> Result<[StarkProof<F, C, D>; NUM_TABLES]>
+) -> Result<[StarkProofWithMetadata<F, C, D>; NUM_TABLES]>
 where
     F: RichField + Extendable<D>,
     C: GenericConfig<D, F = F>,
@@ -323,7 +323,7 @@ pub(crate) fn prove_single_table<F, C, S, const D: usize>(
     challenger: &mut Challenger<F, C::Hasher>,
     timing: &mut TimingTree,
     abort_signal: Option<Arc<AtomicBool>>,
-) -> Result<StarkProof<F, C, D>>
+) -> Result<StarkProofWithMetadata<F, C, D>>
 where
     F: RichField + Extendable<D>,
     C: GenericConfig<D, F = F>,
@@ -340,6 +340,8 @@ where
         fri_params.total_arities() <= degree_bits + rate_bits - cap_height,
         "FRI total reduction arity is too large.",
     );
+
+    let init_challenger_state = challenger.compact();
 
     let constraint_degree = stark.constraint_degree();
     let lookup_challenges = stark.uses_lookups().then(|| {
@@ -518,12 +520,16 @@ where
         )
     );
 
-    Ok(StarkProof {
+    let proof = StarkProof {
         trace_cap: trace_commitment.merkle_tree.cap.clone(),
         auxiliary_polys_cap,
         quotient_polys_cap,
         openings,
         opening_proof,
+    };
+    Ok(StarkProofWithMetadata {
+        init_challenger_state,
+        proof,
     })
 }
 

--- a/evm/src/recursive_verifier.rs
+++ b/evm/src/recursive_verifier.rs
@@ -39,7 +39,8 @@ use crate::memory::VALUE_LIMBS;
 use crate::proof::{
     BlockHashes, BlockHashesTarget, BlockMetadata, BlockMetadataTarget, ExtraBlockData,
     ExtraBlockDataTarget, PublicValues, PublicValuesTarget, StarkOpeningSetTarget, StarkProof,
-    StarkProofChallengesTarget, StarkProofTarget, TrieRoots, TrieRootsTarget,
+    StarkProofChallengesTarget, StarkProofTarget, StarkProofWithMetadata, TrieRoots,
+    TrieRootsTarget,
 };
 use crate::stark::Stark;
 use crate::util::{h256_limbs, u256_limbs, u256_to_u32, u256_to_u64};
@@ -146,7 +147,7 @@ where
 
     pub(crate) fn prove(
         &self,
-        proof: &StarkProof<F, C, D>,
+        proof_with_metadata: &StarkProofWithMetadata<F, C, D>,
         ctl_challenges: &GrandProductChallengeSet<F>,
     ) -> Result<ProofWithPublicInputs<F, C, D>> {
         let mut inputs = PartialWitness::new();
@@ -154,7 +155,7 @@ where
         set_stark_proof_target(
             &mut inputs,
             &self.stark_proof_target,
-            proof,
+            &proof_with_metadata.proof,
             self.zero_target,
         );
 
@@ -167,6 +168,11 @@ where
             inputs.set_target(challenge_target.beta, challenge.beta);
             inputs.set_target(challenge_target.gamma, challenge.gamma);
         }
+
+        inputs.set_target_arr(
+            self.init_challenger_state_target.as_ref(),
+            proof_with_metadata.init_challenger_state.as_ref(),
+        );
 
         self.circuit.prove(inputs)
     }

--- a/evm/src/verifier.rs
+++ b/evm/src/verifier.rs
@@ -72,7 +72,7 @@ where
 
     verify_stark_proof_with_challenges(
         arithmetic_stark,
-        &all_proof.stark_proofs[Table::Arithmetic as usize],
+        &all_proof.stark_proofs[Table::Arithmetic as usize].proof,
         &stark_challenges[Table::Arithmetic as usize],
         &ctl_vars_per_table[Table::Arithmetic as usize],
         &ctl_challenges,
@@ -80,7 +80,7 @@ where
     )?;
     verify_stark_proof_with_challenges(
         byte_packing_stark,
-        &all_proof.stark_proofs[Table::BytePacking as usize],
+        &all_proof.stark_proofs[Table::BytePacking as usize].proof,
         &stark_challenges[Table::BytePacking as usize],
         &ctl_vars_per_table[Table::BytePacking as usize],
         &ctl_challenges,
@@ -88,7 +88,7 @@ where
     )?;
     verify_stark_proof_with_challenges(
         cpu_stark,
-        &all_proof.stark_proofs[Table::Cpu as usize],
+        &all_proof.stark_proofs[Table::Cpu as usize].proof,
         &stark_challenges[Table::Cpu as usize],
         &ctl_vars_per_table[Table::Cpu as usize],
         &ctl_challenges,
@@ -96,7 +96,7 @@ where
     )?;
     verify_stark_proof_with_challenges(
         keccak_stark,
-        &all_proof.stark_proofs[Table::Keccak as usize],
+        &all_proof.stark_proofs[Table::Keccak as usize].proof,
         &stark_challenges[Table::Keccak as usize],
         &ctl_vars_per_table[Table::Keccak as usize],
         &ctl_challenges,
@@ -104,7 +104,7 @@ where
     )?;
     verify_stark_proof_with_challenges(
         keccak_sponge_stark,
-        &all_proof.stark_proofs[Table::KeccakSponge as usize],
+        &all_proof.stark_proofs[Table::KeccakSponge as usize].proof,
         &stark_challenges[Table::KeccakSponge as usize],
         &ctl_vars_per_table[Table::KeccakSponge as usize],
         &ctl_challenges,
@@ -112,7 +112,7 @@ where
     )?;
     verify_stark_proof_with_challenges(
         logic_stark,
-        &all_proof.stark_proofs[Table::Logic as usize],
+        &all_proof.stark_proofs[Table::Logic as usize].proof,
         &stark_challenges[Table::Logic as usize],
         &ctl_vars_per_table[Table::Logic as usize],
         &ctl_challenges,
@@ -120,7 +120,7 @@ where
     )?;
     verify_stark_proof_with_challenges(
         memory_stark,
-        &all_proof.stark_proofs[Table::Memory as usize],
+        &all_proof.stark_proofs[Table::Memory as usize].proof,
         &stark_challenges[Table::Memory as usize],
         &ctl_vars_per_table[Table::Memory as usize],
         &ctl_challenges,
@@ -142,7 +142,7 @@ where
         cross_table_lookups,
         all_proof
             .stark_proofs
-            .map(|proof| proof.openings.ctl_zs_first),
+            .map(|p| p.proof.openings.ctl_zs_first),
         extra_looking_sums,
         config,
     )


### PR DESCRIPTION
Oversight from my end, we need to keep track of the initial challenger state for recursion with many tables (consistency check of the challenger across tables), so reverting past PR.