### PR TITLE
Fix `DummyProofGenerator` serialization

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @muursh @wborgeaud @Nashtare
+* @muursh @wborgeaud @Nashtare @LindaGuiga

--- a/plonky2/src/recursion/dummy_circuit.rs
+++ b/plonky2/src/recursion/dummy_circuit.rs
@@ -287,17 +287,17 @@ where
     }
 
     fn serialize(&self, dst: &mut Vec<u8>, _common_data: &CommonCircuitData<F, D>) -> IoResult<()> {
-        dst.write_target_proof_with_public_inputs(&self.proof_with_pis_target)?;
-        dst.write_proof_with_public_inputs(&self.proof_with_pis)?;
         dst.write_target_verifier_circuit(&self.verifier_data_target)?;
-        dst.write_verifier_circuit_data(&self.verifier_data, &DefaultGateSerializer)
+        dst.write_verifier_circuit_data(&self.verifier_data, &DefaultGateSerializer)?;
+        dst.write_target_proof_with_public_inputs(&self.proof_with_pis_target)?;
+        dst.write_proof_with_public_inputs(&self.proof_with_pis)
     }
 
-    fn deserialize(src: &mut Buffer, common_data: &CommonCircuitData<F, D>) -> IoResult<Self> {
-        let proof_with_pis_target = src.read_target_proof_with_public_inputs()?;
-        let proof_with_pis = src.read_proof_with_public_inputs(common_data)?;
+    fn deserialize(src: &mut Buffer, _common_data: &CommonCircuitData<F, D>) -> IoResult<Self> {
         let verifier_data_target = src.read_target_verifier_circuit()?;
         let verifier_data = src.read_verifier_circuit_data(&DefaultGateSerializer)?;
+        let proof_with_pis_target = src.read_target_proof_with_public_inputs()?;
+        let proof_with_pis = src.read_proof_with_public_inputs(&verifier_data.common)?;
         Ok(Self {
             proof_with_pis_target,
             proof_with_pis,

--- a/plonky2/src/recursion/dummy_circuit.rs
+++ b/plonky2/src/recursion/dummy_circuit.rs
@@ -11,8 +11,11 @@ use plonky2_field::extension::Extendable;
 use plonky2_field::polynomial::PolynomialCoeffs;
 
 use crate::fri::proof::{FriProof, FriProofTarget};
+use crate::fri::reduction_strategies::FriReductionStrategy;
+use crate::fri::{FriConfig, FriParams};
 use crate::gadgets::polynomial::PolynomialCoeffsExtTarget;
 use crate::gates::noop::NoopGate;
+use crate::gates::selectors::SelectorsInfo;
 use crate::hash::hash_types::{HashOutTarget, MerkleCapTarget, RichField};
 use crate::hash::merkle_tree::MerkleCap;
 use crate::iop::generator::{GeneratedValues, SimpleGenerator};
@@ -20,14 +23,15 @@ use crate::iop::target::Target;
 use crate::iop::witness::{PartialWitness, PartitionWitness, WitnessWrite};
 use crate::plonk::circuit_builder::CircuitBuilder;
 use crate::plonk::circuit_data::{
-    CircuitData, CommonCircuitData, VerifierCircuitTarget, VerifierOnlyCircuitData,
+    CircuitConfig, CircuitData, CommonCircuitData, VerifierCircuitData, VerifierCircuitTarget,
+    VerifierOnlyCircuitData,
 };
 use crate::plonk::config::{AlgebraicHasher, GenericConfig, GenericHashOut, Hasher};
 use crate::plonk::proof::{
     OpeningSet, OpeningSetTarget, Proof, ProofTarget, ProofWithPublicInputs,
     ProofWithPublicInputsTarget,
 };
-use crate::util::serialization::{Buffer, IoResult, Read, Write};
+use crate::util::serialization::{Buffer, DefaultGateSerializer, IoResult, Read, Write};
 
 /// Creates a dummy proof which is suitable for use as a base proof in a cyclic recursion tree.
 /// Such a base proof will not actually be verified, so most of its data is arbitrary. However, its
@@ -131,7 +135,7 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
             proof_with_pis_target: dummy_proof_with_pis_target.clone(),
             proof_with_pis: dummy_proof_with_pis,
             verifier_data_target: dummy_verifier_data_target.clone(),
-            verifier_data: dummy_circuit.verifier_only,
+            verifier_data: dummy_circuit.verifier_data(),
         });
 
         Ok((dummy_proof_with_pis_target, dummy_verifier_data_target))
@@ -161,7 +165,7 @@ where
     pub(crate) proof_with_pis_target: ProofWithPublicInputsTarget<D>,
     pub(crate) proof_with_pis: ProofWithPublicInputs<F, C, D>,
     pub(crate) verifier_data_target: VerifierCircuitTarget,
-    pub(crate) verifier_data: VerifierOnlyCircuitData<C, D>,
+    pub(crate) verifier_data: VerifierCircuitData<F, C, D>,
 }
 
 impl<F, C, const D: usize> Default for DummyProofGenerator<F, C, D>
@@ -209,11 +213,42 @@ where
             },
         };
 
