### PR TITLE
Do not panic on `wire set twice` or `generator not run` issues

### DIFF
--- a/plonky2/examples/bench_recursion.rs
+++ b/plonky2/examples/bench_recursion.rs
@@ -138,7 +138,7 @@ fn dummy_lookup_proof<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, 
 
     let data = builder.build::<C>();
     let mut inputs = PartialWitness::<F>::new();
-    inputs.set_target(initial_a, F::ONE);
+    inputs.set_target(initial_a, F::ONE)?;
     let mut timing = TimingTree::new("prove with one lookup", Level::Debug);
     let proof = prove(&data.prover_only, &data.common, inputs, &mut timing)?;
     timing.print();
@@ -189,7 +189,7 @@ fn dummy_many_rows_proof<
     builder.register_public_input(output);
 
     let mut pw = PartialWitness::new();
-    pw.set_target(initial_a, F::ONE);
+    pw.set_target(initial_a, F::ONE)?;
     let data = builder.build::<C>();
     let mut timing = TimingTree::new("prove with many lookups", Level::Debug);
     let proof = prove(&data.prover_only, &data.common, pw, &mut timing)?;
@@ -235,8 +235,8 @@ where
     let data = builder.build::<C>();
 
     let mut pw = PartialWitness::new();
-    pw.set_proof_with_pis_target(&pt, inner_proof);
-    pw.set_verifier_data_target(&inner_data, inner_vd);
+    pw.set_proof_with_pis_target(&pt, inner_proof)?;
+    pw.set_verifier_data_target(&inner_data, inner_vd)?;
 
     let mut timing = TimingTree::new("prove", Level::Debug);
     let proof = prove::<F, C, D>(&data.prover_only, &data.common, pw, &mut timing)?;

