### PR TITLE
Replace stale link

### DIFF
--- a/plonky2/src/hash/arch/x86_64/poseidon_goldilocks_avx2_bmi2.rs
+++ b/plonky2/src/hash/arch/x86_64/poseidon_goldilocks_avx2_bmi2.rs
@@ -494,7 +494,7 @@ unsafe fn mds_multiply_and_add_round_const_s(
         // Fall through for MDS matrix multiplication on low 32 bits
 
         // This is a GCC _local label_. For details, see
-        // https://doc.rust-lang.org/beta/unstable-book/library-features/asm.html#labels
+        // https://doc.rust-lang.org/rust-by-example/unsafe/asm.html#labels
         // In short, the assembler makes sure to assign a unique name to replace `2:` with a unique
         // name, so the label does not clash with any compiler-generated label. `2:` can appear
         // multiple times; to disambiguate, we must refer to it as `2b` or `2f`, specifying the


### PR DESCRIPTION
Tiny chore: inline assembly is stable since Rust [1.59](https://blog.rust-lang.org/2022/02/24/Rust-1.59.0.html), so the docs from the unstable book are now split between the language reference and Rust by Example. I believe this should point to the same section as before, though.