### PR TITLE
doc: clarify that `zk` is disabled with `starky`

### DIFF
--- a/starky/README.md
+++ b/starky/README.md
@@ -1,3 +1,17 @@
+# Starky
+
+Starky is a FRI-based STARK implementation.
+
+It is built for speed, features highly efficient recursive verification through `plonky2` circuits and gadgets, and is
+being used as backend proving system for the Polygon Zero Type-1 zkEVM.
+
+## Note on Zero-Knowledgeness
+
+While STARKs can be made Zero-Knowledge, the primary purpose of `starky` is to provide fast STARK proof generation. As such,
+ZK is disabled by default on `starky`. Applications requiring their proof to be `zero-knowledge` would need to apply a
+recursive wrapper on top of their STARK proof with the `zero_knowledge` parameter activated in their `CircuitConfig`.
+See `plonky2` documentation for more info.
+
 ## License
 
 Licensed under either of


### PR DESCRIPTION
closes #1595 