--- a/plonky2/examples/factorial.rs
+++ b/plonky2/examples/factorial.rs
@@ -29,7 +29,7 @@ fn main() -> Result<()> {
     builder.register_public_input(cur_target);
 
     let mut pw = PartialWitness::new();
-    pw.set_target(initial, F::ONE);
+    pw.set_target(initial, F::ONE)?;
 
     let data = builder.build::<C>();
     let proof = data.prove(pw)?;

--- a/plonky2/examples/fibonacci.rs
+++ b/plonky2/examples/fibonacci.rs
@@ -34,8 +34,8 @@ fn main() -> Result<()> {
 
     // Provide initial values.
     let mut pw = PartialWitness::new();
-    pw.set_target(initial_a, F::ZERO);
-    pw.set_target(initial_b, F::ONE);
+    pw.set_target(initial_a, F::ZERO)?;
+    pw.set_target(initial_b, F::ONE)?;
 
     let data = builder.build::<C>();
     let proof = data.prove(pw)?;

--- a/plonky2/examples/fibonacci_serialization.rs
+++ b/plonky2/examples/fibonacci_serialization.rs
@@ -37,8 +37,8 @@ fn main() -> Result<()> {
 
     // Provide initial values.
     let mut pw = PartialWitness::new();
-    pw.set_target(initial_a, F::ZERO);
-    pw.set_target(initial_b, F::ONE);
+    pw.set_target(initial_a, F::ZERO)?;
+    pw.set_target(initial_b, F::ONE)?;
 
     let data = builder.build::<C>();
 

--- a/plonky2/examples/range_check.rs
+++ b/plonky2/examples/range_check.rs
@@ -24,7 +24,7 @@ fn main() -> Result<()> {
     builder.range_check(value, log_max);
 
     let mut pw = PartialWitness::new();
-    pw.set_target(value, F::from_canonical_usize(42));
+    pw.set_target(value, F::from_canonical_usize(42))?;
 
     let data = builder.build::<C>();
     let proof = data.prove(pw)?;

--- a/plonky2/examples/square_root.rs
+++ b/plonky2/examples/square_root.rs
@@ -41,13 +41,17 @@ impl<F: RichField + Extendable<D>, const D: usize> SimpleGenerator<F, D>
         vec![self.x_squared]
     }
 
-    fn run_once(&self, witness: &PartitionWitness<F>, out_buffer: &mut GeneratedValues<F>) {
+    fn run_once(
+        &self,
+        witness: &PartitionWitness<F>,
+        out_buffer: &mut GeneratedValues<F>,
+    ) -> Result<()> {
         let x_squared = witness.get_target(self.x_squared);
         let x = x_squared.sqrt().unwrap();
 
         println!("Square root: {x}");
 
-        out_buffer.set_target(self.x, x);
+        out_buffer.set_target(self.x, x)
     }
 
     fn serialize(&self, dst: &mut Vec<u8>, _common_data: &CommonCircuitData<F, D>) -> IoResult<()> {
@@ -121,7 +125,7 @@ fn main() -> Result<()> {
     };
 
     let mut pw = PartialWitness::new();
-    pw.set_target(x_squared, x_squared_value);
+    pw.set_target(x_squared, x_squared_value)?;
 
     let data = builder.build::<C>();
     let proof = data.prove(pw.clone())?;

--- a/plonky2/src/batch_fri/oracle.rs
+++ b/plonky2/src/batch_fri/oracle.rs
@@ -599,7 +599,7 @@ mod test {
         );
 
         let mut pw = PartialWitness::new();
-        set_fri_proof_target(&mut pw, &fri_proof_target, &proof);
+        set_fri_proof_target(&mut pw, &fri_proof_target, &proof)?;
 
         let data = builder.build::<C>();
         let proof = prove::<F, C, D>(&data.prover_only, &data.common, pw, &mut timing)?;

--- a/plonky2/src/gadgets/arithmetic.rs
+++ b/plonky2/src/gadgets/arithmetic.rs
@@ -6,6 +6,8 @@ use alloc::{
 };
 use core::borrow::Borrow;
 
+use anyhow::Result;
+
 use crate::field::extension::Extendable;
 use crate::field::types::Field64;
 use crate::gates::arithmetic_base::ArithmeticGate;
@@ -397,14 +399,18 @@ impl<F: RichField + Extendable<D>, const D: usize> SimpleGenerator<F, D> for Equ
         vec![self.x, self.y]
     }
 
-    fn run_once(&self, witness: &PartitionWitness<F>, out_buffer: &mut GeneratedValues<F>) {
+    fn run_once(
+        &self,
+        witness: &PartitionWitness<F>,
+        out_buffer: &mut GeneratedValues<F>,
+    ) -> Result<()> {
         let x = witness.get_target(self.x);
         let y = witness.get_target(self.y);
 
         let inv = if x != y { (x - y).inverse() } else { F::ZERO };
 
-        out_buffer.set_bool_target(self.equal, x == y);
-        out_buffer.set_target(self.inv, inv);
+        out_buffer.set_bool_target(self.equal, x == y)?;
+        out_buffer.set_target(self.inv, inv)
     }
 
     fn serialize(&self, dst: &mut Vec<u8>, _common_data: &CommonCircuitData<F, D>) -> IoResult<()> {

--- a/plonky2/src/gadgets/arithmetic_extension.rs
+++ b/plonky2/src/gadgets/arithmetic_extension.rs
@@ -6,6 +6,8 @@ use alloc::{
 };
 use core::borrow::Borrow;
 
+use anyhow::Result;
+
 use crate::field::extension::{Extendable, FieldExtension, OEF};
 use crate::field::types::{Field, Field64};
 use crate::gates::arithmetic_extension::ArithmeticExtensionGate;
@@ -519,7 +521,11 @@ impl<F: RichField + Extendable<D>, const D: usize> SimpleGenerator<F, D>
         deps
     }
 
-    fn run_once(&self, witness: &PartitionWitness<F>, out_buffer: &mut GeneratedValues<F>) {
+    fn run_once(
+        &self,
+        witness: &PartitionWitness<F>,
+        out_buffer: &mut GeneratedValues<F>,
+    ) -> Result<()> {
         let num = witness.get_extension_target(self.numerator);
         let dem = witness.get_extension_target(self.denominator);
         let quotient = num / dem;
@@ -621,7 +627,7 @@ mod tests {
         let vs = FF::rand_vec(3);
         let ts = builder.add_virtual_extension_targets(3);
         for (&v, &t) in vs.iter().zip(&ts) {
-            pw.set_extension_target(t, v);
+            pw.set_extension_target(t, v)?;
         }
         let mul0 = builder.mul_many_extension(&ts);
         let mul1 = {
@@ -696,9 +702,9 @@ mod tests {
         let y = ExtensionAlgebra::<FF, D>(FF::rand_array());
         let z = x * y;
         for i in 0..D {
-            pw.set_extension_target(xt.0[i], x.0[i]);
-            pw.set_extension_target(yt.0[i], y.0[i]);
-            pw.set_extension_target(zt.0[i], z.0[i]);
+            pw.set_extension_target(xt.0[i], x.0[i])?;
+            pw.set_extension_target(yt.0[i], y.0[i])?;
+            pw.set_extension_target(zt.0[i], z.0[i])?;
         }
 
         let data = builder.build::<C>();

--- a/plonky2/src/gadgets/range_check.rs
+++ b/plonky2/src/gadgets/range_check.rs
@@ -5,6 +5,8 @@ use alloc::{
     vec::Vec,
 };
 
+use anyhow::Result;
+
 use crate::field::extension::Extendable;
 use crate::hash::hash_types::RichField;
 use crate::iop::generator::{GeneratedValues, SimpleGenerator};
@@ -74,13 +76,17 @@ impl<F: RichField + Extendable<D>, const D: usize> SimpleGenerator<F, D> for Low
         vec![self.integer]
     }
 
-    fn run_once(&self, witness: &PartitionWitness<F>, out_buffer: &mut GeneratedValues<F>) {
+    fn run_once(
+        &self,
+        witness: &PartitionWitness<F>,
+        out_buffer: &mut GeneratedValues<F>,
+    ) -> Result<()> {
         let integer_value = witness.get_target(self.integer).to_canonical_u64();
         let low = integer_value & ((1 << self.n_log) - 1);
         let high = integer_value >> self.n_log;
 
-        out_buffer.set_target(self.low, F::from_canonical_u64(low));
-        out_buffer.set_target(self.high, F::from_canonical_u64(high));
+        out_buffer.set_target(self.low, F::from_canonical_u64(low))?;
+        out_buffer.set_target(self.high, F::from_canonical_u64(high))
     }
 
     fn serialize(&self, dst: &mut Vec<u8>, _common_data: &CommonCircuitData<F, D>) -> IoResult<()> {

--- a/plonky2/src/gadgets/select.rs
+++ b/plonky2/src/gadgets/select.rs
@@ -63,8 +63,8 @@ mod tests {
         let truet = builder._true();
         let falset = builder._false();
 
-        pw.set_extension_target(xt, x);
-        pw.set_extension_target(yt, y);
+        pw.set_extension_target(xt, x)?;
+        pw.set_extension_target(yt, y)?;
 
         let should_be_x = builder.select_ext(truet, xt, yt);
         let should_be_y = builder.select_ext(falset, xt, yt);

--- a/plonky2/src/gadgets/split_base.rs
+++ b/plonky2/src/gadgets/split_base.rs
@@ -2,6 +2,7 @@
 use alloc::{format, string::String, vec, vec::Vec};
 use core::borrow::Borrow;
 
+use anyhow::Result;
 use itertools::Itertools;
 
 use crate::field::extension::Extendable;
@@ -97,7 +98,11 @@ impl<F: RichField + Extendable<D>, const B: usize, const D: usize> SimpleGenerat
         self.limbs.iter().map(|b| b.target).collect()
     }
 
-    fn run_once(&self, witness: &PartitionWitness<F>, out_buffer: &mut GeneratedValues<F>) {
+    fn run_once(
+        &self,
+        witness: &PartitionWitness<F>,
+        out_buffer: &mut GeneratedValues<F>,
+    ) -> Result<()> {
         let sum = self
             .limbs
             .iter()
@@ -107,7 +112,7 @@ impl<F: RichField + Extendable<D>, const B: usize, const D: usize> SimpleGenerat
                 acc * F::from_canonical_usize(B) + F::from_bool(limb)
             });
 
-        out_buffer.set_target(Target::wire(self.row, BaseSumGate::<B>::WIRE_SUM), sum);
+        out_buffer.set_target(Target::wire(self.row, BaseSumGate::<B>::WIRE_SUM), sum)
     }
 
     fn serialize(&self, dst: &mut Vec<u8>, _common_data: &CommonCircuitData<F, D>) -> IoResult<()> {

--- a/plonky2/src/gates/arithmetic_base.rs
+++ b/plonky2/src/gates/arithmetic_base.rs
@@ -5,6 +5,8 @@ use alloc::{
     vec::Vec,
 };
 
+use anyhow::Result;
+
 use crate::field::extension::Extendable;
 use crate::field::packed::PackedField;
 use crate::gates::gate::Gate;
@@ -209,7 +211,11 @@ impl<F: RichField + Extendable<D>, const D: usize> SimpleGenerator<F, D>
         .collect()
     }
 
-    fn run_once(&self, witness: &PartitionWitness<F>, out_buffer: &mut GeneratedValues<F>) {
+    fn run_once(
+        &self,
+        witness: &PartitionWitness<F>,
+        out_buffer: &mut GeneratedValues<F>,
+    ) -> Result<()> {
         let get_wire = |wire: usize| -> F { witness.get_target(Target::wire(self.row, wire)) };
 
         let multiplicand_0 = get_wire(ArithmeticGate::wire_ith_multiplicand_0(self.i));

--- a/plonky2/src/gates/arithmetic_extension.rs
+++ b/plonky2/src/gates/arithmetic_extension.rs
@@ -6,6 +6,8 @@ use alloc::{
 };
 use core::ops::Range;
 
+use anyhow::Result;
+
 use crate::field::extension::{Extendable, FieldExtension};
 use crate::gates::gate::Gate;
 use crate::gates::util::StridedConstraintConsumer;
@@ -192,7 +194,11 @@ impl<F: RichField + Extendable<D>, const D: usize> SimpleGenerator<F, D>
             .collect()
     }
 
-    fn run_once(&self, witness: &PartitionWitness<F>, out_buffer: &mut GeneratedValues<F>) {
+    fn run_once(
+        &self,
+        witness: &PartitionWitness<F>,
+        out_buffer: &mut GeneratedValues<F>,
+    ) -> Result<()> {
         let extract_extension = |range: Range<usize>| -> F::Extension {
             let t = ExtensionTarget::from_range(self.row, range);
             witness.get_extension_target(t)

--- a/plonky2/src/gates/base_sum.rs
+++ b/plonky2/src/gates/base_sum.rs
@@ -2,6 +2,8 @@
 use alloc::{format, string::String, vec, vec::Vec};
 use core::ops::Range;
 
+use anyhow::Result;
+
 use crate::field::extension::Extendable;
 use crate::field::packed::PackedField;
 use crate::field::types::{Field, Field64};
@@ -185,7 +187,11 @@ impl<F: RichField + Extendable<D>, const B: usize, const D: usize> SimpleGenerat
         vec![Target::wire(self.row, BaseSumGate::<B>::WIRE_SUM)]
     }
 
-    fn run_once(&self, witness: &PartitionWitness<F>, out_buffer: &mut GeneratedValues<F>) {
+    fn run_once(
+        &self,
+        witness: &PartitionWitness<F>,
+        out_buffer: &mut GeneratedValues<F>,
+    ) -> Result<()> {
         let sum_value = witness
             .get_target(Target::wire(self.row, BaseSumGate::<B>::WIRE_SUM))
             .to_canonical_u64() as usize;
@@ -206,8 +212,10 @@ impl<F: RichField + Extendable<D>, const B: usize, const D: usize> SimpleGenerat
             .collect::<Vec<_>>();
 
         for (b, b_value) in limbs.zip(limbs_value) {
-            out_buffer.set_target(b, b_value);
+            out_buffer.set_target(b, b_value)?;
         }
+
+        Ok(())
     }
 
     fn serialize(&self, dst: &mut Vec<u8>, _common_data: &CommonCircuitData<F, D>) -> IoResult<()> {

--- a/plonky2/src/gates/exponentiation.rs
+++ b/plonky2/src/gates/exponentiation.rs
@@ -7,6 +7,8 @@ use alloc::{
 };
 use core::marker::PhantomData;
 
+use anyhow::Result;
+
 use crate::field::extension::Extendable;
 use crate::field::ops::Square;
 use crate::field::packed::PackedField;
@@ -265,7 +267,11 @@ impl<F: RichField + Extendable<D>, const D: usize> SimpleGenerator<F, D>
         deps
     }
 
-    fn run_once(&self, witness: &PartitionWitness<F>, out_buffer: &mut GeneratedValues<F>) {
+    fn run_once(
+        &self,
+        witness: &PartitionWitness<F>,
+        out_buffer: &mut GeneratedValues<F>,
+    ) -> Result<()> {
         let local_wire = |column| Wire {
             row: self.row,
             column,
@@ -292,11 +298,11 @@ impl<F: RichField + Extendable<D>, const D: usize> SimpleGenerator<F, D>
 
         for i in 0..num_power_bits {
             let intermediate_value_wire = local_wire(self.gate.wire_intermediate_value(i));
-            out_buffer.set_wire(intermediate_value_wire, intermediate_values[i]);
+            out_buffer.set_wire(intermediate_value_wire, intermediate_values[i])?;
         }
 
         let output_wire = local_wire(self.gate.wire_output());
-        out_buffer.set_wire(output_wire, intermediate_values[num_power_bits - 1]);
+        out_buffer.set_wire(output_wire, intermediate_values[num_power_bits - 1])
     }
 
     fn serialize(&self, dst: &mut Vec<u8>, _common_data: &CommonCircuitData<F, D>) -> IoResult<()> {

--- a/plonky2/src/gates/gate_testing.rs
+++ b/plonky2/src/gates/gate_testing.rs
@@ -137,10 +137,10 @@ pub fn test_eval_fns<
 
     let wires_t = builder.add_virtual_extension_targets(wires.len());
     let constants_t = builder.add_virtual_extension_targets(constants.len());
-    pw.set_extension_targets(&wires_t, &wires);
-    pw.set_extension_targets(&constants_t, &constants);
+    pw.set_extension_targets(&wires_t, &wires)?;
+    pw.set_extension_targets(&constants_t, &constants)?;
     let public_inputs_hash_t = builder.add_virtual_hash();
-    pw.set_hash_target(public_inputs_hash_t, public_inputs_hash);
+    pw.set_hash_target(public_inputs_hash_t, public_inputs_hash)?;
 
     let vars = EvaluationVars {
         local_constants: &constants,
@@ -155,7 +155,7 @@ pub fn test_eval_fns<
         public_inputs_hash: &public_inputs_hash_t,
     };
     let evals_t = gate.eval_unfiltered_circuit(&mut builder, vars_t);
-    pw.set_extension_targets(&evals_t, &evals);
+    pw.set_extension_targets(&evals_t, &evals)?;
 
     let data = builder.build::<C>();
     let proof = data.prove(pw)?;

--- a/plonky2/src/gates/lookup.rs
+++ b/plonky2/src/gates/lookup.rs
@@ -6,6 +6,7 @@ use alloc::{
     vec::Vec,
 };
 
+use anyhow::{anyhow, Result};
 use itertools::Itertools;
 use keccak_hash::keccak;
 
@@ -188,7 +189,11 @@ impl<F: RichField + Extendable<D>, const D: usize> SimpleGenerator<F, D> for Loo
         )]
     }
 
-    fn run_once(&self, witness: &PartitionWitness<F>, out_buffer: &mut GeneratedValues<F>) {
+    fn run_once(
+        &self,
+        witness: &PartitionWitness<F>,
+        out_buffer: &mut GeneratedValues<F>,
+    ) -> Result<()> {
         let get_wire = |wire: usize| -> F { witness.get_target(Target::wire(self.row, wire)) };
 
         let input_val = get_wire(LookupGate::wire_ith_looking_inp(self.slot_nb));
@@ -197,7 +202,7 @@ impl<F: RichField + Extendable<D>, const D: usize> SimpleGenerator<F, D> for Loo
             let output_val = F::from_canonical_u16(output);
 
             let out_wire = Target::wire(self.row, LookupGate::wire_ith_looking_out(self.slot_nb));
-            out_buffer.set_target(out_wire, output_val);
+            out_buffer.set_target(out_wire, output_val)
         } else {
             for (input, output) in self.lut.iter() {
                 if input_val == F::from_canonical_u16(*input) {
@@ -205,12 +210,13 @@ impl<F: RichField + Extendable<D>, const D: usize> SimpleGenerator<F, D> for Loo
 
                     let out_wire =
                         Target::wire(self.row, LookupGate::wire_ith_looking_out(self.slot_nb));
-                    out_buffer.set_target(out_wire, output_val);
-                    return;
+                    out_buffer.set_target(out_wire, output_val)?;
+
+                    return Ok(());
                 }
             }
-            panic!("Incorrect input value provided");
-        };
+            Err(anyhow!("Incorrect input value provided"))
+        }
     }
 
     fn serialize(&self, dst: &mut Vec<u8>, common_data: &CommonCircuitData<F, D>) -> IoResult<()> {

--- a/plonky2/src/gates/lookup_table.rs
+++ b/plonky2/src/gates/lookup_table.rs
@@ -9,6 +9,7 @@ use alloc::{
 #[cfg(feature = "std")]
 use std::sync::Arc;
 
+use anyhow::Result;
 use itertools::Itertools;
 use keccak_hash::keccak;
 
@@ -205,7 +206,11 @@ impl<F: RichField + Extendable<D>, const D: usize> SimpleGenerator<F, D> for Loo
         vec![]
     }
 
-    fn run_once(&self, _witness: &PartitionWitness<F>, out_buffer: &mut GeneratedValues<F>) {
+    fn run_once(
+        &self,
+        _witness: &PartitionWitness<F>,
+        out_buffer: &mut GeneratedValues<F>,
+    ) -> Result<()> {
         let first_row = self.last_lut_row + self.lut.len().div_ceil(self.num_slots) - 1;
         let slot = (first_row - self.row) * self.num_slots + self.slot_nb;
 
@@ -216,12 +221,12 @@ impl<F: RichField + Extendable<D>, const D: usize> SimpleGenerator<F, D> for Loo
 
         if slot < self.lut.len() {
             let (input, output) = self.lut[slot];
-            out_buffer.set_target(slot_input_target, F::from_canonical_usize(input as usize));
-            out_buffer.set_target(slot_output_target, F::from_canonical_usize(output as usize));
+            out_buffer.set_target(slot_input_target, F::from_canonical_usize(input as usize))?;
+            out_buffer.set_target(slot_output_target, F::from_canonical_usize(output as usize))
         } else {
             // Pad with zeros.
-            out_buffer.set_target(slot_input_target, F::ZERO);
-            out_buffer.set_target(slot_output_target, F::ZERO);
+            out_buffer.set_target(slot_input_target, F::ZERO)?;
+            out_buffer.set_target(slot_output_target, F::ZERO)
         }
     }
 

--- a/plonky2/src/gates/multiplication_extension.rs
+++ b/plonky2/src/gates/multiplication_extension.rs
@@ -6,6 +6,8 @@ use alloc::{
 };
 use core::ops::Range;
 
+use anyhow::Result;
+
 use crate::field::extension::{Extendable, FieldExtension};
 use crate::gates::gate::Gate;
 use crate::gates::util::StridedConstraintConsumer;
@@ -175,7 +177,11 @@ impl<F: RichField + Extendable<D>, const D: usize> SimpleGenerator<F, D>
             .collect()
     }
 
-    fn run_once(&self, witness: &PartitionWitness<F>, out_buffer: &mut GeneratedValues<F>) {
+    fn run_once(
+        &self,
+        witness: &PartitionWitness<F>,
+        out_buffer: &mut GeneratedValues<F>,
+    ) -> Result<()> {
         let extract_extension = |range: Range<usize>| -> F::Extension {
             let t = ExtensionTarget::from_range(self.row, range);
             witness.get_extension_target(t)

--- a/plonky2/src/gates/poseidon_mds.rs
+++ b/plonky2/src/gates/poseidon_mds.rs
@@ -8,6 +8,8 @@ use alloc::{
 use core::marker::PhantomData;
 use core::ops::Range;
 
+use anyhow::Result;
+
 use crate::field::extension::algebra::ExtensionAlgebra;
 use crate::field::extension::{Extendable, FieldExtension};
 use crate::field::types::Field;
@@ -238,7 +240,11 @@ impl<F: RichField + Extendable<D> + Poseidon, const D: usize> SimpleGenerator<F,
             .collect()
     }
 
-    fn run_once(&self, witness: &PartitionWitness<F>, out_buffer: &mut GeneratedValues<F>) {
+    fn run_once(
+        &self,
+        witness: &PartitionWitness<F>,
+        out_buffer: &mut GeneratedValues<F>,
+    ) -> Result<()> {
         let get_local_get_target = |wire_range| ExtensionTarget::from_range(self.row, wire_range);
         let get_local_ext =
             |wire_range| witness.get_extension_target(get_local_get_target(wire_range));
@@ -255,8 +261,10 @@ impl<F: RichField + Extendable<D> + Poseidon, const D: usize> SimpleGenerator<F,
             out_buffer.set_extension_target(
                 get_local_get_target(PoseidonMdsGate::<F, D>::wires_output(i)),
                 out,
-            );
+            )?;
         }
+
+        Ok(())
     }
 
     fn serialize(&self, dst: &mut Vec<u8>, _common_data: &CommonCircuitData<F, D>) -> IoResult<()> {

--- a/plonky2/src/gates/random_access.rs
+++ b/plonky2/src/gates/random_access.rs
@@ -7,6 +7,7 @@ use alloc::{
 };
 use core::marker::PhantomData;
 
+use anyhow::Result;
 use itertools::Itertools;
 
 use crate::field::extension::Extendable;
@@ -366,7 +367,11 @@ impl<F: RichField + Extendable<D>, const D: usize> SimpleGenerator<F, D>
         deps
     }
 
-    fn run_once(&self, witness: &PartitionWitness<F>, out_buffer: &mut GeneratedValues<F>) {
+    fn run_once(
+        &self,
+        witness: &PartitionWitness<F>,
+        out_buffer: &mut GeneratedValues<F>,
+    ) -> Result<()> {
         let local_wire = |column| Wire {
             row: self.row,
             column,
@@ -390,12 +395,14 @@ impl<F: RichField + Extendable<D>, const D: usize> SimpleGenerator<F, D>
         set_local_wire(
             self.gate.wire_claimed_element(copy),
             get_local_wire(self.gate.wire_list_item(access_index, copy)),
-        );
+        )?;
 
         for i in 0..self.gate.bits {
             let bit = F::from_bool(((access_index >> i) & 1) != 0);
-            set_local_wire(self.gate.wire_bit(i, copy), bit);
+            set_local_wire(self.gate.wire_bit(i, copy), bit)?;
         }
+
+        Ok(())
     }
 
     fn serialize(&self, dst: &mut Vec<u8>, _common_data: &CommonCircuitData<F, D>) -> IoResult<()> {

--- a/plonky2/src/gates/reducing.rs
+++ b/plonky2/src/gates/reducing.rs
@@ -7,6 +7,8 @@ use alloc::{
 };
 use core::ops::Range;
 
+use anyhow::Result;
+
 use crate::field::extension::{Extendable, FieldExtension};
 use crate::gates::gate::Gate;
 use crate::gates::util::StridedConstraintConsumer;
@@ -201,7 +203,11 @@ impl<F: RichField + Extendable<D>, const D: usize> SimpleGenerator<F, D> for Red
             .collect()
     }
 
-    fn run_once(&self, witness: &PartitionWitness<F>, out_buffer: &mut GeneratedValues<F>) {
+    fn run_once(
+        &self,
+        witness: &PartitionWitness<F>,
+        out_buffer: &mut GeneratedValues<F>,
+    ) -> Result<()> {
         let extract_extension = |range: Range<usize>| -> F::Extension {
             let t = ExtensionTarget::from_range(self.row, range);
             witness.get_extension_target(t)
@@ -224,10 +230,11 @@ impl<F: RichField + Extendable<D>, const D: usize> SimpleGenerator<F, D> for Red
         let mut acc = old_acc;
         for i in 0..self.gate.num_coeffs {
             let computed_acc = acc * alpha + coeffs[i].into();
-            out_buffer.set_extension_target(accs[i], computed_acc);
+            out_buffer.set_extension_target(accs[i], computed_acc)?;
             acc = computed_acc;
         }
-        out_buffer.set_extension_target(output, acc);
+
+        out_buffer.set_extension_target(output, acc)
     }
 
     fn serialize(&self, dst: &mut Vec<u8>, _common_data: &CommonCircuitData<F, D>) -> IoResult<()> {

--- a/plonky2/src/hash/merkle_proofs.rs
+++ b/plonky2/src/hash/merkle_proofs.rs
@@ -292,18 +292,18 @@ mod tests {
             siblings: builder.add_virtual_hashes(proof.siblings.len()),
         };
         for i in 0..proof.siblings.len() {
-            pw.set_hash_target(proof_t.siblings[i], proof.siblings[i]);
+            pw.set_hash_target(proof_t.siblings[i], proof.siblings[i])?;
         }
 
         let cap_t = builder.add_virtual_cap(cap_height);
-        pw.set_cap_target(&cap_t, &tree.cap);
+        pw.set_cap_target(&cap_t, &tree.cap)?;
 
         let i_c = builder.constant(F::from_canonical_usize(i));
         let i_bits = builder.split_le(i_c, log_n);
 
         let data = builder.add_virtual_targets(tree.leaves[i].len());
         for j in 0..data.len() {
-            pw.set_target(data[j], tree.leaves[i][j]);
+            pw.set_target(data[j], tree.leaves[i][j])?;
         }
 
         builder.verify_merkle_proof_to_cap::<<C as GenericConfig<D>>::InnerHasher>(

--- a/plonky2/src/iop/challenger.rs
+++ b/plonky2/src/iop/challenger.rs
@@ -365,7 +365,8 @@ mod tests {
         }
         let circuit = builder.build::<C>();
         let inputs = PartialWitness::new();
-        let witness = generate_partial_witness(inputs, &circuit.prover_only, &circuit.common);
+        let witness =
+            generate_partial_witness(inputs, &circuit.prover_only, &circuit.common).unwrap();
         let recursive_output_values_per_round: Vec<Vec<F>> = recursive_outputs_per_round
             .iter()
             .map(|outputs| witness.get_targets(outputs))

--- a/plonky2/src/iop/witness.rs
+++ b/plonky2/src/iop/witness.rs
@@ -1,6 +1,6 @@
 #[cfg(not(feature = "std"))]
 use alloc::{vec, vec::Vec};
-use std::iter::zip;
+use core::iter::zip;
 
 use anyhow::{anyhow, Result};
 use hashbrown::HashMap;

--- a/plonky2/src/iop/witness.rs
+++ b/plonky2/src/iop/witness.rs
@@ -1,6 +1,8 @@
 #[cfg(not(feature = "std"))]
 use alloc::{vec, vec::Vec};
+use std::iter::zip;
 
+use anyhow::{anyhow, Result};
 use hashbrown::HashMap;
 use itertools::{zip_eq, Itertools};
 
@@ -18,52 +20,67 @@ use crate::plonk::config::{AlgebraicHasher, GenericConfig};
 use crate::plonk::proof::{Proof, ProofTarget, ProofWithPublicInputs, ProofWithPublicInputsTarget};
 
 pub trait WitnessWrite<F: Field> {
-    fn set_target(&mut self, target: Target, value: F);
+    fn set_target(&mut self, target: Target, value: F) -> Result<()>;
 
-    fn set_hash_target(&mut self, ht: HashOutTarget, value: HashOut<F>) {
-        ht.elements
-            .iter()
-            .zip(value.elements)
-            .for_each(|(&t, x)| self.set_target(t, x));
+    fn set_hash_target(&mut self, ht: HashOutTarget, value: HashOut<F>) -> Result<()> {
+        for (t, x) in zip(ht.elements, value.elements) {
+            self.set_target(t, x)?;
+        }
+
+        Ok(())
     }
 
     fn set_cap_target<H: AlgebraicHasher<F>>(
         &mut self,
         ct: &MerkleCapTarget,
         value: &MerkleCap<F, H>,
-    ) where
+    ) -> Result<()>
+    where
         F: RichField,
     {
         for (ht, h) in ct.0.iter().zip(&value.0) {
-            self.set_hash_target(*ht, *h);
+            self.set_hash_target(*ht, *h)?;
         }
+
+        Ok(())
     }
 
-    fn set_extension_target<const D: usize>(&mut self, et: ExtensionTarget<D>, value: F::Extension)
+    fn set_extension_target<const D: usize>(
+        &mut self,
+        et: ExtensionTarget<D>,
+        value: F::Extension,
+    ) -> Result<()>
     where
         F: RichField + Extendable<D>,
     {
-        self.set_target_arr(&et.0, &value.to_basefield_array());
+        self.set_target_arr(&et.0, &value.to_basefield_array())
     }
 
-    fn set_target_arr(&mut self, targets: &[Target], values: &[F]) {
-        zip_eq(targets, values).for_each(|(&target, &value)| self.set_target(target, value));
+    fn set_target_arr(&mut self, targets: &[Target], values: &[F]) -> Result<()> {
+        for (&target, &value) in zip_eq(targets, values) {
+            self.set_target(target, value)?;
+        }
+
+        Ok(())
     }
 
     fn set_extension_targets<const D: usize>(
         &mut self,
         ets: &[ExtensionTarget<D>],
         values: &[F::Extension],
-    ) where
+    ) -> Result<()>
+    where
         F: RichField + Extendable<D>,
     {
         debug_assert_eq!(ets.len(), values.len());
-        ets.iter()
-            .zip(values)
-            .for_each(|(&et, &v)| self.set_extension_target(et, v));
+        for (&et, &v) in zip(ets, values) {
+            self.set_extension_target(et, v)?;
+        }
+
+        Ok(())
     }
 
-    fn set_bool_target(&mut self, target: BoolTarget, value: bool) {
+    fn set_bool_target(&mut self, target: BoolTarget, value: bool) -> Result<()> {
         self.set_target(target.target, F::from_bool(value))
     }
 
@@ -73,7 +90,8 @@ pub trait WitnessWrite<F: Field> {
         &mut self,
         proof_with_pis_target: &ProofWithPublicInputsTarget<D>,
         proof_with_pis: &ProofWithPublicInputs<F, C, D>,
-    ) where
+    ) -> Result<()>
+    where
         F: RichField + Extendable<D>,
         C::Hasher: AlgebraicHasher<F>,
     {
@@ -88,10 +106,10 @@ pub trait WitnessWrite<F: Field> {
 
         // Set public inputs.
         for (&pi_t, &pi) in pi_targets.iter().zip_eq(public_inputs) {
-            self.set_target(pi_t, pi);
+            self.set_target(pi_t, pi)?;
         }
 
-        self.set_proof_target(pt, proof);
+        self.set_proof_target(pt, proof)
     }
 
     /// Set the targets in a `ProofTarget` to their corresponding values in a `Proof`.
@@ -99,30 +117,32 @@ pub trait WitnessWrite<F: Field> {
         &mut self,
         proof_target: &ProofTarget<D>,
         proof: &Proof<F, C, D>,
-    ) where
+    ) -> Result<()>
+    where
         F: RichField + Extendable<D>,
         C::Hasher: AlgebraicHasher<F>,
     {
-        self.set_cap_target(&proof_target.wires_cap, &proof.wires_cap);
+        self.set_cap_target(&proof_target.wires_cap, &proof.wires_cap)?;
         self.set_cap_target(
             &proof_target.plonk_zs_partial_products_cap,
             &proof.plonk_zs_partial_products_cap,
-        );
-        self.set_cap_target(&proof_target.quotient_polys_cap, &proof.quotient_polys_cap);
+        )?;
+        self.set_cap_target(&proof_target.quotient_polys_cap, &proof.quotient_polys_cap)?;
 
         self.set_fri_openings(
             &proof_target.openings.to_fri_openings(),
             &proof.openings.to_fri_openings(),
-        );
+        )?;
 
-        set_fri_proof_target(self, &proof_target.opening_proof, &proof.opening_proof);
+        set_fri_proof_target(self, &proof_target.opening_proof, &proof.opening_proof)
     }
 
     fn set_fri_openings<const D: usize>(
         &mut self,
         fri_openings_target: &FriOpeningsTarget<D>,
         fri_openings: &FriOpenings<F, D>,
-    ) where
+    ) -> Result<()>
+    where
         F: RichField + Extendable<D>,
     {
         for (batch_target, batch) in fri_openings_target
@@ -130,48 +150,55 @@ pub trait WitnessWrite<F: Field> {
             .iter()
             .zip_eq(&fri_openings.batches)
         {
-            self.set_extension_targets(&batch_target.values, &batch.values);
+            self.set_extension_targets(&batch_target.values, &batch.values)?;
         }
+
+        Ok(())
     }
 
     fn set_verifier_data_target<C: GenericConfig<D, F = F>, const D: usize>(
         &mut self,
         vdt: &VerifierCircuitTarget,
         vd: &VerifierOnlyCircuitData<C, D>,
-    ) where
+    ) -> Result<()>
+    where
         F: RichField + Extendable<D>,
         C::Hasher: AlgebraicHasher<F>,
     {
-        self.set_cap_target(&vdt.constants_sigmas_cap, &vd.constants_sigmas_cap);
-        self.set_hash_target(vdt.circuit_digest, vd.circuit_digest);
+        self.set_cap_target(&vdt.constants_sigmas_cap, &vd.constants_sigmas_cap)?;
+        self.set_hash_target(vdt.circuit_digest, vd.circuit_digest)
     }
 
-    fn set_wire(&mut self, wire: Wire, value: F) {
+    fn set_wire(&mut self, wire: Wire, value: F) -> Result<()> {
         self.set_target(Target::Wire(wire), value)
     }
 
-    fn set_wires<W>(&mut self, wires: W, values: &[F])
+    fn set_wires<W>(&mut self, wires: W, values: &[F]) -> Result<()>
     where
         W: IntoIterator<Item = Wire>,
     {
         // If we used itertools, we could use zip_eq for extra safety.
         for (wire, &value) in wires.into_iter().zip(values) {
-            self.set_wire(wire, value);
+            self.set_wire(wire, value)?;
         }
+
+        Ok(())
     }
 
-    fn set_ext_wires<W, const D: usize>(&mut self, wires: W, value: F::Extension)
+    fn set_ext_wires<W, const D: usize>(&mut self, wires: W, value: F::Extension) -> Result<()>
     where
         F: RichField + Extendable<D>,
         W: IntoIterator<Item = Wire>,
     {
-        self.set_wires(wires, &value.to_basefield_array());
+        self.set_wires(wires, &value.to_basefield_array())
     }
 
-    fn extend<I: Iterator<Item = (Target, F)>>(&mut self, pairs: I) {
+    fn extend<I: Iterator<Item = (Target, F)>>(&mut self, pairs: I) -> Result<()> {
         for (t, v) in pairs {
-            self.set_target(t, v);
+            self.set_target(t, v)?;
         }
+
+        Ok(())
     }
 }
 
@@ -277,15 +304,20 @@ impl<F: Field> PartialWitness<F> {
 }
 
 impl<F: Field> WitnessWrite<F> for PartialWitness<F> {
-    fn set_target(&mut self, target: Target, value: F) {
+    fn set_target(&mut self, target: Target, value: F) -> Result<()> {
         let opt_old_value = self.target_values.insert(target, value);
         if let Some(old_value) = opt_old_value {
-            assert_eq!(
-                value, old_value,
-                "Target {:?} was set twice with different values: {} != {}",
-                target, old_value, value
-            );
+            if value != old_value {
+                return Err(anyhow!(
+                    "Target {:?} was set twice with different values: {} != {}",
+                    target,
+                    old_value,
+                    value
+                ));
+            }
         }
+
+        Ok(())
     }
 }
 
@@ -317,19 +349,23 @@ impl<'a, F: Field> PartitionWitness<'a, F> {
 
     /// Set a `Target`. On success, returns the representative index of the newly-set target. If the
     /// target was already set, returns `None`.
-    pub fn set_target_returning_rep(&mut self, target: Target, value: F) -> Option<usize> {
+    pub fn set_target_returning_rep(&mut self, target: Target, value: F) -> Result<Option<usize>> {
         let rep_index = self.representative_map[self.target_index(target)];
         let rep_value = &mut self.values[rep_index];
         if let Some(old_value) = *rep_value {
-            assert_eq!(
-                value, old_value,
-                "Partition containing {:?} was set twice with different values: {} != {}",
-                target, old_value, value
-            );
-            None
+            if value != old_value {
+                return Err(anyhow!(
+                    "Partition containing {:?} was set twice with different values: {} != {}",
+                    target,
+                    old_value,
+                    value
+                ));
+            }
+
+            Ok(None)
         } else {
             *rep_value = Some(value);
-            Some(rep_index)
+            Ok(Some(rep_index))
         }
     }
 
@@ -353,8 +389,8 @@ impl<'a, F: Field> PartitionWitness<'a, F> {
 }
 
 impl<'a, F: Field> WitnessWrite<F> for PartitionWitness<'a, F> {
-    fn set_target(&mut self, target: Target, value: F) {
-        self.set_target_returning_rep(target, value);
+    fn set_target(&mut self, target: Target, value: F) -> Result<()> {
+        self.set_target_returning_rep(target, value).map(|_| ())
     }
 }
 

--- a/plonky2/src/lookup_test.rs
+++ b/plonky2/src/lookup_test.rs
@@ -103,8 +103,8 @@ fn test_one_lookup() -> anyhow::Result<()> {
 
     let mut pw = PartialWitness::new();
 
-    pw.set_target(initial_a, F::from_canonical_usize(look_val_a));
-    pw.set_target(initial_b, F::from_canonical_usize(look_val_b));
+    pw.set_target(initial_a, F::from_canonical_usize(look_val_a))?;
+    pw.set_target(initial_b, F::from_canonical_usize(look_val_b))?;
 
     let data = builder.build::<C>();
     let mut timing = TimingTree::new("prove one lookup", Level::Debug);
@@ -171,8 +171,8 @@ fn test_two_luts() -> anyhow::Result<()> {
     builder.register_public_input(output_final);
 
     let mut pw = PartialWitness::new();
-    pw.set_target(initial_a, F::from_canonical_usize(look_val_a));
-    pw.set_target(initial_b, F::from_canonical_usize(look_val_b));
+    pw.set_target(initial_a, F::from_canonical_usize(look_val_a))?;
+    pw.set_target(initial_b, F::from_canonical_usize(look_val_b))?;
     let data = builder.build::<C>();
     let mut timing = TimingTree::new("prove two_luts", Level::Debug);
     let proof = prove(&data.prover_only, &data.common, pw, &mut timing)?;
@@ -241,8 +241,8 @@ fn test_different_inputs() -> anyhow::Result<()> {
 
     let look_val_a = table[init_a].0;
     let look_val_b = table[init_b].0;
-    pw.set_target(initial_a, F::from_canonical_u16(look_val_a));
-    pw.set_target(initial_b, F::from_canonical_u16(look_val_b));
+    pw.set_target(initial_a, F::from_canonical_u16(look_val_a))?;
+    pw.set_target(initial_b, F::from_canonical_u16(look_val_b))?;
 
     let data = builder.build::<C>();
     let mut timing = TimingTree::new("prove different lookups", Level::Debug);
@@ -327,8 +327,8 @@ fn test_many_lookups() -> anyhow::Result<()> {
 
     let mut pw = PartialWitness::new();
 
-    pw.set_target(initial_a, F::from_canonical_usize(look_val_a));
-    pw.set_target(initial_b, F::from_canonical_usize(look_val_b));
+    pw.set_target(initial_a, F::from_canonical_usize(look_val_a))?;
+    pw.set_target(initial_b, F::from_canonical_usize(look_val_b))?;
 
     let data = builder.build::<C>();
     let mut timing = TimingTree::new("prove different lookups", Level::Debug);
@@ -404,8 +404,8 @@ fn test_same_luts() -> anyhow::Result<()> {
 
     let mut pw = PartialWitness::new();
 
-    pw.set_target(initial_a, F::from_canonical_usize(look_val_a));
-    pw.set_target(initial_b, F::from_canonical_usize(look_val_b));
+    pw.set_target(initial_a, F::from_canonical_usize(look_val_a))?;
+    pw.set_target(initial_b, F::from_canonical_usize(look_val_b))?;
 
     let data = builder.build::<C>();
     let mut timing = TimingTree::new("prove two_luts", Level::Debug);
@@ -443,8 +443,8 @@ fn test_big_lut() -> anyhow::Result<()> {
 
     let mut pw = PartialWitness::new();
 
-    pw.set_target(initial_a, F::from_canonical_u16(look_val_a));
-    pw.set_target(initial_b, F::from_canonical_u16(look_val_b));
+    pw.set_target(initial_a, F::from_canonical_u16(look_val_a))?;
+    pw.set_target(initial_b, F::from_canonical_u16(look_val_b))?;
 
     let proof = data.prove(pw)?;
     assert_eq!(
@@ -494,12 +494,11 @@ fn test_many_lookups_on_big_lut() -> anyhow::Result<()> {
 
     let mut pw = PartialWitness::new();
 
-    inputs
-        .into_iter()
-        .enumerate()
-        .for_each(|(i, t)| pw.set_target(t, F::from_canonical_usize(i)));
-    pw.set_target(initial_a, F::from_canonical_u16(look_val_a));
-    pw.set_target(initial_b, F::from_canonical_u16(look_val_b));
+    for (i, t) in inputs.into_iter().enumerate() {
+        pw.set_target(t, F::from_canonical_usize(i))?
+    }
+    pw.set_target(initial_a, F::from_canonical_u16(look_val_a))?;
+    pw.set_target(initial_b, F::from_canonical_u16(look_val_b))?;
 
     let proof = data.prove(pw)?;
     assert_eq!(

--- a/plonky2/src/plonk/circuit_data.rs
+++ b/plonky2/src/plonk/circuit_data.rs
@@ -152,7 +152,7 @@ impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
     MockCircuitData<F, C, D>
 {
     pub fn generate_witness(&self, inputs: PartialWitness<F>) -> PartitionWitness<F> {
-        generate_partial_witness::<F, C, D>(inputs, &self.prover_only, &self.common)
+        generate_partial_witness::<F, C, D>(inputs, &self.prover_only, &self.common).unwrap()
     }
 }
 

--- a/plonky2/src/recursion/conditional_recursive_verifier.rs
+++ b/plonky2/src/recursion/conditional_recursive_verifier.rs
@@ -370,7 +370,7 @@ mod tests {
         let mut builder = CircuitBuilder::<F, D>::new(config.clone());
         let mut pw = PartialWitness::new();
         let t = builder.add_virtual_target();
-        pw.set_target(t, F::rand());
+        pw.set_target(t, F::rand())?;
         builder.register_public_input(t);
         let _t2 = builder.square(t);
         for _ in 0..64 {
@@ -388,15 +388,15 @@ mod tests {
         let mut builder = CircuitBuilder::<F, D>::new(config);
         let mut pw = PartialWitness::new();
         let pt = builder.add_virtual_proof_with_pis(&data.common);
-        pw.set_proof_with_pis_target(&pt, &proof);
+        pw.set_proof_with_pis_target(&pt, &proof)?;
         let dummy_pt = builder.add_virtual_proof_with_pis(&data.common);
-        pw.set_proof_with_pis_target::<C, D>(&dummy_pt, &dummy_proof);
+        pw.set_proof_with_pis_target::<C, D>(&dummy_pt, &dummy_proof)?;
         let inner_data =
             builder.add_virtual_verifier_data(data.common.config.fri_config.cap_height);
-        pw.set_verifier_data_target(&inner_data, &data.verifier_only);
+        pw.set_verifier_data_target(&inner_data, &data.verifier_only)?;
         let dummy_inner_data =
             builder.add_virtual_verifier_data(data.common.config.fri_config.cap_height);
-        pw.set_verifier_data_target(&dummy_inner_data, &dummy_data.verifier_only);
+        pw.set_verifier_data_target(&dummy_inner_data, &dummy_data.verifier_only)?;
         let b = builder.constant_bool(F::rand().0 % 2 == 0);
         builder.conditionally_verify_proof::<C>(
             b,

--- a/plonky2/src/recursion/cyclic_recursion.rs
+++ b/plonky2/src/recursion/cyclic_recursion.rs
@@ -312,7 +312,7 @@ mod tests {
         let mut pw = PartialWitness::new();
         let initial_hash = [F::ZERO, F::ONE, F::TWO, F::from_canonical_usize(3)];
         let initial_hash_pis = initial_hash.into_iter().enumerate().collect();
-        pw.set_bool_target(condition, false);
+        pw.set_bool_target(condition, false)?;
         pw.set_proof_with_pis_target::<C, D>(
             &inner_cyclic_proof_with_pis,
             &cyclic_base_proof(
@@ -320,8 +320,8 @@ mod tests {
                 &cyclic_circuit_data.verifier_only,
                 initial_hash_pis,
             ),
-        );
-        pw.set_verifier_data_target(&verifier_data_target, &cyclic_circuit_data.verifier_only);
+        )?;
+        pw.set_verifier_data_target(&verifier_data_target, &cyclic_circuit_data.verifier_only)?;
         let proof = cyclic_circuit_data.prove(pw)?;
         check_cyclic_proof_verifier_data(
             &proof,
@@ -332,9 +332,9 @@ mod tests {
 
         // 1st recursive layer.
         let mut pw = PartialWitness::new();
-        pw.set_bool_target(condition, true);
-        pw.set_proof_with_pis_target(&inner_cyclic_proof_with_pis, &proof);
-        pw.set_verifier_data_target(&verifier_data_target, &cyclic_circuit_data.verifier_only);
+        pw.set_bool_target(condition, true)?;
+        pw.set_proof_with_pis_target(&inner_cyclic_proof_with_pis, &proof)?;
+        pw.set_verifier_data_target(&verifier_data_target, &cyclic_circuit_data.verifier_only)?;
         let proof = cyclic_circuit_data.prove(pw)?;
         check_cyclic_proof_verifier_data(
             &proof,
@@ -345,9 +345,9 @@ mod tests {
 
         // 2nd recursive layer.
         let mut pw = PartialWitness::new();
-        pw.set_bool_target(condition, true);
-        pw.set_proof_with_pis_target(&inner_cyclic_proof_with_pis, &proof);
-        pw.set_verifier_data_target(&verifier_data_target, &cyclic_circuit_data.verifier_only);
+        pw.set_bool_target(condition, true)?;
+        pw.set_proof_with_pis_target(&inner_cyclic_proof_with_pis, &proof)?;
+        pw.set_verifier_data_target(&verifier_data_target, &cyclic_circuit_data.verifier_only)?;
         let proof = cyclic_circuit_data.prove(pw)?;
         check_cyclic_proof_verifier_data(
             &proof,

--- a/plonky2/src/recursion/dummy_circuit.rs
+++ b/plonky2/src/recursion/dummy_circuit.rs
@@ -5,6 +5,7 @@ use alloc::{
     vec::Vec,
 };
 
+use anyhow::Result;
 use hashbrown::HashMap;
 use plonky2_field::extension::Extendable;
 use plonky2_field::polynomial::PolynomialCoeffs;
@@ -76,7 +77,7 @@ where
     let mut pw = PartialWitness::new();
     for i in 0..circuit.common.num_public_inputs {
         let pi = nonzero_public_inputs.get(&i).copied().unwrap_or_default();
-        pw.set_target(circuit.prover_only.public_inputs[i], pi);
+        pw.set_target(circuit.prover_only.public_inputs[i], pi)?;
     }
     circuit.prove(pw)
 }
@@ -238,9 +239,13 @@ where
         vec![]
     }
 
-    fn run_once(&self, _witness: &PartitionWitness<F>, out_buffer: &mut GeneratedValues<F>) {
-        out_buffer.set_proof_with_pis_target(&self.proof_with_pis_target, &self.proof_with_pis);
-        out_buffer.set_verifier_data_target(&self.verifier_data_target, &self.verifier_data);
+    fn run_once(
+        &self,
+        _witness: &PartitionWitness<F>,
+        out_buffer: &mut GeneratedValues<F>,
+    ) -> Result<()> {
+        out_buffer.set_proof_with_pis_target(&self.proof_with_pis_target, &self.proof_with_pis)?;
+        out_buffer.set_verifier_data_target(&self.verifier_data_target, &self.verifier_data)
     }
 
     fn serialize(&self, dst: &mut Vec<u8>, _common_data: &CommonCircuitData<F, D>) -> IoResult<()> {

--- a/plonky2/src/recursion/recursive_verifier.rs
+++ b/plonky2/src/recursion/recursive_verifier.rs
@@ -473,8 +473,8 @@ mod tests {
 
         let data = builder.build::<C>();
         let mut inputs = PartialWitness::new();
-        inputs.set_target(initial_a, F::from_canonical_usize(look_val_a));
-        inputs.set_target(initial_b, F::from_canonical_usize(look_val_b));
+        inputs.set_target(initial_a, F::from_canonical_usize(look_val_a))?;
+        inputs.set_target(initial_b, F::from_canonical_usize(look_val_b))?;
 
         let proof = data.prove(inputs)?;
         data.verify(proof.clone())?;
@@ -540,8 +540,8 @@ mod tests {
         builder.register_public_input(output_final);
 
         let mut pw = PartialWitness::new();
-        pw.set_target(initial_a, F::ONE);
-        pw.set_target(initial_b, F::TWO);
+        pw.set_target(initial_a, F::ONE)?;
+        pw.set_target(initial_b, F::TWO)?;
 
         let data = builder.build::<C>();
         let proof = data.prove(pw)?;
@@ -606,8 +606,8 @@ mod tests {
 
         let mut pw = PartialWitness::new();
 
-        pw.set_target(initial_a, F::from_canonical_usize(look_val_a));
-        pw.set_target(initial_b, F::from_canonical_usize(look_val_b));
+        pw.set_target(initial_a, F::from_canonical_usize(look_val_a))?;
+        pw.set_target(initial_b, F::from_canonical_usize(look_val_b))?;
 
         let data = builder.build::<C>();
         let proof = data.prove(pw)?;
@@ -646,14 +646,14 @@ mod tests {
         let mut builder = CircuitBuilder::<F, D>::new(config.clone());
         let mut pw = PartialWitness::new();
         let pt = builder.add_virtual_proof_with_pis(&inner_cd);
-        pw.set_proof_with_pis_target(&pt, &inner_proof);
+        pw.set_proof_with_pis_target(&pt, &inner_proof)?;
 
         let inner_data = builder.add_virtual_verifier_data(inner_cd.config.fri_config.cap_height);
         pw.set_cap_target(
             &inner_data.constants_sigmas_cap,
             &inner_vd.constants_sigmas_cap,
-        );
-        pw.set_hash_target(inner_data.circuit_digest, inner_vd.circuit_digest);
+        )?;
+        pw.set_hash_target(inner_data.circuit_digest, inner_vd.circuit_digest)?;
 
         builder.verify_proof::<InnerC>(&pt, &inner_data, &inner_cd);
 

--- a/plonky2/src/util/reducing.rs
+++ b/plonky2/src/util/reducing.rs
@@ -303,7 +303,7 @@ mod tests {
         let mut alpha_t = ReducingFactorTarget::new(builder.constant_extension(alpha));
         let vs_t = builder.add_virtual_targets(vs.len());
         for (&v, &v_t) in vs.iter().zip(&vs_t) {
-            pw.set_target(v_t, v);
+            pw.set_target(v_t, v)?;
         }
         let circuit_reduce = alpha_t.reduce_base(&vs_t, &mut builder);
 
@@ -334,7 +334,7 @@ mod tests {
 
         let mut alpha_t = ReducingFactorTarget::new(builder.constant_extension(alpha));
         let vs_t = builder.add_virtual_extension_targets(vs.len());
-        pw.set_extension_targets(&vs_t, &vs);
+        pw.set_extension_targets(&vs_t, &vs)?;
         let circuit_reduce = alpha_t.reduce(&vs_t, &mut builder);
 
         builder.connect_extension(manual_reduce, circuit_reduce);

--- a/starky/src/fibonacci_stark.rs
+++ b/starky/src/fibonacci_stark.rs
@@ -3,7 +3,7 @@
 //! to highlight the use of the permutation argument with logUp.
 
 #[cfg(not(feature = "std"))]
-use alloc::{vec, vec::Vec};
+use alloc::vec::Vec;
 use core::marker::PhantomData;
 
 use plonky2::field::extension::{Extendable, FieldExtension};

--- a/starky/src/fibonacci_stark.rs
+++ b/starky/src/fibonacci_stark.rs
@@ -255,7 +255,7 @@ mod tests {
         let degree_bits = inner_proof.proof.recover_degree_bits(inner_config);
         let pt =
             add_virtual_stark_proof_with_pis(&mut builder, &stark, inner_config, degree_bits, 0, 0);
-        set_stark_proof_with_pis_target(&mut pw, &pt, &inner_proof, builder.zero());
+        set_stark_proof_with_pis_target(&mut pw, &pt, &inner_proof, builder.zero())?;
 
         verify_stark_proof_circuit::<F, InnerC, S, D>(&mut builder, stark, pt, inner_config);
 

--- a/starky/src/lookup.rs
+++ b/starky/src/lookup.rs
@@ -7,6 +7,7 @@ use core::borrow::Borrow;
 use core::fmt::Debug;
 use core::iter::repeat;
 
+#[cfg(feature = "std")]
 use itertools::Itertools;
 use num_bigint::BigUint;
 use plonky2::field::batch_util::{batch_add_inplace, batch_multiply_inplace};

--- a/starky/src/permutation_stark.rs
+++ b/starky/src/permutation_stark.rs
@@ -217,7 +217,7 @@ mod tests {
         let degree_bits = inner_proof.proof.recover_degree_bits(inner_config);
         let pt =
             add_virtual_stark_proof_with_pis(&mut builder, &stark, inner_config, degree_bits, 0, 0);
-        set_stark_proof_with_pis_target(&mut pw, &pt, &inner_proof, builder.zero());
+        set_stark_proof_with_pis_target(&mut pw, &pt, &inner_proof, builder.zero())?;
 
         verify_stark_proof_circuit::<F, InnerC, S, D>(&mut builder, stark, pt, inner_config);
 

--- a/starky/src/recursive_verifier.rs
+++ b/starky/src/recursive_verifier.rs
@@ -325,7 +325,8 @@ pub fn set_stark_proof_with_pis_target<F, C: GenericConfig<D, F = F>, W, const D
     stark_proof_with_pis_target: &StarkProofWithPublicInputsTarget<D>,
     stark_proof_with_pis: &StarkProofWithPublicInputs<F, C, D>,
     zero: Target,
-) where
+) -> Result<()>
+where
     F: RichField + Extendable<D>,
     C::Hasher: AlgebraicHasher<F>,
     W: WitnessWrite<F>,
@@ -341,10 +342,10 @@ pub fn set_stark_proof_with_pis_target<F, C: GenericConfig<D, F = F>, W, const D
 
     // Set public inputs.
     for (&pi_t, &pi) in pi_targets.iter().zip_eq(public_inputs) {
-        witness.set_target(pi_t, pi);
+        witness.set_target(pi_t, pi)?;
     }
 
-    set_stark_proof_target(witness, pt, proof, zero);
+    set_stark_proof_target(witness, pt, proof, zero)
 }
 
 /// Set the targets in a [`StarkProofTarget`] to their corresponding values in a
@@ -354,31 +355,32 @@ pub fn set_stark_proof_target<F, C: GenericConfig<D, F = F>, W, const D: usize>(
     proof_target: &StarkProofTarget<D>,
     proof: &StarkProof<F, C, D>,
     zero: Target,
-) where
+) -> Result<()>
+where
     F: RichField + Extendable<D>,
     C::Hasher: AlgebraicHasher<F>,
     W: WitnessWrite<F>,
 {
-    witness.set_cap_target(&proof_target.trace_cap, &proof.trace_cap);
+    witness.set_cap_target(&proof_target.trace_cap, &proof.trace_cap)?;
     if let (Some(quotient_polys_cap_target), Some(quotient_polys_cap)) =
         (&proof_target.quotient_polys_cap, &proof.quotient_polys_cap)
     {
-        witness.set_cap_target(quotient_polys_cap_target, quotient_polys_cap);
+        witness.set_cap_target(quotient_polys_cap_target, quotient_polys_cap)?;
     }
 
     witness.set_fri_openings(
         &proof_target.openings.to_fri_openings(zero),
         &proof.openings.to_fri_openings(),
-    );
+    )?;
 
     if let (Some(auxiliary_polys_cap_target), Some(auxiliary_polys_cap)) = (
         &proof_target.auxiliary_polys_cap,
         &proof.auxiliary_polys_cap,
     ) {
-        witness.set_cap_target(auxiliary_polys_cap_target, auxiliary_polys_cap);
+        witness.set_cap_target(auxiliary_polys_cap_target, auxiliary_polys_cap)?;
     }
 
-    set_fri_proof_target(witness, &proof_target.opening_proof, &proof.opening_proof);
+    set_fri_proof_target(witness, &proof_target.opening_proof, &proof.opening_proof)
 }
 
 /// Utility function to check that all lookups data wrapped in `Option`s are `Some` iff

--- a/starky/src/stark_testing.rs
+++ b/starky/src/stark_testing.rs
@@ -109,19 +109,19 @@ pub fn test_stark_circuit_constraints<
     let mut pw = PartialWitness::<F>::new();
 
     let locals_t = builder.add_virtual_extension_targets(S::COLUMNS);
-    pw.set_extension_targets(&locals_t, vars.get_local_values());
+    pw.set_extension_targets(&locals_t, vars.get_local_values())?;
     let nexts_t = builder.add_virtual_extension_targets(S::COLUMNS);
-    pw.set_extension_targets(&nexts_t, vars.get_next_values());
+    pw.set_extension_targets(&nexts_t, vars.get_next_values())?;
     let pis_t = builder.add_virtual_extension_targets(S::PUBLIC_INPUTS);
-    pw.set_extension_targets(&pis_t, vars.get_public_inputs());
+    pw.set_extension_targets(&pis_t, vars.get_public_inputs())?;
     let alphas_t = builder.add_virtual_targets(1);
-    pw.set_target(alphas_t[0], alphas[0]);
+    pw.set_target(alphas_t[0], alphas[0])?;
     let z_last_t = builder.add_virtual_extension_target();
-    pw.set_extension_target(z_last_t, z_last);
+    pw.set_extension_target(z_last_t, z_last)?;
     let lagrange_first_t = builder.add_virtual_extension_target();
-    pw.set_extension_target(lagrange_first_t, lagrange_first);
+    pw.set_extension_target(lagrange_first_t, lagrange_first)?;
     let lagrange_last_t = builder.add_virtual_extension_target();
-    pw.set_extension_target(lagrange_last_t, lagrange_last);
+    pw.set_extension_target(lagrange_last_t, lagrange_last)?;
 
     let vars = S::EvaluationFrameTarget::from_values(&locals_t, &nexts_t, &pis_t);
     let mut consumer = RecursiveConstraintConsumer::<F, D>::new(

--- a/starky/src/unconstrained_stark.rs
+++ b/starky/src/unconstrained_stark.rs
@@ -2,7 +2,7 @@
 //! a proof of knowledge of the trace)
 
 #[cfg(not(feature = "std"))]
-use alloc::{vec, vec::Vec};
+use alloc::vec::Vec;
 use core::marker::PhantomData;
 
 use plonky2::field::extension::{Extendable, FieldExtension};

--- a/starky/src/unconstrained_stark.rs
+++ b/starky/src/unconstrained_stark.rs
@@ -182,7 +182,7 @@ mod tests {
         let degree_bits = inner_proof.proof.recover_degree_bits(inner_config);
         let pt =
             add_virtual_stark_proof_with_pis(&mut builder, &stark, inner_config, degree_bits, 0, 0);
-        set_stark_proof_with_pis_target(&mut pw, &pt, &inner_proof, builder.zero());
+        set_stark_proof_with_pis_target(&mut pw, &pt, &inner_proof, builder.zero())?;
 
         verify_stark_proof_circuit::<F, InnerC, S, D>(&mut builder, stark, pt, inner_config);
 


### PR DESCRIPTION
closes #1490 

Also allows to address https://github.com/0xPolygonZero/zk_evm/issues/292.

Given that we already have some breaking changes pending, and this PR would just trigger warnings of unused returned `Result` on projects depending on `plonky2`, this should be a fairly sane change.

Note: _I'd recommend reviewing with `hidden whitespaces`._