### PR TITLE
Add stdarch_x86_avx512 feature

### DIFF
--- a/field/src/lib.rs
+++ b/field/src/lib.rs
@@ -4,6 +4,7 @@
 #![deny(rustdoc::broken_intra_doc_links)]
 #![deny(missing_debug_implementations)]
 #![feature(specialization)]
+#![cfg_attr(target_arch = "x86_64", feature(stdarch_x86_avx512))]
 #![cfg_attr(not(test), no_std)]
 #![cfg(not(test))]
 extern crate alloc;


### PR DESCRIPTION
Without this, compiling on AVX512 enabled machine gives an error:

```
error[E0658]: use of unstable library feature 'stdarch_x86_avx512'
```