### PR TITLE
Relax restriction to a single looked table for CTL

### DIFF
--- a/field/src/types.rs
+++ b/field/src/types.rs
@@ -556,6 +556,16 @@ pub trait PrimeField64: PrimeField + Field64 {
 
     fn to_noncanonical_u64(&self) -> u64;
 
+    /// The conversion to a canonical i64 is mostly useful for debugging,
+    /// as it tries to recover 'negative' values for better readability.
+    fn to_canonical_i64(&self) -> i64 {
+        i64::try_from(self.to_canonical_u64()).unwrap_or_else(|_| {
+            i64::try_from(self.neg().to_canonical_u64())
+                .expect("This conversion should never fail.")
+                .neg()
+        })
+    }
+
     #[inline(always)]
     fn to_canonical(&self) -> Self {
         Self::from_canonical_u64(self.to_canonical_u64())

--- a/field/src/types.rs
+++ b/field/src/types.rs
@@ -559,11 +559,12 @@ pub trait PrimeField64: PrimeField + Field64 {
     /// The conversion to a canonical i64 is mostly useful for debugging,
     /// as it tries to recover 'negative' values for better readability.
     fn to_canonical_i64(&self) -> i64 {
-        i64::try_from(self.to_canonical_u64()).unwrap_or_else(|_| {
-            i64::try_from(self.neg().to_canonical_u64())
-                .expect("This conversion should never fail.")
-                .neg()
-        })
+        let x = self.to_canonical_u64();
+        if x < Self::ORDER / 2 {
+            x as i64
+        } else {
+            x.wrapping_sub(Self::ORDER) as i64
+        }
     }
 
     #[inline(always)]

--- a/starky/src/cross_table_lookup.rs
+++ b/starky/src/cross_table_lookup.rs
@@ -337,6 +337,9 @@ pub(crate) fn cross_table_lookup_data<'a, F: RichField, const D: usize, const N:
             looking_tables
                 .iter()
                 .map(|table| table.table)
+                .counts()
+                .into_iter()
+                .sorted()
                 .collect::<Vec<_>>()
         );
         for &challenge in &ctl_challenges.challenges {

--- a/starky/src/cross_table_lookup.rs
+++ b/starky/src/cross_table_lookup.rs
@@ -935,10 +935,9 @@ pub fn verify_cross_table_lookups_circuit<
             );
 
             let looking_zs_sum = builder.add(looking_zs_sum, extra_sum_vec[c]);
-            let zero = builder.zero();
 
             // Verify that the combination of looking table openings is equal to the looked table opening.
-            builder.connect(zero, looking_zs_sum);
+            builder.assert_zero(looking_zs_sum);
         }
     }
     debug_assert!(ctl_zs_openings.iter_mut().all(|iter| iter.next().is_none()));

--- a/starky/src/lookup.rs
+++ b/starky/src/lookup.rs
@@ -10,7 +10,7 @@ use core::ops::Neg;
 
 use itertools::Itertools;
 use num_bigint::BigUint;
-use plonky2::field::batch_util::batch_add_inplace;
+use plonky2::field::batch_util::{batch_add_inplace, batch_multiply_inplace};
 use plonky2::field::extension::{Extendable, FieldExtension};
 use plonky2::field::packed::PackedField;
 use plonky2::field::polynomial::PolynomialValues;
@@ -818,11 +818,7 @@ pub(crate) fn get_helper_cols<F: Field>(
             .collect::<Vec<F>>();
 
         let mut acc = F::batch_multiplicative_inverse(&first_combined);
-        for d in 0..degree {
-            if filter_col[d].is_zero() {
-                acc[d] = F::ZERO;
-            }
-        }
+        batch_multiply_inplace(&mut acc, &filter_col);
 
         for (col, filt) in cols_filts {
             let mut filter_col = Vec::with_capacity(degree);
@@ -839,12 +835,7 @@ pub(crate) fn get_helper_cols<F: Field>(
 
             combined = F::batch_multiplicative_inverse(&combined);
 
-            for d in 0..degree {
-                if filter_col[d].is_zero() {
-                    combined[d] = F::ZERO;
-                }
-            }
-
+            batch_multiply_inplace(&mut acc, &filter_col);
             batch_add_inplace(&mut acc, &combined);
         }
 


### PR DESCRIPTION
EDIT: it's perhaps better to get https://github.com/0xPolygonZero/plonky2/pull/1577 in first, and then I rebase this PR.

In our use of plonky2, we have a few instances where we need both several looked and several looking tables.  Think of these lookups as many-to-many multiplexers, or a kind of bus.  Looking tables can be thought of as pushing values with an obligation to process them onto the bus, looked tables can be seen as pulling values to discharge that obligation.

My first attempt changed from `looked_table` to `looked_tables`, but then I noticed that thanks to logup, we don't need this complication: looked_tables are just looking_tables with negative multiplicities.

Thus we can get a simpler system by just removing `looked_table` completely, and giving people tools to negate the multiplicities of their lookup tables.

We also preserve the old `CrossTableLookup::new`, which applies the negation to the passed `looked_table` automatically to keep the API as compatible as possible.

This PR only touches cross table lookups.  We could do the same for the intra-table lookups in `starky/src/lookup.rs`.  But that's for a separate PR.