-        let verifier_data = VerifierOnlyCircuitData {
-            constants_sigmas_cap: MerkleCap(vec![]),
-            circuit_digest: <<C as GenericConfig<D>>::Hasher as Hasher<C::F>>::Hash::from_bytes(
-                &vec![0; <<C as GenericConfig<D>>::Hasher as Hasher<C::F>>::HASH_SIZE],
-            ),
+        let verifier_data = VerifierCircuitData {
+            common: CommonCircuitData {
+                config: CircuitConfig::default(),
+                fri_params: FriParams {
+                    config: FriConfig {
+                        rate_bits: 0,
+                        cap_height: 0,
+                        proof_of_work_bits: 0,
+                        reduction_strategy: FriReductionStrategy::MinSize(None),
+                        num_query_rounds: 0,
+                    },
+                    hiding: false,
+                    degree_bits: 0,
+                    reduction_arity_bits: vec![],
+                },
+                gates: vec![],
+                selectors_info: SelectorsInfo {
+                    selector_indices: vec![],
+                    groups: vec![],
+                },
+                quotient_degree_factor: 0,
+                num_gate_constraints: 0,
+                num_constants: 0,
+                num_public_inputs: 0,
+                k_is: vec![],
+                num_partial_products: 0,
+                num_lookup_polys: 0,
+                num_lookup_selectors: 0,
+                luts: vec![],
+            },
+            verifier_only: VerifierOnlyCircuitData {
+                constants_sigmas_cap: MerkleCap(vec![]),
+                circuit_digest: <<C as GenericConfig<D>>::Hasher as Hasher<C::F>>::Hash::from_bytes(
+                    &vec![0; <<C as GenericConfig<D>>::Hasher as Hasher<C::F>>::HASH_SIZE],
+                ),
+            },
         };
 
         Self {
@@ -245,21 +280,24 @@ where
         out_buffer: &mut GeneratedValues<F>,
     ) -> Result<()> {
         out_buffer.set_proof_with_pis_target(&self.proof_with_pis_target, &self.proof_with_pis)?;
-        out_buffer.set_verifier_data_target(&self.verifier_data_target, &self.verifier_data)
+        out_buffer.set_verifier_data_target(
+            &self.verifier_data_target,
+            &self.verifier_data.verifier_only,
+        )
     }
 
     fn serialize(&self, dst: &mut Vec<u8>, _common_data: &CommonCircuitData<F, D>) -> IoResult<()> {
         dst.write_target_proof_with_public_inputs(&self.proof_with_pis_target)?;
         dst.write_proof_with_public_inputs(&self.proof_with_pis)?;
         dst.write_target_verifier_circuit(&self.verifier_data_target)?;
-        dst.write_verifier_only_circuit_data(&self.verifier_data)
+        dst.write_verifier_circuit_data(&self.verifier_data, &DefaultGateSerializer)
     }
 
     fn deserialize(src: &mut Buffer, common_data: &CommonCircuitData<F, D>) -> IoResult<Self> {
         let proof_with_pis_target = src.read_target_proof_with_public_inputs()?;
         let proof_with_pis = src.read_proof_with_public_inputs(common_data)?;
         let verifier_data_target = src.read_target_verifier_circuit()?;
-        let verifier_data = src.read_verifier_only_circuit_data()?;
+        let verifier_data = src.read_verifier_circuit_data(&DefaultGateSerializer)?;
         Ok(Self {
             proof_with_pis_target,
             proof_with_pis,


### PR DESCRIPTION
We were using the default `common_data` to deserialize `DummyProofGenerator`, which would cause issues when using dummy proofs in a recursive scenario involving different configs.