### PR TITLE
Docs improvements

### DIFF
--- a/field/src/arch/x86_64/avx2_goldilocks_field.rs
+++ b/field/src/arch/x86_64/avx2_goldilocks_field.rs
@@ -348,7 +348,7 @@ unsafe fn neg(y: __m256i) -> __m256i {
 }
 
 /// Full 64-bit by 64-bit multiplication. This emulated multiplication is 1.33x slower than the
-/// scalar instruction, but may be worth it if we want our data to live in vector registers.
+/// scalar instruction, but it may be worth it if we want our data to live in vector registers.
 #[inline]
 unsafe fn mul64_64(x: __m256i, y: __m256i) -> (__m256i, __m256i) {
     // We want to move the high 32 bits to the low position. The multiplication instruction ignores

--- a/field/src/batch_util.rs
+++ b/field/src/batch_util.rs
@@ -30,7 +30,7 @@ pub fn batch_multiply_inplace<F: Field>(out: &mut [F], a: &[F]) {
     let n = out.len();
     assert_eq!(n, a.len(), "both arrays must have the same length");
 
-    // Split out slice of vectors, leaving leftovers as scalars
+    // Split out slices of vectors, leaving leftovers as scalars
     let (out_packed, out_leftovers) =
         pack_slice_with_leftovers_mut::<<F as Packable>::Packing>(out);
     let (a_packed, a_leftovers) = pack_slice_with_leftovers::<<F as Packable>::Packing>(a);

--- a/field/src/extension/mod.rs
+++ b/field/src/extension/mod.rs
@@ -34,7 +34,7 @@ pub trait Frobenius<const D: usize>: OEF<D> {
 
     /// Repeated Frobenius automorphisms: x -> x^(p^count).
     ///
-    /// Follows precomputation suggestion in Section 11.3.3 of the
+    /// Follows the precomputation suggestion in Section 11.3.3 of the
     /// Handbook of Elliptic and Hyperelliptic Curve Cryptography.
     fn repeated_frobenius(&self, count: usize) -> Self {
         if count == 0 {

--- a/field/src/fft.rs
+++ b/field/src/fft.rs
@@ -122,7 +122,7 @@ fn fft_classic_simd<P: PackedField>(
             }
 
             for k in (0..packed_n).step_by(2) {
-                // We have two vectors and want to do math on pairs of adjacent elements (or for
+                // We have two vectors and want to do the math on pairs of adjacent elements (or for
                 // lg_half_m > 0, pairs of adjacent blocks of elements). .interleave does the
                 // appropriate shuffling and is its own inverse.
                 let (u, v) = packed_values[k].interleave(packed_values[k + 1], half_m);

--- a/field/src/goldilocks_field.rs
+++ b/field/src/goldilocks_field.rs
@@ -253,7 +253,7 @@ impl Add for GoldilocksField {
         if over {
             // NB: self.0 > Self::ORDER && rhs.0 > Self::ORDER is necessary but not sufficient for
             // double-overflow.
-            // This assume does two things:
+            // This assumption does two things:
             //  1. If compiler knows that either self.0 or rhs.0 <= ORDER, then it can skip this
             //     check.
             //  2. Hints to the compiler how rare this double-overflow is (thus handled better with

--- a/field/src/polynomial/division.rs
+++ b/field/src/polynomial/division.rs
@@ -54,7 +54,7 @@ impl<F: Field> PolynomialCoeffs<F> {
             // Now we know that self.degree() >= divisor.degree();
             let mut quotient = Self::zero(a_degree_plus_1 - b_degree_plus_1 + 1);
             let mut remainder = self.clone();
-            // Can unwrap here because we know self is not zero.
+            // Can unwrap here because we know the self is not zero.
             let divisor_leading_inv = b.lead().inverse();
             while !remainder.is_zero() && remainder.degree_plus_one() >= b_degree_plus_1 {
                 let cur_q_coeff = remainder.lead() * divisor_leading_inv;

--- a/field/src/polynomial/mod.rs
+++ b/field/src/polynomial/mod.rs
@@ -17,7 +17,7 @@ use crate::types::Field;
 
 /// A polynomial in point-value form.
 ///
-/// The points are implicitly `g^i`, where `g` generates the subgroup whose size equals the number
+/// The points are implicit `g^i`, where `g` generates the subgroup whose size equals the number
 /// of points.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct PolynomialValues<F: Field> {

--- a/starky/README.md
+++ b/starky/README.md
@@ -3,7 +3,7 @@
 Starky is a FRI-based STARK implementation.
 
 It is built for speed, features highly efficient recursive verification through `plonky2` circuits and gadgets, and is
-being used as backend proving system for the Polygon Zero Type-1 zkEVM.
+being used as a backend proving system for the Polygon Zero Type-1 zkEVM.
 
 ## Note on Zero-Knowledgeness
 


### PR DESCRIPTION
Rectify typographical inaccuracies

This PR addresses several typographical errors across various files in the project. The changes improve readability and maintain the professional standard of the documentation and code comments.

Justification
Typographical errors, while minor, can detract from the overall quality of the project. Correcting these errors ensures clarity and professionalism, making the project more accessible and understandable for current and future contributors.