### PR TITLE
Add `connect_array` convenience method in `CircuitBuilder`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,3 +30,6 @@ homepage = "https://github.com/0xPolygonZero/plonky2"
 repository = "https://github.com/0xPolygonZero/plonky2"
 keywords = ["cryptography", "SNARK", "PLONK", "FRI", "plonky2"]
 categories = ["cryptography"]
+
+[workspace.lints.clippy]
+too_long_first_doc_paragraph = "allow"

--- a/field/Cargo.toml
+++ b/field/Cargo.toml
@@ -26,3 +26,6 @@ plonky2_util = { version = "0.2.0", path = "../util", default-features = false }
 # Display math equations properly in documentation
 [package.metadata.docs.rs]
 rustdoc-args = ["--html-in-header", ".cargo/katex-header.html"]
+
+[lints]
+workspace = true

--- a/plonky2/Cargo.toml
+++ b/plonky2/Cargo.toml
@@ -87,3 +87,6 @@ harness = false
 # Display math equations properly in documentation
 [package.metadata.docs.rs]
 rustdoc-args = ["--html-in-header", ".cargo/katex-header.html"]
+
+[lints]
+workspace = true

--- a/plonky2/src/plonk/circuit_builder.rs
+++ b/plonky2/src/plonk/circuit_builder.rs
@@ -524,7 +524,7 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
             .push(CopyConstraint::new((x, y), self.context_log.open_stack()));
     }
 
-    /// Enforces that two [`Target`] arrays are equal.
+    /// Enforces that the underlying values of two [`Target`] arrays are equal.
     pub fn connect_array<const N: usize>(&mut self, x: [Target; N], y: [Target; N]) {
         for i in 0..N {
             self.connect(x[i], y[i]);

--- a/plonky2/src/plonk/circuit_builder.rs
+++ b/plonky2/src/plonk/circuit_builder.rs
@@ -524,6 +524,13 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
             .push(CopyConstraint::new((x, y), self.context_log.open_stack()));
     }
 
+    /// Enforces that two [`Target`] arrays are equal.
+    pub fn connect_array<const N: usize>(&mut self, x: [Target; N], y: [Target; N]) {
+        for i in 0..N {
+            self.connect(x[i], y[i]);
+        }
+    }
+
     /// Enforces that two [`ExtensionTarget<D>`] underlying values are equal.
     pub fn connect_extension(&mut self, src: ExtensionTarget<D>, dst: ExtensionTarget<D>) {
         for i in 0..D {

--- a/starky/Cargo.toml
+++ b/starky/Cargo.toml
@@ -36,3 +36,6 @@ env_logger = { version = "0.9.0", default-features = false }
 # Display math equations properly in documentation
 [package.metadata.docs.rs]
 rustdoc-args = ["--html-in-header", ".cargo/katex-header.html"]
+
+[lints]
+workspace = true


### PR DESCRIPTION
Mostly for reuse on zk_evm side where we heavily use arrays of targets.