### PR TITLE
doc+fix: `clippy::doc-lazy-continuation`

### DIFF
--- a/plonky2/src/gates/selectors.rs
+++ b/plonky2/src/gates/selectors.rs
@@ -42,9 +42,11 @@ pub enum LookupSelectors {
 /// Returns selector polynomials for each LUT. We have two constraint domains (remember that gates are stored upside down):
 /// - [last_lut_row, first_lut_row] (Sum and RE transition constraints),
 /// - [last_lu_row, last_lut_row - 1] (LDC column transition constraints).
+///
 /// We also add two more:
 /// - {first_lut_row + 1} where we check the initial values of sum and RE (which are 0),
 /// - {last_lu_row} where we check that the last value of LDC is 0.
+///
 /// Conceptually they're part of the selector ends lookups, but since we can have one polynomial for *all* LUTs it's here.
 pub(crate) fn selectors_lookup<F: RichField + Extendable<D>, const D: usize>(
     _gates: &[GateRef<F, D>],

--- a/plonky2/src/plonk/vanishing_poly.rs
+++ b/plonky2/src/plonk/vanishing_poly.rs
@@ -329,6 +329,7 @@ pub(crate) fn eval_vanishing_poly_base_batch<F: RichField + Extendable<D>, const
 /// - RE ensures the well formation of lookup tables;
 /// - Sum is a running sum of m_i/(X - (input_i + a * output_i)) where (input_i, output_i) are input pairs in the lookup table (LUT);
 /// - LDC is a running sum of 1/(X - (input_i + a * output_i)) where (input_i, output_i) are input pairs that look in the LUT.
+///
 /// Sum and LDC are broken down in partial polynomials to lower the constraint degree, similarly to the permutation argument.
 /// They also share the same partial SLDC polynomials, so that the last SLDC value is Sum(end) - LDC(end). The final constraint
 /// Sum(end) = LDC(end) becomes simply SLDC(end) = 0, and we can remove the LDC initial constraint.

--- a/starky/src/cross_table_lookup.rs
+++ b/starky/src/cross_table_lookup.rs
@@ -19,7 +19,8 @@
 //! - Z(gw) = Z(w) * combine(w) where combine(w) is the column combination at point w.
 //! - Z(g^(n-1)) = combine(1).
 //! - The verifier also checks that the product of looking table Z polynomials is equal
-//! to the associated looked table Z polynomial.
+//!   to the associated looked table Z polynomial.
+//!
 //! Note that the first two checks are written that way because Z polynomials are computed
 //! upside down for convenience.
 //!
@@ -316,6 +317,7 @@ pub(crate) fn get_ctl_auxiliary_polys<F: Field>(
 /// - `cross_table_lookups` corresponds to all the cross-table lookups, i.e. the looked and looking tables, as described in `CrossTableLookup`.
 /// - `ctl_challenges` corresponds to the challenges used for CTLs.
 /// - `constraint_degree` is the maximal constraint degree for the table.
+///
 /// For each `CrossTableLookup`, and each looking/looked table, the partial products for the CTL are computed, and added to the said table's `CtlZData`.
 pub(crate) fn cross_table_lookup_data<'a, F: RichField, const D: usize, const N: usize>(
     trace_poly_values: &[Vec<PolynomialValues<F>>; N],
@@ -621,6 +623,7 @@ impl<'a, F: RichField + Extendable<D>, const D: usize>
 /// Checks the cross-table lookup Z polynomials for each table:
 /// - Checks that the CTL `Z` partial sums are correctly updated.
 /// - Checks that the final value of the CTL sum is the combination of all STARKs' CTL polynomials.
+///
 /// CTL `Z` partial sums are upside down: the complete sum is on the first row, and
 /// the first term is on the last row. This allows the transition constraint to be:
 /// `combine(w) * (Z(w) - Z(gw)) = filter` where combine is called on the local row
@@ -825,6 +828,7 @@ impl<'a, F: Field, const D: usize> CtlCheckVarsTarget<F, D> {
 /// Circuit version of `eval_cross_table_lookup_checks`. Checks the cross-table lookup Z polynomials for each table:
 /// - Checks that the CTL `Z` partial sums are correctly updated.
 /// - Checks that the final value of the CTL sum is the combination of all STARKs' CTL polynomials.
+///
 /// CTL `Z` partial sums are upside down: the complete sum is on the first row, and
 /// the first term is on the last row. This allows the transition constraint to be:
 /// `combine(w) * (Z(w) - Z(gw)) = filter` where combine is called on the local row

--- a/starky/src/prover.rs
+++ b/starky/src/prover.rs
@@ -92,7 +92,7 @@ where
 /// - all the required Merkle caps,
 /// - all the required polynomial and FRI argument openings.
 /// - individual `ctl_data` and common `ctl_challenges` if the STARK is part
-/// of a multi-STARK system.
+///   of a multi-STARK system.
 pub fn prove_with_commitment<F, C, S, const D: usize>(
     stark: &S,
     config: &StarkConfig,


### PR DESCRIPTION
Another day another newly added clippy warning.

To review, make sure impacted documentation paragraphs are being split/combined correctly.