### PR TITLE
Prep for v1.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix CTL generation of last row ([#1585](https://github.com/0xPolygonZero/plonky2/pull/1585))
 - Allow multiple extra_looking_sums for the same looked table ([#1591](https://github.com/0xPolygonZero/plonky2/pull/1591))
 - Clarify zk usage with starky ([#1596](https://github.com/0xPolygonZero/plonky2/pull/1596))
+- Add row index to constraint failure message ([#1598](https://github.com/0xPolygonZero/plonky2/pull/1598))
 
 ## [0.2.3] - 2024-04-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0] - TBD
+
+### Changed
+- Remove obsolete function `ceil_div_usize` ([#1574](https://github.com/0xPolygonZero/plonky2/pull/1574))
+- Update unconstrained_stark.rs ([#1578](https://github.com/0xPolygonZero/plonky2/pull/1578))
+- Remove restriction to binary-only multiplicities ([#1577](https://github.com/0xPolygonZero/plonky2/pull/1577))
+- Fix `verify_cross_table_lookups` with no `ctl_extra_looking_sums` ([#1584](https://github.com/0xPolygonZero/plonky2/pull/1584))
+- update 2-adic generator to `0x64fdd1a46201e246` ([#1579](https://github.com/0xPolygonZero/plonky2/pull/1579))
+- Changes to prepare for dummy segment removal in zk_evm's continuations ([#1587](https://github.com/0xPolygonZero/plonky2/pull/1587))
+- fix: remove clippy unexpected_cfgs warning ([#1588](https://github.com/0xPolygonZero/plonky2/pull/1588))
+- doc+fix: `clippy::doc-lazy-continuation` ([#1594](https://github.com/0xPolygonZero/plonky2/pull/1594))
+- change `set_stark_proof_target`'s witness to `WitnessWrite` ([#1592](https://github.com/0xPolygonZero/plonky2/pull/1592))
+- Fix CTL generation of last row ([#1585](https://github.com/0xPolygonZero/plonky2/pull/1585))
+- Allow multiple extra_looking_sums for the same looked table ([#1591](https://github.com/0xPolygonZero/plonky2/pull/1591))
+- Clarify zk usage with starky ([#1596](https://github.com/0xPolygonZero/plonky2/pull/1596))
+
 ## [0.2.3] - 2024-04-16
 
+### Changed
 - Code refactoring ([#1558](https://github.com/0xPolygonZero/plonky2/pull/1558))
 - Simplify types: remove option from CTL filters ([#1567](https://github.com/0xPolygonZero/plonky2/pull/1567))
 - Add stdarch_x86_avx512 feature ([#1566](https://github.com/0xPolygonZero/plonky2/pull/1566))

--- a/README.md
+++ b/README.md
@@ -11,6 +11,12 @@ For more details about the Plonky2 argument system, see this [writeup](plonky2/p
 Polymer Labs has written up a helpful tutorial [here](https://polymerlabs.medium.com/a-tutorial-on-writing-zk-proofs-with-plonky2-part-i-be5812f6b798)!
 
 
+## Note on `1.0.0` versions
+
+Starting from `v1.0.0`, the `plonky2_field`, `plonky2` and `starky` crates use a *different* generator for the two-adic subgroup of the Goldilocks field.
+As such, any proof generated with a previous version of either `plonky2` or `starky` would be *unverifiable* with newer versions of those crates,
+starting from `v1.0.0`.
+
 ## Examples
 
 A good starting point for how to use Plonky2 for simple applications is the included examples:

--- a/field/Cargo.toml
+++ b/field/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "plonky2_field"
 description = "Finite field arithmetic"
-version = "0.2.2"
+version = "1.0.0"
 authors = ["Daniel Lubarov <daniel@lubarov.com>", "William Borgeaud <williamborgeaud@gmail.com>", "Jacqueline Nabaglo <j@nab.gl>", "Hamish Ivey-Law <hamish@ivey-law.name>"]
 edition.workspace = true
 license.workspace = true
@@ -20,7 +20,7 @@ static_assertions = { workspace = true }
 unroll = { workspace = true }
 
 # Local dependencies
-plonky2_util = { version = "0.2.0", path = "../util", default-features = false }
+plonky2_util = { version = "0.3.0", path = "../util", default-features = false }
 
 
 # Display math equations properly in documentation

--- a/maybe_rayon/Cargo.toml
+++ b/maybe_rayon/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "plonky2_maybe_rayon"
 description = "Feature-gated wrapper around rayon"
-version = "0.2.0"
+version = "0.2.1"
 edition.workspace = true
 license.workspace = true
 homepage.workspace = true

--- a/plonky2/Cargo.toml
+++ b/plonky2/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "plonky2"
 description = "Recursive SNARKs based on PLONK and FRI"
-version = "0.2.2"
+version = "1.0.0"
 authors = ["Daniel Lubarov <daniel@lubarov.com>", "William Borgeaud <williamborgeaud@gmail.com>", "Nicholas Ward <npward@berkeley.edu>"]
 readme = "README.md"
 edition.workspace = true
@@ -34,9 +34,9 @@ unroll = { workspace = true }
 web-time = { version = "1.0.0", optional = true }
 
 # Local dependencies
-plonky2_field = { version = "0.2.2", path = "../field", default-features = false }
-plonky2_maybe_rayon = { version = "0.2.0", path = "../maybe_rayon", default-features = false }
-plonky2_util = { version = "0.2.0", path = "../util", default-features = false }
+plonky2_field = { version = "1.0.0", path = "../field", default-features = false }
+plonky2_maybe_rayon = { version = "0.2.1", path = "../maybe_rayon", default-features = false }
+plonky2_util = { version = "0.3.0", path = "../util", default-features = false }
 
 
 [target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]

--- a/plonky2/README.md
+++ b/plonky2/README.md
@@ -5,6 +5,11 @@ Plonky2 is a SNARK implementation based on techniques from PLONK and FRI. It is 
 Plonky2 is built for speed, and features a highly efficient recursive circuit. On a Macbook Pro, recursive proofs can be generated in about 170 ms.
 
 
+## Note on `1.0.0` versions
+
+Starting from `v1.0.0`, the `plonky2_field` and `plonky2` crates use a *different* generator for the two-adic subgroup of the Goldilocks field.
+As such, any proof generated with a previous `plonky2` version would be *unverifiable* with newer versions of this crate starting from `v1.0.0`.
+
 ## License
 
 Licensed under either of

--- a/starky/Cargo.toml
+++ b/starky/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "starky"
 description = "Implementation of STARKs"
-version = "0.4.0"
+version = "1.0.0"
 authors = ["Daniel Lubarov <daniel@lubarov.com>", "William Borgeaud <williamborgeaud@gmail.com>"]
 readme = "README.md"
 edition.workspace = true
@@ -26,9 +26,9 @@ log = { workspace = true }
 num-bigint = { version = "0.4.3", default-features = false }
 
 # Local dependencies
-plonky2 = { version = "0.2.2", path = "../plonky2", default-features = false }
-plonky2_maybe_rayon = { version = "0.2.0", path = "../maybe_rayon", default-features = false }
-plonky2_util = { version = "0.2.0", path = "../util", default-features = false }
+plonky2 = { version = "1.0.0", path = "../plonky2", default-features = false }
+plonky2_maybe_rayon = { version = "0.2.1", path = "../maybe_rayon", default-features = false }
+plonky2_util = { version = "0.3.0", path = "../util", default-features = false }
 
 [dev-dependencies]
 env_logger = { version = "0.9.0", default-features = false }

--- a/starky/README.md
+++ b/starky/README.md
@@ -12,6 +12,11 @@ ZK is disabled by default on `starky`. Applications requiring their proof to be 
 recursive wrapper on top of their STARK proof with the `zero_knowledge` parameter activated in their `CircuitConfig`.
 See `plonky2` documentation for more info.
 
+## Note on `1.0.0` versions
+
+Starting from `v1.0.0`, the `plonky2_field` and `starky` crates use a *different* generator for the two-adic subgroup of the Goldilocks field.
+As such, any proof generated with a previous `starky` version would be *unverifiable* with newer versions of this crate starting from `v1.0.0`.
+
 ## License
 
 Licensed under either of

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "plonky2_util"
 description = "Utilities used by Plonky2"
-version = "0.2.0"
+version = "0.3.0"
 license = "MIT OR Apache-2.0"
 edition = "2021"
 


### PR DESCRIPTION
- Update `CHANGELOG`
- Bump versions
- Include a note in `README` for backwards incompatibility 