### PR TITLE
Remove risk of panics in interpreter

### DIFF
--- a/evm/src/witness/operation.rs
+++ b/evm/src/witness/operation.rs
@@ -398,7 +398,7 @@ pub(crate) fn generate_set_context<F: Field>(
     };
 
     // If the new stack isn't empty, read stack_top from memory.
-    let new_sp = new_sp.as_usize();
+    let new_sp = u256_to_usize(new_sp)?;
     if new_sp > 0 {
         // Set up columns to disable the channel if it *is* empty.
         let new_sp_field = F::from_canonical_usize(new_sp);


### PR DESCRIPTION
Now that the interpreter is aimed at being used for `jumpdest_analysis`, and soon for continuations, we need to alleviate the remaining risks of `panic` that can occur.