### PR TITLE
update 2-adic generator to `0x64fdd1a46201e246`

### DIFF
--- a/field/src/goldilocks_extensions.rs
+++ b/field/src/goldilocks_extensions.rs
@@ -21,8 +21,7 @@ impl Extendable<2> for GoldilocksField {
     // DTH_ROOT = W^((ORDER - 1)/2)
     const DTH_ROOT: Self = Self(18446744069414584320);
 
-    const EXT_MULTIPLICATIVE_GROUP_GENERATOR: [Self; 2] =
-        [Self(0), Self(11713931119993638672)];
+    const EXT_MULTIPLICATIVE_GROUP_GENERATOR: [Self; 2] = [Self(0), Self(11713931119993638672)];
 
     const EXT_POWER_OF_TWO_GENERATOR: [Self; 2] = [Self(0), Self(7226896044987257365)];
 }
@@ -45,12 +44,8 @@ impl Extendable<4> for GoldilocksField {
     // DTH_ROOT = W^((ORDER - 1)/4)
     const DTH_ROOT: Self = Self(281474976710656);
 
-    const EXT_MULTIPLICATIVE_GROUP_GENERATOR: [Self; 4] = [
-        Self(0),
-        Self(8295451483910296135),
-        Self(0),
-        Self(0),
-    ];
+    const EXT_MULTIPLICATIVE_GROUP_GENERATOR: [Self; 4] =
+        [Self(0), Self(8295451483910296135), Self(0), Self(0)];
 
     const EXT_POWER_OF_TWO_GENERATOR: [Self; 4] =
         [Self(0), Self(0), Self(0), Self(17216955519093520442)];

--- a/field/src/goldilocks_extensions.rs
+++ b/field/src/goldilocks_extensions.rs
@@ -22,9 +22,9 @@ impl Extendable<2> for GoldilocksField {
     const DTH_ROOT: Self = Self(18446744069414584320);
 
     const EXT_MULTIPLICATIVE_GROUP_GENERATOR: [Self; 2] =
-        [Self(18081566051660590251), Self(16121475356294670766)];
+        [Self(0), Self(11713931119993638672)];
 
-    const EXT_POWER_OF_TWO_GENERATOR: [Self; 2] = [Self(0), Self(15659105665374529263)];
+    const EXT_POWER_OF_TWO_GENERATOR: [Self; 2] = [Self(0), Self(7226896044987257365)];
 }
 
 impl Mul for QuadraticExtension<GoldilocksField> {
@@ -46,14 +46,14 @@ impl Extendable<4> for GoldilocksField {
     const DTH_ROOT: Self = Self(281474976710656);
 
     const EXT_MULTIPLICATIVE_GROUP_GENERATOR: [Self; 4] = [
-        Self(5024755240244648895),
-        Self(13227474371289740625),
-        Self(3912887029498544536),
-        Self(3900057112666848848),
+        Self(0),
+        Self(8295451483910296135),
+        Self(0),
+        Self(0),
     ];
 
     const EXT_POWER_OF_TWO_GENERATOR: [Self; 4] =
-        [Self(0), Self(0), Self(0), Self(12587610116473453104)];
+        [Self(0), Self(0), Self(0), Self(17216955519093520442)];
 }
 
 impl Mul for QuarticExtension<GoldilocksField> {
@@ -75,11 +75,11 @@ impl Extendable<5> for GoldilocksField {
     const DTH_ROOT: Self = Self(1041288259238279555);
 
     const EXT_MULTIPLICATIVE_GROUP_GENERATOR: [Self; 5] = [
-        Self(2899034827742553394),
-        Self(13012057356839176729),
-        Self(14593811582388663055),
-        Self(7722900811313895436),
-        Self(4557222484695340057),
+        Self(4624713872807171977),
+        Self(381988216716071028),
+        Self(14499722700050429911),
+        Self(4870631734967222356),
+        Self(4518902370426242880),
     ];
 
     const EXT_POWER_OF_TWO_GENERATOR: [Self; 5] = [

--- a/field/src/goldilocks_field.rs
+++ b/field/src/goldilocks_field.rs
@@ -77,14 +77,14 @@ impl Field for GoldilocksField {
     const CHARACTERISTIC_TWO_ADICITY: usize = Self::TWO_ADICITY;
 
     // Sage: `g = GF(p).multiplicative_generator()`
-    const MULTIPLICATIVE_GROUP_GENERATOR: Self = Self(7);
+    const MULTIPLICATIVE_GROUP_GENERATOR: Self = Self(14293326489335486720);
 
     // Sage:
     // ```
     // g_2 = g^((p - 1) / 2^32)
     // g_2.multiplicative_order().factor()
     // ```
-    const POWER_OF_TWO_GENERATOR: Self = Self(1753635133440165772);
+    const POWER_OF_TWO_GENERATOR: Self = Self(7277203076849721926);
 
     const BITS: usize = 64;
 


### PR DESCRIPTION
- this is a first step towards addressing https://github.com/0xPolygonZero/plonky2/issues/850. note that `0x64fdd1a46201e246^(2^30) == 0x1000000000000` holds modulo p, as desired. we don't actually change the FFT in this PR; but this paves the way for that as a future change.
- both [Hermez](https://github.com/0xPolygonHermez/goldilocks/blob/f89eb016830f8c4301482d83691aed22e5a92742/src/goldilocks_base_field.cpp#L44) and [Miden](https://github.com/facebook/winterfell/blob/09525751727a283dfbf5e569a09909b82380e059/math/src/field/f64/mod.rs#L282) already currently use this new generator.

upon changing the main 2^32nd root of unity of Goldilocks, a few auxiliary values also need to change. these include:
- the multiplicative generator [here](https://github.com/benediamond/plonky2/blob/5055681898f327365e59e9b91393dd67192abc2b/field/src/goldilocks_field.rs#L80). this is a generator of Goldilocks' _entire_ multiplicative group of units, which moreover "lifts" the main 2-adic generator above in the sense that `MULTIPLICATIVE_GROUP_GENERATOR^((p - 1) / 2^32) == POWER_OF_TWO_GENERATOR` holds. this isn't too hard to construct; essentially, it amounts to finding a multiplicative generator of $\mathbb{F}_p^*$'s order-(p - 1) / 2^32 subgroup, which is not hard.
- in the extension fields, we need to do something analogous, but for 2-adic generators. for example, in the quadratic extension of Goldilocks given by `X^2 - 7`, we now get 2^33-order 2-adicity; the value [`EXT_POWER_OF_TWO_GENERATOR`](https://github.com/benediamond/plonky2/blob/5055681898f327365e59e9b91393dd67192abc2b/field/src/goldilocks_extensions.rs#L27) needs to be a primitive 2^33nd root of unity which _moreover_ lifts `POWER_OF_TWO_GENERATOR`, in the sense that `EXT_POWER_OF_TWO_GENERATOR^2 = POWER_OF_TWO_GENERATOR`. this is a bit tricky to do; we were able to construct this efficiently using essentially a Pohlig–Hellman-type idea.
- Finally, this 2-adic generator itself also needs to be lifted to a full multiplicative generator `EXT_MULTIPLICATIVE_GROUP_GENERATOR` of $\mathbb{F}_{p^2}^*$, i.e., so that `EXT_MULTIPLICATIVE_GROUP_GENERATOR^((p^2 - 1) / 2^33) == EXT_POWER_OF_TWO_GENERATOR` holds.

we also need to do something analogous for the quartic and quintic extensions.