### PR TITLE
Add `Field::shifted_powers` and some iterator niceties

### DIFF
--- a/field/src/types.rs
+++ b/field/src/types.rs
@@ -567,10 +567,6 @@ pub trait PrimeField64: PrimeField + Field64 {
 }
 
 /// An iterator over the powers of a certain base element `b`: `b^0, b^1, b^2, ...`.
-///
-/// This iterator panics on calls to [`nth`] if `n` overflows [`u64`].
-///
-/// [`nth`]: ::core::iter::Iterator::nth
 #[must_use = "iterators are lazy and do nothing unless consumed"]
 #[derive(Clone, Debug)]
 pub struct Powers<F: Field> {


### PR DESCRIPTION
Adds the `Field::shifted_powers` method from [Plonky3](https://github.com/Plonky3/Plonky3/blob/fde81db95b8eeb39e07890f4099a7d59daeec52f/field/src/field.rs#L122-L127) along with a few additions to the `Powers` iterator implementation.

Please pick and choose what's useful.

`<Powers<F> as Iterator>::nth` in particular might require some tweaking:
- It currently panics if `n` overflows `u64`. This seems at least as good as the current behavior of hanging trying to compute `u64::MAX` field multiplications. But, maybe it's worth the performance hit to use `Field::exp_biguint`.
- The current implementation incurs one extra multiplication in the case of `n = 1` (e.g. `generator.powers().skip(1)`). It's possible this is the most commonly expected case and `nth` should just be removed altogether. 