### PR TITLE
fix(starky): observe public inputs

### DIFF
--- a/starky/src/get_challenges.rs
+++ b/starky/src/get_challenges.rs
@@ -157,6 +157,7 @@ where
         ignore_trace_cap: bool,
         config: &StarkConfig,
     ) -> StarkProofChallenges<F, D> {
+        challenger.observe_elements(&self.public_inputs);
         self.proof
             .get_challenges(challenger, challenges, ignore_trace_cap, config)
     }
@@ -302,6 +303,7 @@ impl<const D: usize> StarkProofWithPublicInputsTarget<D> {
         C: GenericConfig<D, F = F>,
         C::Hasher: AlgebraicHasher<F>,
     {
+        challenger.observe_elements(&self.public_inputs);
         self.proof
             .get_challenges::<F, C>(builder, challenger, challenges, ignore_trace_cap, config)
     }

--- a/starky/src/prover.rs
+++ b/starky/src/prover.rs
@@ -71,6 +71,7 @@ where
 
     let trace_cap = trace_commitment.merkle_tree.cap.clone();
     let mut challenger = Challenger::new();
+    challenger.observe_elements(public_inputs);
     challenger.observe_cap(&trace_cap);
 
     prove_with_commitment(


### PR DESCRIPTION
Public inputs were not part of the transcript used to generate challenges.