### PR TITLE
changed to web-time in circuit_builder

### DIFF
--- a/plonky2/src/plonk/circuit_builder.rs
+++ b/plonky2/src/plonk/circuit_builder.rs
@@ -5,12 +5,12 @@ use alloc::{collections::BTreeMap, sync::Arc, vec, vec::Vec};
 use core::cmp::max;
 #[cfg(feature = "std")]
 use std::{collections::BTreeMap, sync::Arc};
-#[cfg(feature = "timing")]
-use web_time::Instant;
 
 use hashbrown::{HashMap, HashSet};
 use itertools::Itertools;
 use log::{debug, info, warn, Level};
+#[cfg(feature = "timing")]
+use web_time::Instant;
 
 use crate::field::cosets::get_unique_coset_shifts;
 use crate::field::extension::{Extendable, FieldExtension};

--- a/plonky2/src/plonk/circuit_builder.rs
+++ b/plonky2/src/plonk/circuit_builder.rs
@@ -4,7 +4,9 @@
 use alloc::{collections::BTreeMap, sync::Arc, vec, vec::Vec};
 use core::cmp::max;
 #[cfg(feature = "std")]
-use std::{collections::BTreeMap, sync::Arc, time::Instant};
+use std::{collections::BTreeMap, sync::Arc};
+#[cfg(feature = "timing")]
+use web_time::Instant;
 
 use hashbrown::{HashMap, HashSet};
 use itertools::Itertools;


### PR DESCRIPTION
Over in circuit_builder.rs,

std::time::Instant was used because of which wasm compilation was failing, using web_time solves it