### PR TITLE
Derive `Default` and `Eq` where possible

### DIFF
--- a/plonky2/Cargo.toml
+++ b/plonky2/Cargo.toml
@@ -37,6 +37,7 @@ web-time = { version = "1.0.0", optional = true }
 plonky2_field = { version = "0.2.1", path = "../field", default-features = false }
 plonky2_maybe_rayon = { version = "0.2.0", path = "../maybe_rayon", default-features = false }
 plonky2_util = { version = "0.2.0", path = "../util", default-features = false }
+derivative = { version = "2.2", features = ["use_core"] }
 
 
 [target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]

--- a/plonky2/src/fri/oracle.rs
+++ b/plonky2/src/fri/oracle.rs
@@ -26,7 +26,8 @@ use crate::util::{log2_strict, reverse_bits, reverse_index_bits_in_place, transp
 pub const SALT_SIZE: usize = 4;
 
 /// Represents a FRI oracle, i.e. a batch of polynomials which have been Merklized.
-#[derive(Eq, PartialEq, Debug)]
+#[derive(Eq, PartialEq, Debug, derivative::Derivative)]
+#[derivative(Default)]
 pub struct PolynomialBatch<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
 {
     pub polynomials: Vec<PolynomialCoeffs<F>>,
@@ -34,20 +35,6 @@ pub struct PolynomialBatch<F: RichField + Extendable<D>, C: GenericConfig<D, F =
     pub degree_log: usize,
     pub rate_bits: usize,
     pub blinding: bool,
-}
-
-impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize> Default
-    for PolynomialBatch<F, C, D>
-{
-    fn default() -> Self {
-        PolynomialBatch {
-            polynomials: Vec::new(),
-            merkle_tree: MerkleTree::default(),
-            degree_log: 0,
-            rate_bits: 0,
-            blinding: false,
-        }
-    }
 }
 
 impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>

--- a/plonky2/src/gates/gate.rs
+++ b/plonky2/src/gates/gate.rs
@@ -265,8 +265,11 @@ impl<T: Gate<F, D>, F: RichField + Extendable<D>, const D: usize> AnyGate<F, D> 
 }
 
 /// A wrapper around an `Arc<AnyGate>` which implements `PartialEq`, `Eq` and `Hash` based on gate IDs.
-#[derive(Clone)]
-pub struct GateRef<F: RichField + Extendable<D>, const D: usize>(pub Arc<dyn AnyGate<F, D>>);
+#[derive(Clone, derivative::Derivative)]
+#[derivative(Eq)]
+pub struct GateRef<F: RichField + Extendable<D>, const D: usize>(
+    #[derivative(Eq(bound = ""))] pub Arc<dyn AnyGate<F, D>>,
+);
 
 impl<F: RichField + Extendable<D>, const D: usize> GateRef<F, D> {
     pub fn new<G: Gate<F, D>>(gate: G) -> GateRef<F, D> {
@@ -285,8 +288,6 @@ impl<F: RichField + Extendable<D>, const D: usize> Hash for GateRef<F, D> {
         self.0.id().hash(state)
     }
 }
-
-impl<F: RichField + Extendable<D>, const D: usize> Eq for GateRef<F, D> {}
 
 impl<F: RichField + Extendable<D>, const D: usize> Debug for GateRef<F, D> {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), Error> {

--- a/plonky2/src/hash/hash_types.rs
+++ b/plonky2/src/hash/hash_types.rs
@@ -18,7 +18,7 @@ impl RichField for GoldilocksField {}
 pub const NUM_HASH_OUT_ELTS: usize = 4;
 
 /// Represents a ~256 bit hash output.
-#[derive(Copy, Clone, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
+#[derive(Copy, Clone, Debug, Default, Eq, PartialEq, Hash, Serialize, Deserialize)]
 #[serde(bound = "")]
 pub struct HashOut<F: Field> {
     pub elements: [F; NUM_HASH_OUT_ELTS],
@@ -103,12 +103,6 @@ impl<F: RichField> GenericHashOut<F> for HashOut<F> {
 
     fn to_vec(&self) -> Vec<F> {
         self.elements.to_vec()
-    }
-}
-
-impl<F: Field> Default for HashOut<F> {
-    fn default() -> Self {
-        Self::ZERO
     }
 }
 

--- a/plonky2/src/hash/merkle_tree.rs
+++ b/plonky2/src/hash/merkle_tree.rs
@@ -15,14 +15,10 @@ use crate::util::log2_strict;
 /// It can be used in place of the root to verify Merkle paths, which are `h` elements shorter.
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 #[serde(bound = "")]
+#[derive(derivative::Derivative)]
+#[derivative(Default)]
 // TODO: Change H to GenericHashOut<F>, since this only cares about the hash, not the hasher.
 pub struct MerkleCap<F: RichField, H: Hasher<F>>(pub Vec<H::Hash>);
-
-impl<F: RichField, H: Hasher<F>> Default for MerkleCap<F, H> {
-    fn default() -> Self {
-        Self(Vec::new())
-    }
-}
 
 impl<F: RichField, H: Hasher<F>> MerkleCap<F, H> {
     pub fn len(&self) -> usize {
@@ -42,7 +38,8 @@ impl<F: RichField, H: Hasher<F>> MerkleCap<F, H> {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, derivative::Derivative)]
+#[derivative(Default(bound = ""))]
 pub struct MerkleTree<F: RichField, H: Hasher<F>> {
     /// The data in the leaves of the Merkle tree.
     pub leaves: Vec<Vec<F>>,
@@ -59,16 +56,6 @@ pub struct MerkleTree<F: RichField, H: Hasher<F>> {
 
     /// The Merkle cap.
     pub cap: MerkleCap<F, H>,
-}
-
-impl<F: RichField, H: Hasher<F>> Default for MerkleTree<F, H> {
-    fn default() -> Self {
-        Self {
-            leaves: Vec::new(),
-            digests: Vec::new(),
-            cap: MerkleCap::default(),
-        }
-    }
 }
 
 fn capacity_up_to_mut<T>(v: &mut Vec<T>, len: usize) -> &mut [MaybeUninit<T>] {


### PR DESCRIPTION
We can't use Rust's default deriving mechanism, until https://github.com/rust-lang/rust/issues/26925 and https://github.com/rust-lang/rust/issues/7671 are fixed.

But fortunately, there's a crate for that.