### PR TITLE
fix: remove clippy unexpected_cfgs warning

### DIFF
--- a/maybe_rayon/src/lib.rs
+++ b/maybe_rayon/src/lib.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(not(std), no_std)]
+#![no_std]
 
 #[cfg(not(feature = "parallel"))]
 extern crate alloc;


### PR DESCRIPTION
Since `std` doesn't exist as a cfg, `not(std)` was always true, so this does not change any behavior.

```
warning: unexpected `cfg` condition name: `std`
 --> maybe_rayon/src/lib.rs:1:17
  |
1 | #![cfg_attr(not(std), no_std)]
  |                 ^^^
  |
  = help: expected names are: `clippy`, `debug_assertions`, `doc`, `docsrs`, `doctest`, `feature`, `miri`, `overflow_checks`, `panic`, `proc_macro`, `relocation_model`, `rustfmt`, `sanitize`, `sanitizer_cfi_generalize_pointers`, `sanitizer_cfi_normalize_integers`, `target_abi`, `target_arch`, `target_endian`, `target_env`, `target_family`, `target_feature`, `target_has_atomic`, `target_has_atomic_equal_alignment`, `target_has_atomic_load_store`, `target_os`, `target_pointer_width`, `target_thread_local`, `target_vendor`, `test`, `ub_checks`, `unix`, `windows`
  = help: consider using a Cargo feature instead or adding `println!("cargo::rustc-check-cfg=cfg(std)");` to the top of the `build.rs`
  = note: see <https://doc.rust-lang.org/nightly/cargo/reference/build-scripts.html#rustc-check-cfg> for more information about checking conditional configuration
  = note: `#[warn(unexpected_cfgs)]` on by default
```