### PR TITLE
Implement `Default` for `DefaultGateSerializer` and `DefaultGeneratorSerializer`

### DIFF
--- a/plonky2/examples/bench_recursion.rs
+++ b/plonky2/examples/bench_recursion.rs
@@ -275,7 +275,7 @@ fn test_serialization<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, 
         CompressedProofWithPublicInputs::from_bytes(compressed_proof_bytes, common_data)?;
     assert_eq!(compressed_proof, compressed_proof_from_bytes);
 
-    let gate_serializer = DefaultGateSerializer;
+    let gate_serializer = DefaultGateSerializer::default();
     let common_data_bytes = common_data
         .to_bytes(&gate_serializer)
         .map_err(|_| anyhow::Error::msg("CommonCircuitData serialization failed."))?;

--- a/plonky2/examples/bench_recursion.rs
+++ b/plonky2/examples/bench_recursion.rs
@@ -275,7 +275,7 @@ fn test_serialization<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, 
         CompressedProofWithPublicInputs::from_bytes(compressed_proof_bytes, common_data)?;
     assert_eq!(compressed_proof, compressed_proof_from_bytes);
 
-    let gate_serializer = DefaultGateSerializer::default();
+    let gate_serializer = DefaultGateSerializer;
     let common_data_bytes = common_data
         .to_bytes(&gate_serializer)
         .map_err(|_| anyhow::Error::msg("CommonCircuitData serialization failed."))?;

--- a/plonky2/examples/square_root.rs
+++ b/plonky2/examples/square_root.rs
@@ -66,16 +66,9 @@ impl<F: RichField + Extendable<D>, const D: usize> SimpleGenerator<F, D>
     }
 }
 
+#[derive(Default)]
 pub struct CustomGeneratorSerializer<C: GenericConfig<D>, const D: usize> {
     pub _phantom: PhantomData<C>,
-}
-
-impl<C: GenericConfig<D>, const D: usize> Default for CustomGeneratorSerializer<C, D> {
-    fn default() -> Self {
-        Self {
-            _phantom: PhantomData::<C>,
-        }
-    }
 }
 
 impl<F, C, const D: usize> WitnessGeneratorSerializer<F, D> for CustomGeneratorSerializer<C, D>

