### PR TITLE
Fix nightly build (ahash issue)

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install nightly toolchain
-        uses: dtolnay/rust-toolchain@nightly-2024-02-01
+        uses: dtolnay/rust-toolchain@nightly
 
       - name: Set up rust cache
         uses: Swatinem/rust-cache@v2
@@ -77,7 +77,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install nightly toolchain
-        uses: dtolnay/rust-toolchain@nightly-2024-02-01
+        uses: dtolnay/rust-toolchain@nightly
         with:
           targets: wasm32-unknown-unknown
 
@@ -147,7 +147,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install nightly toolchain
-        uses: dtolnay/rust-toolchain@nightly-2024-02-01
+        uses: dtolnay/rust-toolchain@nightly
         with:
           components: rustfmt, clippy
 

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -28,9 +28,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install nightly toolchain
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: nightly-2024-02-01
+        uses: dtolnay/rust-toolchain@nightly-2024-02-01
 
       - name: Set up rust cache
         uses: Swatinem/rust-cache@v2
@@ -79,9 +77,8 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install nightly toolchain
-        uses: dtolnay/rust-toolchain@master
+        uses: dtolnay/rust-toolchain@nightly-2024-02-01
         with:
-          toolchain: nightly-2024-02-01
           targets: wasm32-unknown-unknown
 
       - name: Set up rust cache
@@ -150,9 +147,8 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install nightly toolchain
-        uses: dtolnay/rust-toolchain@master
+        uses: dtolnay/rust-toolchain@nightly-2024-02-01
         with:
-          toolchain: nightly-2024-02-01
           components: rustfmt, clippy
 
       - name: Set up rust cache

--- a/field/src/lib.rs
+++ b/field/src/lib.rs
@@ -3,7 +3,6 @@
 #![allow(clippy::type_complexity)]
 #![allow(clippy::len_without_is_empty)]
 #![allow(clippy::needless_range_loop)]
-#![feature(stdsimd)]
 #![feature(specialization)]
 #![cfg_attr(not(test), no_std)]
 

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,1 +1,1 @@
-nightly-2024-02-01
+nightly


### PR DESCRIPTION
- Revert "Fix workflow"
- Revert "Fix nightly version"
- chore: remove stdsimd feature req (stabilized)

Likely requires an updated Cargo.lock file. 
