### PR TITLE
change `set_stark_proof_target`'s witness to `WitnessWrite`

### DIFF
--- a/starky/src/recursive_verifier.rs
+++ b/starky/src/recursive_verifier.rs
@@ -14,7 +14,7 @@ use plonky2::hash::hash_types::RichField;
 use plonky2::iop::challenger::RecursiveChallenger;
 use plonky2::iop::ext_target::ExtensionTarget;
 use plonky2::iop::target::Target;
-use plonky2::iop::witness::Witness;
+use plonky2::iop::witness::WitnessWrite;
 use plonky2::plonk::circuit_builder::CircuitBuilder;
 use plonky2::plonk::config::{AlgebraicHasher, GenericConfig};
 use plonky2::util::reducing::ReducingFactorTarget;
@@ -328,7 +328,7 @@ pub fn set_stark_proof_with_pis_target<F, C: GenericConfig<D, F = F>, W, const D
 ) where
     F: RichField + Extendable<D>,
     C::Hasher: AlgebraicHasher<F>,
-    W: Witness<F>,
+    W: WitnessWrite<F>,
 {
     let StarkProofWithPublicInputs {
         proof,
@@ -357,7 +357,7 @@ pub fn set_stark_proof_target<F, C: GenericConfig<D, F = F>, W, const D: usize>(
 ) where
     F: RichField + Extendable<D>,
     C::Hasher: AlgebraicHasher<F>,
-    W: Witness<F>,
+    W: WitnessWrite<F>,
 {
     witness.set_cap_target(&proof_target.trace_cap, &proof.trace_cap);
     if let (Some(quotient_polys_cap_target), Some(quotient_polys_cap)) =


### PR DESCRIPTION
The witness used in `set_stark_proof_target` is sufficient with `WitnessWrite`. `Witness` (which inherits from `WitnessWrite`) cannot be used in cases like `run_once` of `SimpleGenerator`.