--- a/plonky2/examples/square_root.rs
+++ b/plonky2/examples/square_root.rs
@@ -131,7 +131,7 @@ fn main() -> Result<()> {
 
     // Test serialization
     {
-        let gate_serializer = DefaultGateSerializer::default();
+        let gate_serializer = DefaultGateSerializer;
         let generator_serializer = CustomGeneratorSerializer::<C, D>::default();
 
         let data_bytes = data

--- a/plonky2/examples/square_root.rs
+++ b/plonky2/examples/square_root.rs
@@ -131,7 +131,7 @@ fn main() -> Result<()> {
 
     // Test serialization
     {
-        let gate_serializer = DefaultGateSerializer;
+        let gate_serializer = DefaultGateSerializer::default();
         let generator_serializer = CustomGeneratorSerializer::<C, D>::default();
 
         let data_bytes = data

--- a/plonky2/examples/square_root.rs
+++ b/plonky2/examples/square_root.rs
@@ -70,6 +70,14 @@ pub struct CustomGeneratorSerializer<C: GenericConfig<D>, const D: usize> {
     pub _phantom: PhantomData<C>,
 }
 
+impl<C: GenericConfig<D>, const D: usize> Default for CustomGeneratorSerializer<C, D> {
+    fn default() -> Self {
+        Self {
+            _phantom: PhantomData::<C>,
+        }
+    }
+}
+
 impl<F, C, const D: usize> WitnessGeneratorSerializer<F, D> for CustomGeneratorSerializer<C, D>
 where
     F: RichField + Extendable<D>,
@@ -131,9 +139,7 @@ fn main() -> Result<()> {
     // Test serialization
     {
         let gate_serializer = DefaultGateSerializer;
-        let generator_serializer = CustomGeneratorSerializer {
-            _phantom: PhantomData::<C>,
-        };
+        let generator_serializer = CustomGeneratorSerializer::<C, D>::default();
 
         let data_bytes = data
             .to_bytes(&gate_serializer, &generator_serializer)

--- a/plonky2/src/plonk/config.rs
+++ b/plonky2/src/plonk/config.rs
@@ -106,7 +106,7 @@ pub trait GenericConfig<const D: usize>:
 }
 
 /// Configuration using Poseidon over the Goldilocks field.
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Serialize)]
+#[derive(Debug, Copy, Clone, Default, Eq, PartialEq, Serialize)]
 pub struct PoseidonGoldilocksConfig;
 impl GenericConfig<2> for PoseidonGoldilocksConfig {
     type F = GoldilocksField;
@@ -116,7 +116,7 @@ impl GenericConfig<2> for PoseidonGoldilocksConfig {
 }
 
 /// Configuration using truncated Keccak over the Goldilocks field.
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, Default, Eq, PartialEq)]
 pub struct KeccakGoldilocksConfig;
 impl GenericConfig<2> for KeccakGoldilocksConfig {
     type F = GoldilocksField;

--- a/plonky2/src/util/serialization/gate_serialization.rs
+++ b/plonky2/src/util/serialization/gate_serialization.rs
@@ -123,6 +123,7 @@ pub mod default {
     /// ```
     /// Applications using custom gates should define their own serializer implementing
     /// the `GateSerializer` trait. This can be easily done through the `impl_gate_serializer` macro.
+    #[derive(Default)]
     pub struct DefaultGateSerializer;
     impl<F: RichField + Extendable<D>, const D: usize> GateSerializer<F, D> for DefaultGateSerializer {
         impl_gate_serializer! {

--- a/plonky2/src/util/serialization/gate_serialization.rs
+++ b/plonky2/src/util/serialization/gate_serialization.rs
@@ -114,6 +114,15 @@ pub mod default {
     use crate::hash::hash_types::RichField;
     use crate::util::serialization::GateSerializer;
 
+    /// A gate serializer that can be used to serialize all default gates supported
+    /// by the `plonky2` library.
+    /// Being a unit struct, it can be simply called as
+    /// ```rust
+    /// use plonky2::util::serialization::DefaultGateSerializer;
+    /// let gate_serializer = DefaultGateSerializer;
+    /// ```
+    /// Applications using custom gates should define their own serializer implementing
+    /// the `GateSerializer` trait. This can be easily done through the `impl_gate_serializer` macro.
     pub struct DefaultGateSerializer;
     impl<F: RichField + Extendable<D>, const D: usize> GateSerializer<F, D> for DefaultGateSerializer {
         impl_gate_serializer! {

--- a/plonky2/src/util/serialization/gate_serialization.rs
+++ b/plonky2/src/util/serialization/gate_serialization.rs
@@ -115,14 +115,14 @@ pub mod default {
     use crate::util::serialization::GateSerializer;
 
     /// A gate serializer that can be used to serialize all default gates supported
-    /// by the `plonky2` library. It can simply be called as
+    /// by the `plonky2` library.
+    /// Being a unit struct, it can be simply called as
     /// ```rust
     /// use plonky2::util::serialization::DefaultGateSerializer;
-    /// let gate_serializer = DefaultGateSerializer::default();
+    /// let gate_serializer = DefaultGateSerializer;
     /// ```
     /// Applications using custom gates should define their own serializer implementing
     /// the `GateSerializer` trait. This can be easily done through the `impl_gate_serializer` macro.
-    #[derive(Default)]
     pub struct DefaultGateSerializer;
     impl<F: RichField + Extendable<D>, const D: usize> GateSerializer<F, D> for DefaultGateSerializer {
         impl_gate_serializer! {

--- a/plonky2/src/util/serialization/gate_serialization.rs
+++ b/plonky2/src/util/serialization/gate_serialization.rs
@@ -115,11 +115,10 @@ pub mod default {
     use crate::util::serialization::GateSerializer;
 
     /// A gate serializer that can be used to serialize all default gates supported
-    /// by the `plonky2` library.
-    /// Being a unit struct, it can be simply called as
+    /// by the `plonky2` library. It can simply be called as
     /// ```rust
     /// use plonky2::util::serialization::DefaultGateSerializer;
-    /// let gate_serializer = DefaultGateSerializer;
+    /// let gate_serializer = DefaultGateSerializer::default();
     /// ```
     /// Applications using custom gates should define their own serializer implementing
     /// the `GateSerializer` trait. This can be easily done through the `impl_gate_serializer` macro.

--- a/plonky2/src/util/serialization/generator_serialization.rs
+++ b/plonky2/src/util/serialization/generator_serialization.rs
@@ -128,8 +128,11 @@ pub mod default {
     use crate::util::serialization::WitnessGeneratorSerializer;
 
     /// A generator serializer that can be used to serialize all default generators supported
-    /// by the `plonky2` library.
-    ///
+    /// by the `plonky2` library. It can simply be called as
+    /// ```rust
+    /// use plonky2::util::serialization::DefaultGeneratorSerializer;
+    /// let gate_serializer = DefaultGeneratorSerializer::default();
+    /// ```
     /// Applications using custom generators should define their own serializer implementing
     /// the `WitnessGeneratorSerializer` trait. This can be easily done through the
     /// `impl_generator_serializer` macro.

--- a/plonky2/src/util/serialization/generator_serialization.rs
+++ b/plonky2/src/util/serialization/generator_serialization.rs
@@ -131,7 +131,11 @@ pub mod default {
     /// by the `plonky2` library. It can simply be called as
     /// ```rust
     /// use plonky2::util::serialization::DefaultGeneratorSerializer;
-    /// let generator_serializer = DefaultGeneratorSerializer::default();
+    /// use plonky2::plonk::config::PoseidonGoldilocksConfig;
+    ///
+    /// const D: usize = 2;
+    /// type C = PoseidonGoldilocksConfig;
+    /// let generator_serializer = DefaultGeneratorSerializer::<C, D>::default();
     /// ```
     /// Applications using custom generators should define their own serializer implementing
     /// the `WitnessGeneratorSerializer` trait. This can be easily done through the

--- a/plonky2/src/util/serialization/generator_serialization.rs
+++ b/plonky2/src/util/serialization/generator_serialization.rs
@@ -127,8 +127,22 @@ pub mod default {
     use crate::recursion::dummy_circuit::DummyProofGenerator;
     use crate::util::serialization::WitnessGeneratorSerializer;
 
+    /// A generator serializer that can be used to serialize all default generators supported
+    /// by the `plonky2` library.
+    ///
+    /// Applications using custom generators should define their own serializer implementing
+    /// the `WitnessGeneratorSerializer` trait. This can be easily done through the
+    /// `impl_generator_serializer` macro.
     pub struct DefaultGeneratorSerializer<C: GenericConfig<D>, const D: usize> {
         pub _phantom: PhantomData<C>,
+    }
+
+    impl<C: GenericConfig<D>, const D: usize> Default for DefaultGeneratorSerializer<C, D> {
+        fn default() -> Self {
+            Self {
+                _phantom: PhantomData::<C>,
+            }
+        }
     }
 
     impl<F, C, const D: usize> WitnessGeneratorSerializer<F, D> for DefaultGeneratorSerializer<C, D>

--- a/plonky2/src/util/serialization/generator_serialization.rs
+++ b/plonky2/src/util/serialization/generator_serialization.rs
@@ -133,16 +133,9 @@ pub mod default {
     /// Applications using custom generators should define their own serializer implementing
     /// the `WitnessGeneratorSerializer` trait. This can be easily done through the
     /// `impl_generator_serializer` macro.
+    #[derive(Default)]
     pub struct DefaultGeneratorSerializer<C: GenericConfig<D>, const D: usize> {
         pub _phantom: PhantomData<C>,
-    }
-
-    impl<C: GenericConfig<D>, const D: usize> Default for DefaultGeneratorSerializer<C, D> {
-        fn default() -> Self {
-            Self {
-                _phantom: PhantomData::<C>,
-            }
-        }
     }
 
     impl<F, C, const D: usize> WitnessGeneratorSerializer<F, D> for DefaultGeneratorSerializer<C, D>

--- a/plonky2/src/util/serialization/generator_serialization.rs
+++ b/plonky2/src/util/serialization/generator_serialization.rs
@@ -131,7 +131,7 @@ pub mod default {
     /// by the `plonky2` library. It can simply be called as
     /// ```rust
     /// use plonky2::util::serialization::DefaultGeneratorSerializer;
-    /// let gate_serializer = DefaultGeneratorSerializer::default();
+    /// let generator_serializer = DefaultGeneratorSerializer::default();
     /// ```
     /// Applications using custom generators should define their own serializer implementing
     /// the `WitnessGeneratorSerializer` trait. This can be easily done through the


### PR DESCRIPTION
Following suggestion from @cpubot, to not have to rely on the internals of the serializers when instantiating them for higher-level applications.