### PR TITLE
fix(field): Re-enable `alloc` for tests

### DIFF
--- a/field/src/lib.rs
+++ b/field/src/lib.rs
@@ -6,7 +6,7 @@
 #![feature(specialization)]
 #![cfg_attr(target_arch = "x86_64", feature(stdarch_x86_avx512))]
 #![cfg_attr(not(test), no_std)]
-#![cfg(not(test))]
+
 extern crate alloc;
 
 pub(crate) mod arch;


### PR DESCRIPTION
For some reason, this was disabling all unit tests in the `plonky2_field` crate.
Credits to @gio256 for noticing!