### PR TITLE
Changes to prepare for dummy segment removal in zk_evm's continuations

### DIFF
--- a/plonky2/src/plonk/circuit_builder.rs
+++ b/plonky2/src/plonk/circuit_builder.rs
@@ -532,7 +532,7 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
     }
 
     /// If `condition`, enforces that two routable `Target` values are equal, using Plonk's permutation argument.
-    pub fn assert_equal_if(&mut self, condition: Target, x: Target, y: Target) {
+    pub fn conditional_assert_eq(&mut self, condition: Target, x: Target, y: Target) {
         let zero = self.zero();
         let diff = self.sub(x, y);
         let constr = self.mul(condition, diff);

--- a/plonky2/src/plonk/circuit_builder.rs
+++ b/plonky2/src/plonk/circuit_builder.rs
@@ -531,6 +531,14 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
         }
     }
 
+    /// If `condition`, enforces that two routable `Target` values are equal, using Plonk's permutation argument.
+    pub fn assert_equal_if(&mut self, condition: Target, x: Target, y: Target) {
+        let zero = self.zero();
+        let diff = self.sub(x, y);
+        let constr = self.mul(condition, diff);
+        self.connect(constr, zero);
+    }
+
     /// Enforces that a routable `Target` value is 0, using Plonk's permutation argument.
     pub fn assert_zero(&mut self, x: Target) {
         let zero = self.zero();

--- a/plonky2/src/recursion/conditional_recursive_verifier.rs
+++ b/plonky2/src/recursion/conditional_recursive_verifier.rs
@@ -34,18 +34,8 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
     {
         let selected_proof =
             self.select_proof_with_pis(condition, proof_with_pis0, proof_with_pis1);
-        let selected_verifier_data = VerifierCircuitTarget {
-            constants_sigmas_cap: self.select_cap(
-                condition,
-                &inner_verifier_data0.constants_sigmas_cap,
-                &inner_verifier_data1.constants_sigmas_cap,
-            ),
-            circuit_digest: self.select_hash(
-                condition,
-                inner_verifier_data0.circuit_digest,
-                inner_verifier_data1.circuit_digest,
-            ),
-        };
+        let selected_verifier_data =
+            self.select_verifier_data(condition, inner_verifier_data0, inner_verifier_data1);
 
         self.verify_proof::<C>(&selected_proof, &selected_verifier_data, inner_common_data);
     }
@@ -177,6 +167,23 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
             .zip_eq(v1)
             .map(|(c0, c1)| self.select_cap(b, c0, c1))
             .collect()
+    }
+
+    /// Computes `if b { vk0 } else { vk1 }`.
+    pub fn select_verifier_data(
+        &mut self,
+        b: BoolTarget,
+        vk0: &VerifierCircuitTarget,
+        vk1: &VerifierCircuitTarget,
+    ) -> VerifierCircuitTarget {
+        VerifierCircuitTarget {
+            constants_sigmas_cap: self.select_cap(
+                b,
+                &vk0.constants_sigmas_cap,
+                &vk1.constants_sigmas_cap,
+            ),
+            circuit_digest: self.select_hash(b, vk0.circuit_digest, vk1.circuit_digest),
+        }
     }
 
     /// Computes `if b { os0 } else { os1 }`.

--- a/plonky2/src/recursion/conditional_recursive_verifier.rs
+++ b/plonky2/src/recursion/conditional_recursive_verifier.rs
@@ -75,7 +75,7 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
     }
 
     /// Computes `if b { proof_with_pis0 } else { proof_with_pis1 }`.
-    fn select_proof_with_pis(
+    pub fn select_proof_with_pis(
         &mut self,
         b: BoolTarget,
         proof_with_pis0: &ProofWithPublicInputsTarget<D>,

--- a/plonky2/src/recursion/dummy_circuit.rs
+++ b/plonky2/src/recursion/dummy_circuit.rs
@@ -121,7 +121,7 @@ pub(crate) fn dummy_circuit<
 }
 
 impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
-    pub(crate) fn dummy_proof_and_vk<C: GenericConfig<D, F = F> + 'static>(
+    pub fn dummy_proof_and_vk<C: GenericConfig<D, F = F> + 'static>(
         &mut self,
         common_data: &CommonCircuitData<F, D>,
     ) -> anyhow::Result<(ProofWithPublicInputsTarget<D>, VerifierCircuitTarget)>
@@ -140,6 +140,22 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
             verifier_data_target: dummy_verifier_data_target.clone(),
             verifier_data: dummy_circuit.verifier_only,
         });
