### PR TITLE
Add mention to versions for local dependencies

### DIFF
--- a/field/Cargo.toml
+++ b/field/Cargo.toml
@@ -20,7 +20,7 @@ static_assertions = { workspace = true }
 unroll = { workspace = true }
 
 # Local dependencies
-plonky2_util = { path = "../util", default-features = false }
+plonky2_util = { version = "0.2.0", path = "../util", default-features = false }
 
 
 # Display math equations properly in documentation

--- a/plonky2/Cargo.toml
+++ b/plonky2/Cargo.toml
@@ -34,9 +34,9 @@ unroll = { workspace = true }
 web-time = { version = "1.0.0", optional = true }
 
 # Local dependencies
-plonky2_field = { path = "../field", default-features = false }
-plonky2_maybe_rayon = { path = "../maybe_rayon", default-features = false }
-plonky2_util = { path = "../util", default-features = false }
+plonky2_field = { version = "0.2.0", path = "../field", default-features = false }
+plonky2_maybe_rayon = { version = "0.2.0", path = "../maybe_rayon", default-features = false }
+plonky2_util = { version = "0.2.0", path = "../util", default-features = false }
 
 
 [target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]

--- a/starky/Cargo.toml
+++ b/starky/Cargo.toml
@@ -26,9 +26,9 @@ log = { workspace = true }
 num-bigint = { version = "0.4.3", default-features = false }
 
 # Local dependencies
-plonky2 = { path = "../plonky2", default-features = false }
-plonky2_maybe_rayon = { path = "../maybe_rayon", default-features = false }
-plonky2_util = { path = "../util", default-features = false }
+plonky2 = { version = "0.2.0", path = "../plonky2", default-features = false }
+plonky2_maybe_rayon = { version = "0.2.0", path = "../maybe_rayon", default-features = false }
+plonky2_util = { version = "0.2.0", path = "../util", default-features = false }
 
 [dev-dependencies]
 env_logger = { version = "0.9.0", default-features = false }


### PR DESCRIPTION
No concrete change, just adding the versions that were locally used when publishing the latest release, for ease of publishing and clarity.