### PR TITLE
docs: In the sentence "Licensed under either of," it is recommended to change it to "licensed under one of the following licenses," as this is a more common and accurate phrasing.

### DIFF
--- a/plonky2/README.md
+++ b/plonky2/README.md
@@ -7,7 +7,7 @@ Plonky2 is built for speed, and features a highly efficient recursive circuit. O
 
 ## License
 
-Licensed under either of
+This project is licensed under one of the following licenses:
 
 * Apache License, Version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
 * MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)


### PR DESCRIPTION
In the sentence "Licensed under either of," it is recommended to change it to "licensed under one of the following licenses," as this is a more common and accurate phrasing.