+
+        Ok((dummy_proof_with_pis_target, dummy_verifier_data_target))
+    }
+
+    pub fn dummy_proof_and_vk_no_generator<C: GenericConfig<D, F = F> + 'static>(
+        &mut self,
+        common_data: &CommonCircuitData<F, D>,
+    ) -> anyhow::Result<(ProofWithPublicInputsTarget<D>, VerifierCircuitTarget)>
+    where
+        C::Hasher: AlgebraicHasher<F>,
+    {
+        let dummy_circuit = dummy_circuit::<F, C, D>(common_data);
+        let dummy_proof_with_pis = dummy_proof::<F, C, D>(&dummy_circuit, HashMap::new())?;
+        let dummy_proof_with_pis_target = self.add_virtual_proof_with_pis(common_data);
+        let dummy_verifier_data_target =
+            self.add_virtual_verifier_data(self.config.fri_config.cap_height);
 
         Ok((dummy_proof_with_pis_target, dummy_verifier_data_target))
     }

--- a/plonky2/src/recursion/dummy_circuit.rs
+++ b/plonky2/src/recursion/dummy_circuit.rs
@@ -136,7 +136,7 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
         Ok((dummy_proof_with_pis_target, dummy_verifier_data_target))
     }
 
-    pub fn dummy_proof_and_vk_no_generator<C: GenericConfig<D, F = F> + 'static>(
+    pub fn dummy_proof_and_constant_vk_no_generator<C: GenericConfig<D, F = F> + 'static>(
         &mut self,
         common_data: &CommonCircuitData<F, D>,
     ) -> anyhow::Result<(ProofWithPublicInputsTarget<D>, VerifierCircuitTarget)>
@@ -146,8 +146,7 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
         let dummy_circuit = dummy_circuit::<F, C, D>(common_data);
         let dummy_proof_with_pis = dummy_proof::<F, C, D>(&dummy_circuit, HashMap::new())?;
         let dummy_proof_with_pis_target = self.add_virtual_proof_with_pis(common_data);
-        let dummy_verifier_data_target =
-            self.add_virtual_verifier_data(self.config.fri_config.cap_height);
+        let dummy_verifier_data_target = self.constant_verifier_data(&dummy_circuit.verifier_only);
 
         Ok((dummy_proof_with_pis_target, dummy_verifier_data_target))
     }

--- a/plonky2/src/recursion/dummy_circuit.rs
+++ b/plonky2/src/recursion/dummy_circuit.rs
@@ -144,7 +144,6 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
         C::Hasher: AlgebraicHasher<F>,
     {
         let dummy_circuit = dummy_circuit::<F, C, D>(common_data);
-        let dummy_proof_with_pis = dummy_proof::<F, C, D>(&dummy_circuit, HashMap::new())?;
         let dummy_proof_with_pis_target = self.add_virtual_proof_with_pis(common_data);
         let dummy_verifier_data_target = self.constant_verifier_data(&dummy_circuit.verifier_only);
 

--- a/plonky2/src/recursion/dummy_circuit.rs
+++ b/plonky2/src/recursion/dummy_circuit.rs
@@ -113,7 +113,7 @@ pub fn dummy_circuit<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, c
 }
 
 impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
-    pub fn dummy_proof_and_vk<C: GenericConfig<D, F = F> + 'static>(
+    pub(crate) fn dummy_proof_and_vk<C: GenericConfig<D, F = F> + 'static>(
         &mut self,
         common_data: &CommonCircuitData<F, D>,
     ) -> anyhow::Result<(ProofWithPublicInputsTarget<D>, VerifierCircuitTarget)>

--- a/plonky2/src/recursion/dummy_circuit.rs
+++ b/plonky2/src/recursion/dummy_circuit.rs
@@ -67,11 +67,7 @@ where
 /// Generate a proof for a dummy circuit. The `public_inputs` parameter let the caller specify
 /// certain public inputs (identified by their indices) which should be given specific values.
 /// The rest will default to zero.
-pub(crate) fn dummy_proof<
-    F: RichField + Extendable<D>,
-    C: GenericConfig<D, F = F>,
-    const D: usize,
->(
+pub fn dummy_proof<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>(
     circuit: &CircuitData<F, C, D>,
     nonzero_public_inputs: HashMap<usize, F>,
 ) -> anyhow::Result<ProofWithPublicInputs<F, C, D>>
@@ -86,11 +82,7 @@ where
 }
 
 /// Generate a circuit matching a given `CommonCircuitData`.
-pub(crate) fn dummy_circuit<
-    F: RichField + Extendable<D>,
-    C: GenericConfig<D, F = F>,
-    const D: usize,
->(
+pub fn dummy_circuit<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>(
     common_data: &CommonCircuitData<F, D>,
 ) -> CircuitData<F, C, D> {
     let config = common_data.config.clone();


### PR DESCRIPTION
This PR makes some methods public so they can be used on the `zk_evm` side, and creates a couple of new methods.