### PR TITLE
Fix clippy for `maybe_rayon`

### DIFF
--- a/maybe_rayon/src/lib.rs
+++ b/maybe_rayon/src/lib.rs
@@ -16,7 +16,7 @@ use rayon::{
     prelude::*,
     slice::{
         Chunks as ParChunks, ChunksExact as ParChunksExact, ChunksExactMut as ParChunksExactMut,
-        ChunksMut as ParChunksMut, ParallelSlice, ParallelSliceMut,
+        ChunksMut as ParChunksMut,
     },
 };
 #[cfg(not(feature = "parallel"))]


### PR DESCRIPTION
Latest nightly is detecting that rayon::prelude already re-exports `ParallelSlice, ParallelSliceMut` from `rayon::slice`, making clippy to complain about double import.

Detected when merging #1534 to main.