### PR TITLE
refactor: remove superfluous type parameters

### DIFF
--- a/field/src/extension/mod.rs
+++ b/field/src/extension/mod.rs
@@ -108,6 +108,8 @@ pub trait FieldExtension<const D: usize>: Field {
     }
 }
 
+pub type BaseField<F, const D: usize> = <F as FieldExtension<D>>::BaseField;
+
 impl<F: Field> FieldExtension<1> for F {
     type BaseField = F;
 

--- a/plonky2/examples/square_root.rs
+++ b/plonky2/examples/square_root.rs
@@ -71,21 +71,20 @@ pub struct CustomGeneratorSerializer<C: GenericConfig<D>, const D: usize> {
     pub _phantom: PhantomData<C>,
 }
 
-impl<F, C, const D: usize> WitnessGeneratorSerializer<F, D> for CustomGeneratorSerializer<C, D>
+impl<C, const D: usize> WitnessGeneratorSerializer<C::F, D> for CustomGeneratorSerializer<C, D>
 where
-    F: RichField + Extendable<D>,
-    C: GenericConfig<D, F = F> + 'static,
-    C::Hasher: AlgebraicHasher<F>,
+    C: GenericConfig<D> + 'static,
+    C::Hasher: AlgebraicHasher<C::F>,
 {
     impl_generator_serializer! {
         CustomGeneratorSerializer,
-        DummyProofGenerator<F, C, D>,
-        ArithmeticBaseGenerator<F, D>,
-        ConstantGenerator<F>,
-        PoseidonGenerator<F, D>,
+        DummyProofGenerator<C, D>,
+        ArithmeticBaseGenerator<C::F, D>,
+        ConstantGenerator<C::F>,
+        PoseidonGenerator<C::F, D>,
         PoseidonMdsGenerator<D>,
         RandomValueGenerator,
-        SquareRootGenerator<F, D>
+        SquareRootGenerator<C::F, D>
     }
 }
 
@@ -138,12 +137,9 @@ fn main() -> Result<()> {
             .to_bytes(&gate_serializer, &generator_serializer)
             .map_err(|_| anyhow::Error::msg("CircuitData serialization failed."))?;
 
-        let data_from_bytes = CircuitData::<F, C, D>::from_bytes(
-            &data_bytes,
-            &gate_serializer,
-            &generator_serializer,
-        )
-        .map_err(|_| anyhow::Error::msg("CircuitData deserialization failed."))?;
+        let data_from_bytes =
+            CircuitData::<C, D>::from_bytes(&data_bytes, &gate_serializer, &generator_serializer)
+                .map_err(|_| anyhow::Error::msg("CircuitData deserialization failed."))?;
 
         assert_eq!(data, data_from_bytes);
     }

--- a/plonky2/src/fri/validate_shape.rs
+++ b/plonky2/src/fri/validate_shape.rs
@@ -1,22 +1,16 @@
 use anyhow::ensure;
 
-use crate::field::extension::Extendable;
 use crate::fri::proof::{FriProof, FriQueryRound, FriQueryStep};
 use crate::fri::structure::FriInstanceInfo;
 use crate::fri::FriParams;
-use crate::hash::hash_types::RichField;
 use crate::plonk::config::GenericConfig;
 use crate::plonk::plonk_common::salt_size;
 
-pub(crate) fn validate_fri_proof_shape<F, C, const D: usize>(
-    proof: &FriProof<F, C::Hasher, D>,
-    instance: &FriInstanceInfo<F, D>,
+pub(crate) fn validate_fri_proof_shape<C: GenericConfig<D>, const D: usize>(
+    proof: &FriProof<C::F, C::Hasher, D>,
+    instance: &FriInstanceInfo<C::F, D>,
     params: &FriParams,
-) -> anyhow::Result<()>
-where
-    F: RichField + Extendable<D>,
-    C: GenericConfig<D, F = F>,
-{
+) -> anyhow::Result<()> {
     let FriProof {
         commit_phase_merkle_caps,
         query_round_proofs,

--- a/plonky2/src/gates/arithmetic_base.rs
+++ b/plonky2/src/gates/arithmetic_base.rs
@@ -253,7 +253,7 @@ mod tests {
     use crate::gates::arithmetic_base::ArithmeticGate;
     use crate::gates::gate_testing::{test_eval_fns, test_low_degree};
     use crate::plonk::circuit_data::CircuitConfig;
-    use crate::plonk::config::{GenericConfig, PoseidonGoldilocksConfig};
+    use crate::plonk::config::PoseidonGoldilocksConfig;
 
     #[test]
     fn low_degree() {
@@ -265,8 +265,7 @@ mod tests {
     fn eval_fns() -> Result<()> {
         const D: usize = 2;
         type C = PoseidonGoldilocksConfig;
-        type F = <C as GenericConfig<D>>::F;
         let gate = ArithmeticGate::new_from_config(&CircuitConfig::standard_recursion_config());
-        test_eval_fns::<F, C, _, D>(gate)
+        test_eval_fns::<C, _, D>(gate)
     }
 }

--- a/plonky2/src/gates/arithmetic_extension.rs
+++ b/plonky2/src/gates/arithmetic_extension.rs
@@ -246,7 +246,7 @@ mod tests {
     use crate::gates::arithmetic_extension::ArithmeticExtensionGate;
     use crate::gates::gate_testing::{test_eval_fns, test_low_degree};
     use crate::plonk::circuit_data::CircuitConfig;
-    use crate::plonk::config::{GenericConfig, PoseidonGoldilocksConfig};
+    use crate::plonk::config::PoseidonGoldilocksConfig;
 
     #[test]
     fn low_degree() {
@@ -259,9 +259,8 @@ mod tests {
     fn eval_fns() -> Result<()> {
         const D: usize = 2;
         type C = PoseidonGoldilocksConfig;
-        type F = <C as GenericConfig<D>>::F;
         let gate =
             ArithmeticExtensionGate::new_from_config(&CircuitConfig::standard_recursion_config());
-        test_eval_fns::<F, C, _, D>(gate)
+        test_eval_fns::<C, _, D>(gate)
     }
 }

--- a/plonky2/src/gates/base_sum.rs
+++ b/plonky2/src/gates/base_sum.rs
@@ -229,7 +229,7 @@ mod tests {
     use crate::field::goldilocks_field::GoldilocksField;
     use crate::gates::base_sum::BaseSumGate;
     use crate::gates::gate_testing::{test_eval_fns, test_low_degree};
-    use crate::plonk::config::{GenericConfig, PoseidonGoldilocksConfig};
+    use crate::plonk::config::PoseidonGoldilocksConfig;
 
     #[test]
     fn low_degree() {
@@ -240,7 +240,6 @@ mod tests {
     fn eval_fns() -> Result<()> {
         const D: usize = 2;
         type C = PoseidonGoldilocksConfig;
-        type F = <C as GenericConfig<D>>::F;
-        test_eval_fns::<F, C, _, D>(BaseSumGate::<6>::new(11))
+        test_eval_fns::<C, _, D>(BaseSumGate::<6>::new(11))
     }
 }

--- a/plonky2/src/gates/constant.rs
+++ b/plonky2/src/gates/constant.rs
@@ -137,7 +137,7 @@ mod tests {
     use crate::gates::constant::ConstantGate;
     use crate::gates::gate_testing::{test_eval_fns, test_low_degree};
     use crate::plonk::circuit_data::CircuitConfig;
-    use crate::plonk::config::{GenericConfig, PoseidonGoldilocksConfig};
+    use crate::plonk::config::PoseidonGoldilocksConfig;
 
     #[test]
     fn low_degree() {
@@ -150,9 +150,8 @@ mod tests {
     fn eval_fns() -> Result<()> {
         const D: usize = 2;
         type C = PoseidonGoldilocksConfig;
-        type F = <C as GenericConfig<D>>::F;
         let num_consts = CircuitConfig::standard_recursion_config().num_constants;
         let gate = ConstantGate { num_consts };
-        test_eval_fns::<F, C, _, D>(gate)
+        test_eval_fns::<C, _, D>(gate)
     }
 }

--- a/plonky2/src/gates/coset_interpolation.rs
+++ b/plonky2/src/gates/coset_interpolation.rs
@@ -788,9 +788,8 @@ mod tests {
     fn eval_fns() -> Result<()> {
         const D: usize = 2;
         type C = PoseidonGoldilocksConfig;
-        type F = <C as GenericConfig<D>>::F;
         for degree in 2..=4 {
-            test_eval_fns::<F, C, _, D>(CosetInterpolationGate::with_max_degree(2, degree))?;
+            test_eval_fns::<C, _, D>(CosetInterpolationGate::with_max_degree(2, degree))?;
         }
         Ok(())
     }

--- a/plonky2/src/gates/exponentiation.rs
+++ b/plonky2/src/gates/exponentiation.rs
@@ -357,8 +357,7 @@ mod tests {
     fn eval_fns() -> Result<()> {
         const D: usize = 2;
         type C = PoseidonGoldilocksConfig;
-        type F = <C as GenericConfig<D>>::F;
-        test_eval_fns::<F, C, _, D>(ExponentiationGate::new_from_config(
+        test_eval_fns::<C, _, D>(ExponentiationGate::new_from_config(
             &CircuitConfig::standard_recursion_config(),
         ))
     }

--- a/plonky2/src/gates/multiplication_extension.rs
+++ b/plonky2/src/gates/multiplication_extension.rs
@@ -215,7 +215,7 @@ mod tests {
     use super::*;
     use crate::field::goldilocks_field::GoldilocksField;
     use crate::gates::gate_testing::{test_eval_fns, test_low_degree};
-    use crate::plonk::config::{GenericConfig, PoseidonGoldilocksConfig};
+    use crate::plonk::config::PoseidonGoldilocksConfig;
 
     #[test]
     fn low_degree() {
@@ -227,8 +227,7 @@ mod tests {
     fn eval_fns() -> Result<()> {
         const D: usize = 2;
         type C = PoseidonGoldilocksConfig;
-        type F = <C as GenericConfig<D>>::F;
         let gate = MulExtensionGate::new_from_config(&CircuitConfig::standard_recursion_config());
-        test_eval_fns::<F, C, _, D>(gate)
+        test_eval_fns::<C, _, D>(gate)
     }
 }

--- a/plonky2/src/gates/noop.rs
+++ b/plonky2/src/gates/noop.rs
@@ -74,7 +74,7 @@ mod tests {
     use crate::field::goldilocks_field::GoldilocksField;
     use crate::gates::gate_testing::{test_eval_fns, test_low_degree};
     use crate::gates::noop::NoopGate;
-    use crate::plonk::config::{GenericConfig, PoseidonGoldilocksConfig};
+    use crate::plonk::config::PoseidonGoldilocksConfig;
 
     #[test]
     fn low_degree() {
@@ -85,7 +85,6 @@ mod tests {
     fn eval_fns() -> anyhow::Result<()> {
         const D: usize = 2;
         type C = PoseidonGoldilocksConfig;
-        type F = <C as GenericConfig<D>>::F;
-        test_eval_fns::<F, C, _, D>(NoopGate)
+        test_eval_fns::<C, _, D>(NoopGate)
     }
 }

--- a/plonky2/src/gates/poseidon.rs
+++ b/plonky2/src/gates/poseidon.rs
@@ -632,6 +632,6 @@ mod tests {
         type C = PoseidonGoldilocksConfig;
         type F = <C as GenericConfig<D>>::F;
         let gate = PoseidonGate::<F, 2>::new();
-        test_eval_fns::<F, C, _, D>(gate)
+        test_eval_fns::<C, _, D>(gate)
     }
 }

--- a/plonky2/src/gates/poseidon_mds.rs
+++ b/plonky2/src/gates/poseidon_mds.rs
@@ -290,6 +290,6 @@ mod tests {
         type C = PoseidonGoldilocksConfig;
         type F = <C as GenericConfig<D>>::F;
         let gate = PoseidonMdsGate::<F, D>::new();
-        test_eval_fns::<F, C, _, D>(gate)
+        test_eval_fns::<C, _, D>(gate)
     }
 }

--- a/plonky2/src/gates/public_input.rs
+++ b/plonky2/src/gates/public_input.rs
@@ -118,7 +118,7 @@ mod tests {
     use crate::field::goldilocks_field::GoldilocksField;
     use crate::gates::gate_testing::{test_eval_fns, test_low_degree};
     use crate::gates::public_input::PublicInputGate;
-    use crate::plonk::config::{GenericConfig, PoseidonGoldilocksConfig};
+    use crate::plonk::config::PoseidonGoldilocksConfig;
 
     #[test]
     fn low_degree() {
@@ -129,7 +129,6 @@ mod tests {
     fn eval_fns() -> anyhow::Result<()> {
         const D: usize = 2;
         type C = PoseidonGoldilocksConfig;
-        type F = <C as GenericConfig<D>>::F;
-        test_eval_fns::<F, C, _, D>(PublicInputGate)
+        test_eval_fns::<C, _, D>(PublicInputGate)
     }
 }

--- a/plonky2/src/gates/random_access.rs
+++ b/plonky2/src/gates/random_access.rs
@@ -434,8 +434,7 @@ mod tests {
     fn eval_fns() -> Result<()> {
         const D: usize = 2;
         type C = PoseidonGoldilocksConfig;
-        type F = <C as GenericConfig<D>>::F;
-        test_eval_fns::<F, C, _, D>(RandomAccessGate::new(4, 4, 1))
+        test_eval_fns::<C, _, D>(RandomAccessGate::new(4, 4, 1))
     }
 
     #[test]

--- a/plonky2/src/gates/reducing.rs
+++ b/plonky2/src/gates/reducing.rs
@@ -249,7 +249,7 @@ mod tests {
     use crate::field::goldilocks_field::GoldilocksField;
     use crate::gates::gate_testing::{test_eval_fns, test_low_degree};
     use crate::gates::reducing::ReducingGate;
-    use crate::plonk::config::{GenericConfig, PoseidonGoldilocksConfig};
+    use crate::plonk::config::PoseidonGoldilocksConfig;
 
     #[test]
     fn low_degree() {
@@ -260,7 +260,6 @@ mod tests {
     fn eval_fns() -> Result<()> {
         const D: usize = 2;
         type C = PoseidonGoldilocksConfig;
-        type F = <C as GenericConfig<D>>::F;
-        test_eval_fns::<F, C, _, D>(ReducingGate::new(22))
+        test_eval_fns::<C, _, D>(ReducingGate::new(22))
     }
 }

--- a/plonky2/src/gates/reducing_extension.rs
+++ b/plonky2/src/gates/reducing_extension.rs
@@ -243,7 +243,7 @@ mod tests {
     use crate::field::goldilocks_field::GoldilocksField;
     use crate::gates::gate_testing::{test_eval_fns, test_low_degree};
     use crate::gates::reducing_extension::ReducingExtensionGate;
-    use crate::plonk::config::{GenericConfig, PoseidonGoldilocksConfig};
+    use crate::plonk::config::PoseidonGoldilocksConfig;
 
     #[test]
     fn low_degree() {
@@ -254,7 +254,6 @@ mod tests {
     fn eval_fns() -> Result<()> {
         const D: usize = 2;
         type C = PoseidonGoldilocksConfig;
-        type F = <C as GenericConfig<D>>::F;
-        test_eval_fns::<F, C, _, D>(ReducingExtensionGate::new(22))
+        test_eval_fns::<C, _, D>(ReducingExtensionGate::new(22))
     }
 }

--- a/plonky2/src/hash/merkle_tree.rs
+++ b/plonky2/src/hash/merkle_tree.rs
@@ -229,7 +229,6 @@ mod tests {
     use anyhow::Result;
 
     use super::*;
-    use crate::field::extension::Extendable;
     use crate::hash::merkle_proofs::verify_merkle_proof_to_cap;
     use crate::plonk::config::{GenericConfig, PoseidonGoldilocksConfig};
 
@@ -238,14 +237,13 @@ mod tests {
     }
 
     fn verify_all_leaves<
-        F: RichField + Extendable<D>,
-        C: GenericConfig<D, F = F>,
+        C: GenericConfig<D>,
         const D: usize,
     >(
-        leaves: Vec<Vec<F>>,
+        leaves: Vec<Vec<C::F>>,
         cap_height: usize,
     ) -> Result<()> {
-        let tree = MerkleTree::<F, C::Hasher>::new(leaves.clone(), cap_height);
+        let tree = MerkleTree::<C::F, C::Hasher>::new(leaves.clone(), cap_height);
         for (i, leaf) in leaves.into_iter().enumerate() {
             let proof = tree.prove(i);
             verify_merkle_proof_to_cap(leaf, i, &tree.cap, &proof)?;
@@ -277,7 +275,7 @@ mod tests {
         let n = 1 << log_n;
         let leaves = random_data::<F>(n, 7);
 
-        verify_all_leaves::<F, C, D>(leaves, log_n)?;
+        verify_all_leaves::<C, D>(leaves, log_n)?;
 
         Ok(())
     }
@@ -292,7 +290,7 @@ mod tests {
         let n = 1 << log_n;
         let leaves = random_data::<F>(n, 7);
 
-        verify_all_leaves::<F, C, D>(leaves, 1)?;
+        verify_all_leaves::<C, D>(leaves, 1)?;
 
         Ok(())
     }

--- a/plonky2/src/hash/merkle_tree.rs
+++ b/plonky2/src/hash/merkle_tree.rs
@@ -236,10 +236,7 @@ mod tests {
         (0..n).map(|_| F::rand_vec(k)).collect()
     }
 
-    fn verify_all_leaves<
-        C: GenericConfig<D>,
-        const D: usize,
-    >(
+    fn verify_all_leaves<C: GenericConfig<D>, const D: usize>(
         leaves: Vec<Vec<C::F>>,
         cap_height: usize,
     ) -> Result<()> {

--- a/plonky2/src/hash/poseidon.rs
+++ b/plonky2/src/hash/poseidon.rs
@@ -8,7 +8,7 @@ use core::fmt::Debug;
 use plonky2_field::packed::PackedField;
 use unroll::unroll_for_loops;
 
-use crate::field::extension::{Extendable, FieldExtension};
+use crate::field::extension::{Extendable, FieldExtension, BaseField};
 use crate::field::types::{Field, PrimeField64};
 use crate::gates::gate::Gate;
 use crate::gates::poseidon::PoseidonGate;
@@ -217,18 +217,16 @@ pub trait Poseidon: PrimeField64 {
 
     /// Same as `mds_row_shf` for `PackedField`.
     fn mds_row_shf_packed_field<
-        F: RichField + Extendable<D>,
         const D: usize,
-        FE,
-        P,
+        P: PackedField,
         const D2: usize,
     >(
         r: usize,
         v: &[P; SPONGE_WIDTH],
     ) -> P
     where
-        FE: FieldExtension<D2, BaseField = F>,
-        P: PackedField<Scalar = FE>,
+        BaseField<P::Scalar, D2>: RichField + Extendable<D>,
+        P::Scalar: FieldExtension<D2>,
     {
         debug_assert!(r < SPONGE_WIDTH);
         let mut res = P::ZEROS;
@@ -304,17 +302,15 @@ pub trait Poseidon: PrimeField64 {
 
     /// Same as `mds_layer` for `PackedField`.
     fn mds_layer_packed_field<
-        F: RichField + Extendable<D>,
         const D: usize,
-        FE,
-        P,
+        P: PackedField,
         const D2: usize,
     >(
         state: &[P; SPONGE_WIDTH],
     ) -> [P; SPONGE_WIDTH]
     where
-        FE: FieldExtension<D2, BaseField = F>,
-        P: PackedField<Scalar = FE>,
+        BaseField<P::Scalar, D2>: RichField + Extendable<D>,
+        P::Scalar: FieldExtension<D2>,
     {
         let mut result = [P::ZEROS; SPONGE_WIDTH];
 
@@ -376,16 +372,14 @@ pub trait Poseidon: PrimeField64 {
     #[inline(always)]
     #[unroll_for_loops]
     fn partial_first_constant_layer_packed_field<
-        F: RichField + Extendable<D>,
         const D: usize,
-        FE,
-        P,
+        P: PackedField,
         const D2: usize,
     >(
         state: &mut [P; SPONGE_WIDTH],
     ) where
-        FE: FieldExtension<D2, BaseField = F>,
-        P: PackedField<Scalar = FE>,
+        BaseField<P::Scalar, D2>: RichField + Extendable<D>,
+        P::Scalar: FieldExtension<D2>,
     {
         for i in 0..12 {
             if i < SPONGE_WIDTH {
@@ -444,17 +438,15 @@ pub trait Poseidon: PrimeField64 {
     #[inline(always)]
     #[unroll_for_loops]
     fn mds_partial_layer_init_packed_field<
-        F: RichField + Extendable<D>,
         const D: usize,
-        FE,
-        P,
+        P: PackedField,
         const D2: usize,
     >(
         state: &[P; SPONGE_WIDTH],
     ) -> [P; SPONGE_WIDTH]
     where
-        FE: FieldExtension<D2, BaseField = F>,
-        P: PackedField<Scalar = FE>,
+        BaseField<P::Scalar, D2>: RichField + Extendable<D>,
+        P::Scalar: FieldExtension<D2>,
     {
         let mut result = [P::ZEROS; SPONGE_WIDTH];
 
@@ -566,18 +558,16 @@ pub trait Poseidon: PrimeField64 {
 
     /// Same as `mds_partial_layer_fast` for `PackedField.
     fn mds_partial_layer_fast_packed_field<
-        F: RichField + Extendable<D>,
         const D: usize,
-        FE,
-        P,
+        P: PackedField,
         const D2: usize,
     >(
         state: &[P; SPONGE_WIDTH],
         r: usize,
     ) -> [P; SPONGE_WIDTH]
     where
-        FE: FieldExtension<D2, BaseField = F>,
-        P: PackedField<Scalar = FE>,
+        BaseField<P::Scalar, D2>: RichField + Extendable<D>,
+        P::Scalar: FieldExtension<D2>,
     {
         let s0 = state[0];
         let mds0to0 = Self::MDS_MATRIX_CIRC[0] + Self::MDS_MATRIX_DIAG[0];
@@ -652,17 +642,15 @@ pub trait Poseidon: PrimeField64 {
 
     /// Same as `constant_layer` for PackedFields.
     fn constant_layer_packed_field<
-        F: RichField + Extendable<D>,
         const D: usize,
-        FE,
-        P,
+        P: PackedField,
         const D2: usize,
     >(
         state: &mut [P; SPONGE_WIDTH],
         round_ctr: usize,
     ) where
-        FE: FieldExtension<D2, BaseField = F>,
-        P: PackedField<Scalar = FE>,
+        BaseField<P::Scalar, D2>: RichField + Extendable<D>,
+        P::Scalar: FieldExtension<D2>,
     {
         for i in 0..SPONGE_WIDTH {
             state[i] +=

--- a/plonky2/src/hash/poseidon.rs
+++ b/plonky2/src/hash/poseidon.rs
@@ -8,7 +8,7 @@ use core::fmt::Debug;
 use plonky2_field::packed::PackedField;
 use unroll::unroll_for_loops;
 
-use crate::field::extension::{Extendable, FieldExtension, BaseField};
+use crate::field::extension::{BaseField, Extendable, FieldExtension};
 use crate::field::types::{Field, PrimeField64};
 use crate::gates::gate::Gate;
 use crate::gates::poseidon::PoseidonGate;
@@ -216,11 +216,7 @@ pub trait Poseidon: PrimeField64 {
     }
 
     /// Same as `mds_row_shf` for `PackedField`.
-    fn mds_row_shf_packed_field<
-        const D: usize,
-        P: PackedField,
-        const D2: usize,
-    >(
+    fn mds_row_shf_packed_field<const D: usize, P: PackedField, const D2: usize>(
         r: usize,
         v: &[P; SPONGE_WIDTH],
     ) -> P
@@ -301,11 +297,7 @@ pub trait Poseidon: PrimeField64 {
     }
 
     /// Same as `mds_layer` for `PackedField`.
-    fn mds_layer_packed_field<
-        const D: usize,
-        P: PackedField,
-        const D2: usize,
-    >(
+    fn mds_layer_packed_field<const D: usize, P: PackedField, const D2: usize>(
         state: &[P; SPONGE_WIDTH],
     ) -> [P; SPONGE_WIDTH]
     where
@@ -371,11 +363,7 @@ pub trait Poseidon: PrimeField64 {
     /// Same as `partial_first_constant_layer` for `PackedField`.
     #[inline(always)]
     #[unroll_for_loops]
-    fn partial_first_constant_layer_packed_field<
-        const D: usize,
-        P: PackedField,
-        const D2: usize,
-    >(
+    fn partial_first_constant_layer_packed_field<const D: usize, P: PackedField, const D2: usize>(
         state: &mut [P; SPONGE_WIDTH],
     ) where
         BaseField<P::Scalar, D2>: RichField + Extendable<D>,
@@ -437,11 +425,7 @@ pub trait Poseidon: PrimeField64 {
     /// Same as `mds_partial_layer_init` for `PackedField`.
     #[inline(always)]
     #[unroll_for_loops]
-    fn mds_partial_layer_init_packed_field<
-        const D: usize,
-        P: PackedField,
-        const D2: usize,
-    >(
+    fn mds_partial_layer_init_packed_field<const D: usize, P: PackedField, const D2: usize>(
         state: &[P; SPONGE_WIDTH],
     ) -> [P; SPONGE_WIDTH]
     where
@@ -557,11 +541,7 @@ pub trait Poseidon: PrimeField64 {
     }
 
     /// Same as `mds_partial_layer_fast` for `PackedField.
-    fn mds_partial_layer_fast_packed_field<
-        const D: usize,
-        P: PackedField,
-        const D2: usize,
-    >(
+    fn mds_partial_layer_fast_packed_field<const D: usize, P: PackedField, const D2: usize>(
         state: &[P; SPONGE_WIDTH],
         r: usize,
     ) -> [P; SPONGE_WIDTH]
@@ -641,11 +621,7 @@ pub trait Poseidon: PrimeField64 {
     }
 
     /// Same as `constant_layer` for PackedFields.
-    fn constant_layer_packed_field<
-        const D: usize,
-        P: PackedField,
-        const D2: usize,
-    >(
+    fn constant_layer_packed_field<const D: usize, P: PackedField, const D2: usize>(
         state: &mut [P; SPONGE_WIDTH],
         round_ctr: usize,
     ) where

--- a/plonky2/src/iop/generator.rs
+++ b/plonky2/src/iop/generator.rs
@@ -21,16 +21,11 @@ use crate::util::serialization::{Buffer, IoResult, Read, Write};
 
 /// Given a `PartitionWitness` that has only inputs set, populates the rest of the witness using the
 /// given set of generators.
-pub fn generate_partial_witness<
-    'a,
-    F: RichField + Extendable<D>,
-    C: GenericConfig<D, F = F>,
-    const D: usize,
->(
-    inputs: PartialWitness<F>,
-    prover_data: &'a ProverOnlyCircuitData<F, C, D>,
-    common_data: &'a CommonCircuitData<F, D>,
-) -> PartitionWitness<'a, F> {
+pub fn generate_partial_witness<'a, C: GenericConfig<D>, const D: usize>(
+    inputs: PartialWitness<C::F>,
+    prover_data: &'a ProverOnlyCircuitData<C, D>,
+    common_data: &'a CommonCircuitData<C::F, D>,
+) -> PartitionWitness<'a, C::F> {
     let config = &common_data.config;
     let generators = &prover_data.generators;
     let generator_indices_by_watches = &prover_data.generator_indices_by_watches;

--- a/plonky2/src/iop/witness.rs
+++ b/plonky2/src/iop/witness.rs
@@ -72,7 +72,7 @@ pub trait WitnessWrite<F: Field> {
     fn set_proof_with_pis_target<C: GenericConfig<D, F = F>, const D: usize>(
         &mut self,
         proof_with_pis_target: &ProofWithPublicInputsTarget<D>,
-        proof_with_pis: &ProofWithPublicInputs<F, C, D>,
+        proof_with_pis: &ProofWithPublicInputs<C, D>,
     ) where
         F: RichField + Extendable<D>,
         C::Hasher: AlgebraicHasher<F>,
@@ -98,7 +98,7 @@ pub trait WitnessWrite<F: Field> {
     fn set_proof_target<C: GenericConfig<D, F = F>, const D: usize>(
         &mut self,
         proof_target: &ProofTarget<D>,
-        proof: &Proof<F, C, D>,
+        proof: &Proof<C, D>,
     ) where
         F: RichField + Extendable<D>,
         C::Hasher: AlgebraicHasher<F>,

--- a/plonky2/src/plonk/circuit_builder.rs
+++ b/plonky2/src/plonk/circuit_builder.rs
@@ -1040,7 +1040,7 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
     pub fn build_with_options<C: GenericConfig<D, F = F>>(
         self,
         commit_to_sigma: bool,
-    ) -> CircuitData<F, C, D> {
+    ) -> CircuitData<C, D> {
         let (circuit_data, success) = self.try_build_with_options(commit_to_sigma);
         if !success {
             panic!("Failed to build circuit");
@@ -1051,7 +1051,7 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
     pub fn try_build_with_options<C: GenericConfig<D, F = F>>(
         mut self,
         commit_to_sigma: bool,
-    ) -> (CircuitData<F, C, D>, bool) {
+    ) -> (CircuitData<C, D>, bool) {
         let mut timing = TimingTree::new("preprocess", Level::Trace);
 
         #[cfg(feature = "std")]
@@ -1160,7 +1160,7 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
 
         let constants_sigmas_commitment = if commit_to_sigma {
             let constants_sigmas_vecs = [constant_vecs, sigma_vecs.clone()].concat();
-            PolynomialBatch::<F, C, D>::from_values(
+            PolynomialBatch::<C, D>::from_values(
                 constants_sigmas_vecs,
                 rate_bits,
                 PlonkOracle::CONSTANTS_SIGMAS.blinding,
@@ -1169,7 +1169,7 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
                 Some(&fft_root_table),
             )
         } else {
-            PolynomialBatch::<F, C, D>::default()
+            PolynomialBatch::<C, D>::default()
         };
 
         // Map between gates where not all generators are used and the gate's number of used generators.
@@ -1267,7 +1267,7 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
             }
         }
 
-        let prover_only = ProverOnlyCircuitData::<F, C, D> {
+        let prover_only = ProverOnlyCircuitData::<C, D> {
             generators: self.generators,
             generator_indices_by_watches,
             constants_sigmas_commitment,
@@ -1300,11 +1300,11 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
     }
 
     /// Builds a "full circuit", with both prover and verifier data.
-    pub fn build<C: GenericConfig<D, F = F>>(self) -> CircuitData<F, C, D> {
+    pub fn build<C: GenericConfig<D, F = F>>(self) -> CircuitData<C, D> {
         self.build_with_options(true)
     }
 
-    pub fn mock_build<C: GenericConfig<D, F = F>>(self) -> MockCircuitData<F, C, D> {
+    pub fn mock_build<C: GenericConfig<D, F = F>>(self) -> MockCircuitData<C, D> {
         let circuit_data = self.build_with_options(false);
         MockCircuitData {
             prover_only: circuit_data.prover_only,
@@ -1312,14 +1312,14 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
         }
     }
     /// Builds a "prover circuit", with data needed to generate proofs but not verify them.
-    pub fn build_prover<C: GenericConfig<D, F = F>>(self) -> ProverCircuitData<F, C, D> {
+    pub fn build_prover<C: GenericConfig<D, F = F>>(self) -> ProverCircuitData<C, D> {
         // TODO: Can skip parts of this.
         let circuit_data = self.build::<C>();
         circuit_data.prover_data()
     }
 
     /// Builds a "verifier circuit", with data needed to verify proofs but not generate them.
-    pub fn build_verifier<C: GenericConfig<D, F = F>>(self) -> VerifierCircuitData<F, C, D> {
+    pub fn build_verifier<C: GenericConfig<D, F = F>>(self) -> VerifierCircuitData<C, D> {
         // TODO: Can skip parts of this.
         let circuit_data = self.build::<C>();
         circuit_data.verifier_data()

--- a/plonky2/src/plonk/validate_shape.rs
+++ b/plonky2/src/plonk/validate_shape.rs
@@ -1,18 +1,15 @@
 use anyhow::ensure;
 
-use crate::field::extension::Extendable;
-use crate::hash::hash_types::RichField;
 use crate::plonk::circuit_data::CommonCircuitData;
 use crate::plonk::config::GenericConfig;
 use crate::plonk::proof::{OpeningSet, Proof, ProofWithPublicInputs};
 
-pub(crate) fn validate_proof_with_pis_shape<F, C, const D: usize>(
-    proof_with_pis: &ProofWithPublicInputs<F, C, D>,
-    common_data: &CommonCircuitData<F, D>,
+pub(crate) fn validate_proof_with_pis_shape<C, const D: usize>(
+    proof_with_pis: &ProofWithPublicInputs<C, D>,
+    common_data: &CommonCircuitData<C::F, D>,
 ) -> anyhow::Result<()>
 where
-    F: RichField + Extendable<D>,
-    C: GenericConfig<D, F = F>,
+    C: GenericConfig<D>,
 {
     let ProofWithPublicInputs {
         proof,
@@ -26,14 +23,10 @@ where
     Ok(())
 }
 
-fn validate_proof_shape<F, C, const D: usize>(
-    proof: &Proof<F, C, D>,
-    common_data: &CommonCircuitData<F, D>,
-) -> anyhow::Result<()>
-where
-    F: RichField + Extendable<D>,
-    C: GenericConfig<D, F = F>,
-{
+fn validate_proof_shape<C: GenericConfig<D>, const D: usize>(
+    proof: &Proof<C, D>,
+    common_data: &CommonCircuitData<C::F, D>,
+) -> anyhow::Result<()> {
     let config = &common_data.config;
     let Proof {
         wires_cap,

--- a/plonky2/src/recursion/cyclic_recursion.rs
+++ b/plonky2/src/recursion/cyclic_recursion.rs
@@ -213,10 +213,7 @@ mod tests {
     use crate::recursion::dummy_circuit::cyclic_base_proof;
 
     // Generates `CommonCircuitData` usable for recursion.
-    fn common_data_for_recursion<
-        C: GenericConfig<D>,
-        const D: usize,
-    >() -> CommonCircuitData<C::F, D>
+    fn common_data_for_recursion<C: GenericConfig<D>, const D: usize>() -> CommonCircuitData<C::F, D>
     where
         C::Hasher: AlgebraicHasher<C::F>,
     {

--- a/plonky2/src/recursion/recursive_verifier.rs
+++ b/plonky2/src/recursion/recursive_verifier.rs
@@ -31,7 +31,7 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
         );
         let public_inputs_hash =
             self.hash_n_to_hash_no_pad::<C::InnerHasher>(proof_with_pis.public_inputs.clone());
-        let challenges = proof_with_pis.get_challenges::<F, C>(
+        let challenges = proof_with_pis.get_challenges::<C>(
             self,
             public_inputs_hash,
             inner_verifier_data.circuit_digest,
@@ -207,6 +207,7 @@ mod tests {
     use log::{info, Level};
 
     use super::*;
+    use crate::field::types::Field;
     use crate::fri::reduction_strategies::FriReductionStrategy;
     use crate::fri::FriConfig;
     use crate::gadgets::lookup::{OTHER_TABLE, TIP5_TABLE};
@@ -224,12 +225,11 @@ mod tests {
         init_logger();
         const D: usize = 2;
         type C = PoseidonGoldilocksConfig;
-        type F = <C as GenericConfig<D>>::F;
         let config = CircuitConfig::standard_recursion_zk_config();
 
-        let (proof, vd, common_data) = dummy_proof::<F, C, D>(&config, 4_000)?;
+        let (proof, vd, common_data) = dummy_proof::<C, D>(&config, 4_000)?;
         let (proof, vd, common_data) =
-            recursive_proof::<F, C, C, D>(proof, vd, common_data, &config, None, true, true)?;
+            recursive_proof::<C, C, D>(proof, vd, common_data, &config, None, true, true)?;
         test_serialization(&proof, &vd, &common_data)?;
 
         Ok(())
@@ -240,12 +240,11 @@ mod tests {
         init_logger();
         const D: usize = 2;
         type C = PoseidonGoldilocksConfig;
-        type F = <C as GenericConfig<D>>::F;
         let config = CircuitConfig::standard_recursion_zk_config();
 
-        let (proof, vd, common_data) = dummy_lookup_proof::<F, C, D>(&config, 10)?;
+        let (proof, vd, common_data) = dummy_lookup_proof::<C, D>(&config, 10)?;
         let (proof, vd, common_data) =
-            recursive_proof::<F, C, C, D>(proof, vd, common_data, &config, None, true, true)?;
+            recursive_proof::<C, C, D>(proof, vd, common_data, &config, None, true, true)?;
         test_serialization(&proof, &vd, &common_data)?;
 
         Ok(())
@@ -256,12 +255,11 @@ mod tests {
         init_logger();
         const D: usize = 2;
         type C = PoseidonGoldilocksConfig;
-        type F = <C as GenericConfig<D>>::F;
         let config = CircuitConfig::standard_recursion_config();
 
-        let (proof, vd, common_data) = dummy_two_luts_proof::<F, C, D>(&config)?;
+        let (proof, vd, common_data) = dummy_two_luts_proof::<C, D>(&config)?;
         let (proof, vd, common_data) =
-            recursive_proof::<F, C, C, D>(proof, vd, common_data, &config, None, true, true)?;
+            recursive_proof::<C, C, D>(proof, vd, common_data, &config, None, true, true)?;
         test_serialization(&proof, &vd, &common_data)?;
 
         Ok(())
@@ -272,12 +270,11 @@ mod tests {
         init_logger();
         const D: usize = 2;
         type C = PoseidonGoldilocksConfig;
-        type F = <C as GenericConfig<D>>::F;
         let config = CircuitConfig::standard_recursion_config();
 
-        let (proof, vd, common_data) = dummy_too_many_rows_proof::<F, C, D>(&config)?;
+        let (proof, vd, common_data) = dummy_too_many_rows_proof::<C, D>(&config)?;
         let (proof, vd, common_data) =
-            recursive_proof::<F, C, C, D>(proof, vd, common_data, &config, None, true, true)?;
+            recursive_proof::<C, C, D>(proof, vd, common_data, &config, None, true, true)?;
         test_serialization(&proof, &vd, &common_data)?;
 
         Ok(())
@@ -288,22 +285,21 @@ mod tests {
         init_logger();
         const D: usize = 2;
         type C = PoseidonGoldilocksConfig;
-        type F = <C as GenericConfig<D>>::F;
 
         let config = CircuitConfig::standard_recursion_config();
 
         // Start with a degree 2^14 proof
-        let (proof, vd, common_data) = dummy_proof::<F, C, D>(&config, 16_000)?;
+        let (proof, vd, common_data) = dummy_proof::<C, D>(&config, 16_000)?;
         assert_eq!(common_data.degree_bits(), 14);
 
         // Shrink it to 2^13.
         let (proof, vd, common_data) =
-            recursive_proof::<F, C, C, D>(proof, vd, common_data, &config, Some(13), false, false)?;
+            recursive_proof::<C, C, D>(proof, vd, common_data, &config, Some(13), false, false)?;
         assert_eq!(common_data.degree_bits(), 13);
 
         // Shrink it to 2^12.
         let (proof, vd, common_data) =
-            recursive_proof::<F, C, C, D>(proof, vd, common_data, &config, None, true, true)?;
+            recursive_proof::<C, C, D>(proof, vd, common_data, &config, None, true, true)?;
         assert_eq!(common_data.degree_bits(), 12);
 
         test_serialization(&proof, &vd, &common_data)?;
@@ -320,16 +316,15 @@ mod tests {
         const D: usize = 2;
         type C = PoseidonGoldilocksConfig;
         type KC = KeccakGoldilocksConfig;
-        type F = <C as GenericConfig<D>>::F;
 
         let standard_config = CircuitConfig::standard_recursion_config();
 
         // An initial dummy proof.
-        let (proof, vd, common_data) = dummy_proof::<F, C, D>(&standard_config, 4_000)?;
+        let (proof, vd, common_data) = dummy_proof::<C, D>(&standard_config, 4_000)?;
         assert_eq!(common_data.degree_bits(), 12);
 
         // A standard recursive proof.
-        let (proof, vd, common_data) = recursive_proof::<F, C, C, D>(
+        let (proof, vd, common_data) = recursive_proof::<C, C, D>(
             proof,
             vd,
             common_data,
@@ -350,7 +345,7 @@ mod tests {
             },
             ..standard_config
         };
-        let (proof, vd, common_data) = recursive_proof::<F, C, C, D>(
+        let (proof, vd, common_data) = recursive_proof::<C, C, D>(
             proof,
             vd,
             common_data,
@@ -373,15 +368,8 @@ mod tests {
             },
             ..high_rate_config
         };
-        let (proof, vd, common_data) = recursive_proof::<F, KC, C, D>(
-            proof,
-            vd,
-            common_data,
-            &final_config,
-            None,
-            true,
-            true,
-        )?;
+        let (proof, vd, common_data) =
+            recursive_proof::<KC, C, D>(proof, vd, common_data, &final_config, None, true, true)?;
         assert_eq!(common_data.degree_bits(), 12, "final proof too large");
 
         test_serialization(&proof, &vd, &common_data)?;
@@ -395,34 +383,33 @@ mod tests {
         const D: usize = 2;
         type PC = PoseidonGoldilocksConfig;
         type KC = KeccakGoldilocksConfig;
-        type F = <PC as GenericConfig<D>>::F;
 
         let config = CircuitConfig::standard_recursion_config();
-        let (proof, vd, common_data) = dummy_proof::<F, PC, D>(&config, 4_000)?;
+        let (proof, vd, common_data) = dummy_proof::<PC, D>(&config, 4_000)?;
 
         let (proof, vd, common_data) =
-            recursive_proof::<F, PC, PC, D>(proof, vd, common_data, &config, None, false, false)?;
+            recursive_proof::<PC, PC, D>(proof, vd, common_data, &config, None, false, false)?;
         test_serialization(&proof, &vd, &common_data)?;
 
         let (proof, vd, common_data) =
-            recursive_proof::<F, KC, PC, D>(proof, vd, common_data, &config, None, false, false)?;
+            recursive_proof::<KC, PC, D>(proof, vd, common_data, &config, None, false, false)?;
         test_serialization(&proof, &vd, &common_data)?;
 
         Ok(())
     }
 
-    type Proof<F, C, const D: usize> = (
-        ProofWithPublicInputs<F, C, D>,
+    type Proof<C, const D: usize> = (
+        ProofWithPublicInputs<C, D>,
         VerifierOnlyCircuitData<C, D>,
-        CommonCircuitData<F, D>,
+        CommonCircuitData<<C as GenericConfig<D>>::F, D>,
     );
 
     /// Creates a dummy proof which should have roughly `num_dummy_gates` gates.
-    fn dummy_proof<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>(
+    fn dummy_proof<C: GenericConfig<D>, const D: usize>(
         config: &CircuitConfig,
         num_dummy_gates: u64,
-    ) -> Result<Proof<F, C, D>> {
-        let mut builder = CircuitBuilder::<F, D>::new(config.clone());
+    ) -> Result<Proof<C, D>> {
+        let mut builder = CircuitBuilder::<C::F, D>::new(config.clone());
         for _ in 0..num_dummy_gates {
             builder.add_gate(NoopGate, vec![]);
         }
@@ -436,15 +423,11 @@ mod tests {
     }
 
     /// Creates a dummy lookup proof which does one lookup to one LUT.
-    fn dummy_lookup_proof<
-        F: RichField + Extendable<D>,
-        C: GenericConfig<D, F = F>,
-        const D: usize,
-    >(
+    fn dummy_lookup_proof<C: GenericConfig<D>, const D: usize>(
         config: &CircuitConfig,
         num_dummy_gates: u64,
-    ) -> Result<Proof<F, C, D>> {
-        let mut builder = CircuitBuilder::<F, D>::new(config.clone());
+    ) -> Result<Proof<C, D>> {
+        let mut builder = CircuitBuilder::<C::F, D>::new(config.clone());
         let initial_a = builder.add_virtual_target();
         let initial_b = builder.add_virtual_target();
 
@@ -473,19 +456,19 @@ mod tests {
 
         let data = builder.build::<C>();
         let mut inputs = PartialWitness::new();
-        inputs.set_target(initial_a, F::from_canonical_usize(look_val_a));
-        inputs.set_target(initial_b, F::from_canonical_usize(look_val_b));
+        inputs.set_target(initial_a, C::F::from_canonical_usize(look_val_a));
+        inputs.set_target(initial_b, C::F::from_canonical_usize(look_val_b));
 
         let proof = data.prove(inputs)?;
         data.verify(proof.clone())?;
 
         assert!(
-            proof.public_inputs[2] == F::from_canonical_u16(out_a),
+            proof.public_inputs[2] == C::F::from_canonical_u16(out_a),
             "First lookup, at index {} in the Tip5 table gives an incorrect output.",
             proof.public_inputs[0]
         );
         assert!(
-            proof.public_inputs[3] == F::from_canonical_u16(out_b),
+            proof.public_inputs[3] == C::F::from_canonical_u16(out_b),
             "Second lookup, at index {} in the Tip5 table gives an incorrect output.",
             proof.public_inputs[1]
         );
@@ -494,14 +477,10 @@ mod tests {
     }
 
     /// Creates a dummy lookup proof which does one lookup to two different LUTs.
-    fn dummy_two_luts_proof<
-        F: RichField + Extendable<D>,
-        C: GenericConfig<D, F = F>,
-        const D: usize,
-    >(
+    fn dummy_two_luts_proof<C: GenericConfig<D>, const D: usize>(
         config: &CircuitConfig,
-    ) -> Result<Proof<F, C, D>> {
-        let mut builder = CircuitBuilder::<F, D>::new(config.clone());
+    ) -> Result<Proof<C, D>> {
+        let mut builder = CircuitBuilder::<C::F, D>::new(config.clone());
         let initial_a = builder.add_virtual_target();
         let initial_b = builder.add_virtual_target();
 
@@ -540,29 +519,29 @@ mod tests {
         builder.register_public_input(output_final);
 
         let mut pw = PartialWitness::new();
-        pw.set_target(initial_a, F::ONE);
-        pw.set_target(initial_b, F::TWO);
+        pw.set_target(initial_a, C::F::ONE);
+        pw.set_target(initial_b, C::F::TWO);
 
         let data = builder.build::<C>();
         let proof = data.prove(pw)?;
         data.verify(proof.clone())?;
 
         assert!(
-            proof.public_inputs[3] == F::from_canonical_u16(first_out),
+            proof.public_inputs[3] == C::F::from_canonical_u16(first_out),
             "First lookup, at index {} in the Tip5 table gives an incorrect output.",
             proof.public_inputs[0]
         );
         assert!(
-            proof.public_inputs[4] == F::from_canonical_u16(second_out),
+            proof.public_inputs[4] == C::F::from_canonical_u16(second_out),
             "Second lookup, at index {} in the Tip5 table gives an incorrect output.",
             proof.public_inputs[1]
         );
         assert!(
-            proof.public_inputs[2] == F::from_canonical_u16(s),
+            proof.public_inputs[2] == C::F::from_canonical_u16(s),
             "Sum between the first two LUT outputs is incorrect."
         );
         assert!(
-            proof.public_inputs[5] == F::from_canonical_u16(final_out),
+            proof.public_inputs[5] == C::F::from_canonical_u16(final_out),
             "Output of the second LUT at index {} is incorrect.",
             s
         );
@@ -571,14 +550,10 @@ mod tests {
     }
 
     /// Creates a dummy proof which has more than 256 lookups to one LUT.
-    fn dummy_too_many_rows_proof<
-        F: RichField + Extendable<D>,
-        C: GenericConfig<D, F = F>,
-        const D: usize,
-    >(
+    fn dummy_too_many_rows_proof<C: GenericConfig<D>, const D: usize>(
         config: &CircuitConfig,
-    ) -> Result<Proof<F, C, D>> {
-        let mut builder = CircuitBuilder::<F, D>::new(config.clone());
+    ) -> Result<Proof<C, D>> {
+        let mut builder = CircuitBuilder::<C::F, D>::new(config.clone());
 
         let initial_a = builder.add_virtual_target();
         let initial_b = builder.add_virtual_target();
@@ -606,18 +581,18 @@ mod tests {
 
         let mut pw = PartialWitness::new();
 
-        pw.set_target(initial_a, F::from_canonical_usize(look_val_a));
-        pw.set_target(initial_b, F::from_canonical_usize(look_val_b));
+        pw.set_target(initial_a, C::F::from_canonical_usize(look_val_a));
+        pw.set_target(initial_b, C::F::from_canonical_usize(look_val_b));
 
         let data = builder.build::<C>();
         let proof = data.prove(pw)?;
         assert!(
-            proof.public_inputs[2] == F::from_canonical_u16(out_b),
+            proof.public_inputs[2] == C::F::from_canonical_u16(out_b),
             "First lookup, at index {} in the Tip5 table gives an incorrect output.",
             proof.public_inputs[1]
         );
         assert!(
-            proof.public_inputs[3] == F::from_canonical_u16(out_a),
+            proof.public_inputs[3] == C::F::from_canonical_u16(out_a),
             "Lookups at index {} in the Tip5 table gives an incorrect output.",
             proof.public_inputs[0]
         );
@@ -626,24 +601,19 @@ mod tests {
         Ok((proof, data.verifier_only, data.common))
     }
 
-    fn recursive_proof<
-        F: RichField + Extendable<D>,
-        C: GenericConfig<D, F = F>,
-        InnerC: GenericConfig<D, F = F>,
-        const D: usize,
-    >(
-        inner_proof: ProofWithPublicInputs<F, InnerC, D>,
+    fn recursive_proof<C: GenericConfig<D>, InnerC: GenericConfig<D, F = C::F>, const D: usize>(
+        inner_proof: ProofWithPublicInputs<InnerC, D>,
         inner_vd: VerifierOnlyCircuitData<InnerC, D>,
-        inner_cd: CommonCircuitData<F, D>,
+        inner_cd: CommonCircuitData<C::F, D>,
         config: &CircuitConfig,
         min_degree_bits: Option<usize>,
         print_gate_counts: bool,
         print_timing: bool,
-    ) -> Result<Proof<F, C, D>>
+    ) -> Result<Proof<C, D>>
     where
-        InnerC::Hasher: AlgebraicHasher<F>,
+        InnerC::Hasher: AlgebraicHasher<C::F>,
     {
-        let mut builder = CircuitBuilder::<F, D>::new(config.clone());
+        let mut builder = CircuitBuilder::<C::F, D>::new(config.clone());
         let mut pw = PartialWitness::new();
         let pt = builder.add_virtual_proof_with_pis(&inner_cd);
         pw.set_proof_with_pis_target(&pt, &inner_proof);
@@ -685,14 +655,10 @@ mod tests {
     }
 
     /// Test serialization and print some size info.
-    fn test_serialization<
-        F: RichField + Extendable<D>,
-        C: GenericConfig<D, F = F>,
-        const D: usize,
-    >(
-        proof: &ProofWithPublicInputs<F, C, D>,
+    fn test_serialization<C: GenericConfig<D>, const D: usize>(
+        proof: &ProofWithPublicInputs<C, D>,
         vd: &VerifierOnlyCircuitData<C, D>,
-        common_data: &CommonCircuitData<F, D>,
+        common_data: &CommonCircuitData<C::F, D>,
     ) -> Result<()> {
         let proof_bytes = proof.to_bytes();
         info!("Proof length: {} bytes", proof_bytes.len());

--- a/plonky2/src/util/reducing.rs
+++ b/plonky2/src/util/reducing.rs
@@ -37,14 +37,13 @@ impl<F: Field> ReducingFactor<F> {
         self.base * x
     }
 
-    fn mul_ext<FE, P, const D: usize>(&mut self, x: P) -> P
+    fn mul_ext<P: PackedField, const D: usize>(&mut self, x: P) -> P
     where
-        FE: FieldExtension<D, BaseField = F>,
-        P: PackedField<Scalar = FE>,
+        P::Scalar: FieldExtension<D, BaseField = F>,
     {
         self.count += 1;
-        // TODO: Would like to use `FE::scalar_mul`, but it doesn't work with Packed currently.
-        x * FE::from_basefield(self.base)
+        // TODO: Would like to use `FieldExtension::scalar_mul`, but it doesn't work with Packed currently.
+        x * P::Scalar::from_basefield(self.base)
     }
 
     fn mul_poly(&mut self, p: &mut PolynomialCoeffs<F>) {
@@ -57,13 +56,12 @@ impl<F: Field> ReducingFactor<F> {
             .fold(F::ZERO, |acc, x| self.mul(acc) + *x.borrow())
     }
 
-    pub fn reduce_ext<FE, P, const D: usize>(
+    pub fn reduce_ext<P: PackedField, const D: usize>(
         &mut self,
         iter: impl DoubleEndedIterator<Item = impl Borrow<P>>,
     ) -> P
     where
-        FE: FieldExtension<D, BaseField = F>,
-        P: PackedField<Scalar = FE>,
+        P::Scalar: FieldExtension<D, BaseField = F>,
     {
         iter.rev()
             .fold(P::ZEROS, |acc, x| self.mul_ext(acc) + *x.borrow())

--- a/starky/src/lib.rs
+++ b/starky/src/lib.rs
@@ -78,22 +78,20 @@
 //! const PUBLIC_INPUTS: usize = 3;
 //!
 //! impl<F: RichField + Extendable<D>, const D: usize> Stark<F, D> for FibonacciStark<F, D> {
-//!     type EvaluationFrame<FE, P, const D2: usize> = StarkFrame<P, P::Scalar, COLUMNS, PUBLIC_INPUTS>
+//!     type EvaluationFrame<P: PackedField, const D2: usize> = StarkFrame<P, P::Scalar, COLUMNS, PUBLIC_INPUTS>
 //!     where
-//!         FE: FieldExtension<D2, BaseField = F>,
-//!         P: PackedField<Scalar = FE>;
+//!         P::Scalar: FieldExtension<D2, BaseField = F>;
 //!
 //!     type EvaluationFrameTarget =
 //!         StarkFrame<ExtensionTarget<D>, ExtensionTarget<D>, COLUMNS, PUBLIC_INPUTS>;
 //!
 //!     // Define this STARK's constraints.
-//!     fn eval_packed_generic<FE, P, const D2: usize>(
+//!     fn eval_packed_generic<P: PackedField, const D2: usize>(
 //!         &self,
-//!         vars: &Self::EvaluationFrame<FE, P, D2>,
+//!         vars: &Self::EvaluationFrame<P, D2>,
 //!         yield_constr: &mut ConstraintConsumer<P>,
 //!     ) where
-//!         FE: FieldExtension<D2, BaseField = F>,
-//!         P: PackedField<Scalar = FE>,
+//!         P::Scalar: FieldExtension<D2, BaseField = F>
 //!     {
 //!         let local_values = vars.get_local_values();
 //!         let next_values = vars.get_next_values();
@@ -216,20 +214,18 @@
 //! # const COLUMNS: usize = 3;
 //! # const PUBLIC_INPUTS: usize = 3;
 //! # impl<F: RichField + Extendable<D>, const D: usize> Stark<F, D> for FibonacciStark<F, D> {
-//! #     type EvaluationFrame<FE, P, const D2: usize> = StarkFrame<P, P::Scalar, COLUMNS, PUBLIC_INPUTS>
+//! #     type EvaluationFrame<P: PackedField, const D2: usize> = StarkFrame<P, P::Scalar, COLUMNS, PUBLIC_INPUTS>
 //! #     where
-//! #         FE: FieldExtension<D2, BaseField = F>,
-//! #         P: PackedField<Scalar = FE>;
+//! #         P::Scalar: FieldExtension<D2, BaseField = F>;
 //! #     type EvaluationFrameTarget =
 //! #         StarkFrame<ExtensionTarget<D>, ExtensionTarget<D>, COLUMNS, PUBLIC_INPUTS>;
 //! #     // Define this STARK's constraints.
-//! #     fn eval_packed_generic<FE, P, const D2: usize>(
+//! #     fn eval_packed_generic<P: PackedField, const D2: usize>(
 //! #         &self,
-//! #         vars: &Self::EvaluationFrame<FE, P, D2>,
+//! #         vars: &Self::EvaluationFrame<P, D2>,
 //! #         yield_constr: &mut ConstraintConsumer<P>,
 //! #     ) where
-//! #         FE: FieldExtension<D2, BaseField = F>,
-//! #         P: PackedField<Scalar = FE>,
+//! #         P::Scalar: FieldExtension<D2, BaseField = F>,
 //! #     {
 //! #         let local_values = vars.get_local_values();
 //! #         let next_values = vars.get_next_values();
@@ -297,7 +293,7 @@
 //!     let stark = FibonacciStark::<F, D>::new(num_rows);
 //!     let trace = stark.generate_trace(public_inputs[0], public_inputs[1]);
 //!
-//!     let proof = prove::<F, C, S, D>(
+//!     let proof = prove::<C, S, D>(
 //!         stark,
 //!         &CONFIG,
 //!         trace,

--- a/starky/src/permutation_stark.rs
+++ b/starky/src/permutation_stark.rs
@@ -55,10 +55,9 @@ const PERM_COLUMNS: usize = 3;
 const PERM_PUBLIC_INPUTS: usize = 1;
 
 impl<F: RichField + Extendable<D>, const D: usize> Stark<F, D> for PermutationStark<F, D> {
-    type EvaluationFrame<FE, P, const D2: usize> = StarkFrame<P, P::Scalar, PERM_COLUMNS, PERM_PUBLIC_INPUTS>
+    type EvaluationFrame<P: PackedField, const D2: usize> = StarkFrame<P, P::Scalar, PERM_COLUMNS, PERM_PUBLIC_INPUTS>
     where
-        FE: FieldExtension<D2, BaseField = F>,
-        P: PackedField<Scalar = FE>;
+        P::Scalar: FieldExtension<D2, BaseField = F>;
 
     type EvaluationFrameTarget =
         StarkFrame<ExtensionTarget<D>, ExtensionTarget<D>, PERM_COLUMNS, PERM_PUBLIC_INPUTS>;
@@ -77,13 +76,12 @@ impl<F: RichField + Extendable<D>, const D: usize> Stark<F, D> for PermutationSt
     }
 
     // We don't constrain any register, for the sake of highlighting the permutation argument only.
-    fn eval_packed_generic<FE, P, const D2: usize>(
+    fn eval_packed_generic<P: PackedField, const D2: usize>(
         &self,
-        _vars: &Self::EvaluationFrame<FE, P, D2>,
+        _vars: &Self::EvaluationFrame<P, D2>,
         _yield_constr: &mut ConstraintConsumer<P>,
     ) where
-        FE: FieldExtension<D2, BaseField = F>,
-        P: PackedField<Scalar = FE>,
+        P::Scalar: FieldExtension<D2, BaseField = F>,
     {
     }
 
@@ -100,9 +98,7 @@ impl<F: RichField + Extendable<D>, const D: usize> Stark<F, D> for PermutationSt
 #[cfg(test)]
 mod tests {
     use anyhow::Result;
-    use plonky2::field::extension::Extendable;
     use plonky2::field::types::Field;
-    use plonky2::hash::hash_types::RichField;
     use plonky2::iop::witness::PartialWitness;
     use plonky2::plonk::circuit_builder::CircuitBuilder;
     use plonky2::plonk::circuit_data::CircuitConfig;
@@ -135,7 +131,7 @@ mod tests {
 
         let stark = S::new(num_rows);
         let trace = stark.generate_trace(public_input);
-        let proof = prove::<F, C, S, D>(
+        let proof = prove::<C, S, D>(
             stark,
             &config,
             trace,
@@ -167,7 +163,7 @@ mod tests {
 
         let num_rows = 1 << 5;
         let stark = S::new(num_rows);
-        test_stark_circuit_constraints::<F, C, S, D>(stark)
+        test_stark_circuit_constraints::<C, S, D>(stark)
     }
 
     #[test]
@@ -184,7 +180,7 @@ mod tests {
 
         let stark = S::new(num_rows);
         let trace = stark.generate_trace(public_input);
-        let proof = prove::<F, C, S, D>(
+        let proof = prove::<C, S, D>(
             stark,
             &config,
             trace,
@@ -193,33 +189,32 @@ mod tests {
         )?;
         verify_stark_proof(stark, proof.clone(), &config)?;
 
-        recursive_proof::<F, C, S, C, D>(stark, proof, &config, true)
+        recursive_proof::<C, S, C, D>(stark, proof, &config, true)
     }
 
     fn recursive_proof<
-        F: RichField + Extendable<D>,
-        C: GenericConfig<D, F = F>,
-        S: Stark<F, D> + Copy,
-        InnerC: GenericConfig<D, F = F>,
+        C: GenericConfig<D>,
+        S: Stark<C::F, D> + Copy,
+        InnerC: GenericConfig<D, F = C::F>,
         const D: usize,
     >(
         stark: S,
-        inner_proof: StarkProofWithPublicInputs<F, InnerC, D>,
+        inner_proof: StarkProofWithPublicInputs<InnerC, D>,
         inner_config: &StarkConfig,
         print_gate_counts: bool,
     ) -> Result<()>
     where
-        InnerC::Hasher: AlgebraicHasher<F>,
+        InnerC::Hasher: AlgebraicHasher<C::F>,
     {
         let circuit_config = CircuitConfig::standard_recursion_config();
-        let mut builder = CircuitBuilder::<F, D>::new(circuit_config);
+        let mut builder = CircuitBuilder::<C::F, D>::new(circuit_config);
         let mut pw = PartialWitness::new();
         let degree_bits = inner_proof.proof.recover_degree_bits(inner_config);
         let pt =
             add_virtual_stark_proof_with_pis(&mut builder, &stark, inner_config, degree_bits, 0, 0);
         set_stark_proof_with_pis_target(&mut pw, &pt, &inner_proof, builder.zero());
 
-        verify_stark_proof_circuit::<F, InnerC, S, D>(&mut builder, stark, pt, inner_config);
+        verify_stark_proof_circuit::<InnerC, S, D>(&mut builder, stark, pt, inner_config);
 
         if print_gate_counts {
             builder.print_gate_counts(0);

--- a/starky/src/stark.rs
+++ b/starky/src/stark.rs
@@ -28,10 +28,9 @@ pub trait Stark<F: RichField + Extendable<D>, const D: usize>: Sync {
     const PUBLIC_INPUTS: usize = Self::EvaluationFrameTarget::PUBLIC_INPUTS;
 
     /// This is used to evaluate constraints natively.
-    type EvaluationFrame<FE, P, const D2: usize>: StarkEvaluationFrame<P, FE>
+    type EvaluationFrame<P: PackedField, const D2: usize>: StarkEvaluationFrame<P, P::Scalar>
     where
-        FE: FieldExtension<D2, BaseField = F>,
-        P: PackedField<Scalar = FE>;
+        P::Scalar: FieldExtension<D2, BaseField = F>;
 
     /// The `Target` version of `Self::EvaluationFrame`, used to evaluate constraints recursively.
     type EvaluationFrameTarget: StarkEvaluationFrame<ExtensionTarget<D>, ExtensionTarget<D>>;
@@ -42,18 +41,17 @@ pub trait Stark<F: RichField + Extendable<D>, const D: usize>: Sync {
     /// evaluate constraints over a larger domain if desired. This can also be called with `FE = F`
     /// and `D2 = 1`, in which case we are using the trivial extension, i.e. just evaluating
     /// constraints over `F`.
-    fn eval_packed_generic<FE, P, const D2: usize>(
+    fn eval_packed_generic<P: PackedField, const D2: usize>(
         &self,
-        vars: &Self::EvaluationFrame<FE, P, D2>,
+        vars: &Self::EvaluationFrame<P, D2>,
         yield_constr: &mut ConstraintConsumer<P>,
     ) where
-        FE: FieldExtension<D2, BaseField = F>,
-        P: PackedField<Scalar = FE>;
+        P::Scalar: FieldExtension<D2, BaseField = F>;
 
     /// Evaluates constraints at a vector of points from the base field `F`.
     fn eval_packed_base<P: PackedField<Scalar = F>>(
         &self,
-        vars: &Self::EvaluationFrame<F, P, 1>,
+        vars: &Self::EvaluationFrame<P, 1>,
         yield_constr: &mut ConstraintConsumer<P>,
     ) {
         self.eval_packed_generic(vars, yield_constr)
@@ -62,7 +60,7 @@ pub trait Stark<F: RichField + Extendable<D>, const D: usize>: Sync {
     /// Evaluates constraints at a single point from the degree `D` extension field.
     fn eval_ext(
         &self,
-        vars: &Self::EvaluationFrame<F::Extension, F::Extension, D>,
+        vars: &Self::EvaluationFrame<F::Extension, D>,
         yield_constr: &mut ConstraintConsumer<F::Extension>,
     ) {
         self.eval_packed_generic(vars, yield_constr)

--- a/starky/src/unconstrained_stark.rs
+++ b/starky/src/unconstrained_stark.rs
@@ -45,10 +45,9 @@ const COLUMNS: usize = 2;
 const PUBLIC_INPUTS: usize = 0;
 
 impl<F: RichField + Extendable<D>, const D: usize> Stark<F, D> for UnconstrainedStark<F, D> {
-    type EvaluationFrame<FE, P, const D2: usize> = StarkFrame<P, P::Scalar, COLUMNS, PUBLIC_INPUTS>
+    type EvaluationFrame<P: PackedField, const D2: usize> = StarkFrame<P, P::Scalar, COLUMNS, PUBLIC_INPUTS>
     where
-        FE: FieldExtension<D2, BaseField = F>,
-        P: PackedField<Scalar = FE>;
+        P::Scalar: FieldExtension<D2, BaseField = F>;
 
     type EvaluationFrameTarget =
         StarkFrame<ExtensionTarget<D>, ExtensionTarget<D>, COLUMNS, PUBLIC_INPUTS>;
@@ -58,13 +57,12 @@ impl<F: RichField + Extendable<D>, const D: usize> Stark<F, D> for Unconstrained
     }
 
     // We don't constrain any register.
-    fn eval_packed_generic<FE, P, const D2: usize>(
+    fn eval_packed_generic<P: PackedField, const D2: usize>(
         &self,
-        _vars: &Self::EvaluationFrame<FE, P, D2>,
+        _vars: &Self::EvaluationFrame<P, D2>,
         _yield_constr: &mut ConstraintConsumer<P>,
     ) where
-        FE: FieldExtension<D2, BaseField = F>,
-        P: PackedField<Scalar = FE>,
+        P::Scalar: FieldExtension<D2, BaseField = F>,
     {
     }
 
@@ -81,8 +79,6 @@ impl<F: RichField + Extendable<D>, const D: usize> Stark<F, D> for Unconstrained
 #[cfg(test)]
 mod tests {
     use anyhow::Result;
-    use plonky2::field::extension::Extendable;
-    use plonky2::hash::hash_types::RichField;
     use plonky2::iop::witness::PartialWitness;
     use plonky2::plonk::circuit_builder::CircuitBuilder;
     use plonky2::plonk::circuit_data::CircuitConfig;
@@ -113,7 +109,7 @@ mod tests {
 
         let stark = S::new(num_rows);
         let trace = stark.generate_trace();
-        let proof = prove::<F, C, S, D>(stark, &config, trace, &[], &mut TimingTree::default())?;
+        let proof = prove::<C, S, D>(stark, &config, trace, &[], &mut TimingTree::default())?;
 
         verify_stark_proof(stark, proof, &config)
     }
@@ -139,7 +135,7 @@ mod tests {
 
         let num_rows = 1 << 5;
         let stark = S::new(num_rows);
-        test_stark_circuit_constraints::<F, C, S, D>(stark)
+        test_stark_circuit_constraints::<C, S, D>(stark)
     }
 
     #[test]
@@ -155,36 +151,35 @@ mod tests {
 
         let stark = S::new(num_rows);
         let trace = stark.generate_trace();
-        let proof = prove::<F, C, S, D>(stark, &config, trace, &[], &mut TimingTree::default())?;
+        let proof = prove::<C, S, D>(stark, &config, trace, &[], &mut TimingTree::default())?;
         verify_stark_proof(stark, proof.clone(), &config)?;
 
-        recursive_proof::<F, C, S, C, D>(stark, proof, &config, true)
+        recursive_proof::<C, S, C, D>(stark, proof, &config, true)
     }
 
     fn recursive_proof<
-        F: RichField + Extendable<D>,
-        C: GenericConfig<D, F = F>,
-        S: Stark<F, D> + Copy,
-        InnerC: GenericConfig<D, F = F>,
+        C: GenericConfig<D>,
+        S: Stark<C::F, D> + Copy,
+        InnerC: GenericConfig<D, F = C::F>,
         const D: usize,
     >(
         stark: S,
-        inner_proof: StarkProofWithPublicInputs<F, InnerC, D>,
+        inner_proof: StarkProofWithPublicInputs<InnerC, D>,
         inner_config: &StarkConfig,
         print_gate_counts: bool,
     ) -> Result<()>
     where
-        InnerC::Hasher: AlgebraicHasher<F>,
+        InnerC::Hasher: AlgebraicHasher<C::F>,
     {
         let circuit_config = CircuitConfig::standard_recursion_config();
-        let mut builder = CircuitBuilder::<F, D>::new(circuit_config);
+        let mut builder = CircuitBuilder::<C::F, D>::new(circuit_config);
         let mut pw = PartialWitness::new();
         let degree_bits = inner_proof.proof.recover_degree_bits(inner_config);
         let pt =
             add_virtual_stark_proof_with_pis(&mut builder, &stark, inner_config, degree_bits, 0, 0);
         set_stark_proof_with_pis_target(&mut pw, &pt, &inner_proof, builder.zero());
 
-        verify_stark_proof_circuit::<F, InnerC, S, D>(&mut builder, stark, pt, inner_config);
+        verify_stark_proof_circuit::<InnerC, S, D>(&mut builder, stark, pt, inner_config);
 
         if print_gate_counts {
             builder.print_gate_counts(0);


### PR DESCRIPTION
Many types and functions use generics with parameters like:

`F: RichField + Extendable<D>, C: GenericConfig<D, F = F>`

Instead, those places could use `C: GenericConfig<D>`, substituting `C::F` in place of `F` where necessary.

`PackedField` is a similar story.

Removing these parameters can simplify type declarations and turbofishes for downstream crates.