### PR TITLE
fix: use u64 in BaseSplitGenerator

### DIFF
--- a/plonky2/src/gates/base_sum.rs
+++ b/plonky2/src/gates/base_sum.rs
@@ -194,9 +194,9 @@ impl<F: RichField + Extendable<D>, const B: usize, const D: usize> SimpleGenerat
     ) -> Result<()> {
         let sum_value = witness
             .get_target(Target::wire(self.row, BaseSumGate::<B>::WIRE_SUM))
-            .to_canonical_u64() as usize;
+            .to_canonical_u64();
         debug_assert_eq!(
-            (0..self.num_limbs).fold(sum_value, |acc, _| acc / B),
+            (0..self.num_limbs).fold(sum_value, |acc, _| acc / (B as u64)),
             0,
             "Integer too large to fit in given number of limbs"
         );
@@ -205,9 +205,9 @@ impl<F: RichField + Extendable<D>, const B: usize, const D: usize> SimpleGenerat
             .map(|i| Target::wire(self.row, i));
         let limbs_value = (0..self.num_limbs)
             .scan(sum_value, |acc, _| {
-                let tmp = *acc % B;
-                *acc /= B;
-                Some(F::from_canonical_usize(tmp))
+                let tmp = *acc % (B as u64);
+                *acc /= B as u64;
+                Some(F::from_canonical_u64(tmp))
             })
             .collect::<Vec<_>>();
 


### PR DESCRIPTION
The BaseSplitGenerator was casting fields (which fit in `u64`) into `usize`. This doesn't work in 32-bit architectures where usize is 32 bits, like wasm32.  Keeping the value in `u64` allows it to work in 32-bit architectures.

We found this error while trying to run a recursive circuit in wasm, where the verification was failing.  This issue can be easily tested on an amd64 linux machine by compiling with the target i686 and running the tests.  Before this PR these are the tests that fail:
```
$ cargo test --release --target i686-unknown-linux-gnu
[...]
failures:
    batch_fri::oracle::test::batch_prove_openings
    recursion::conditional_recursive_verifier::tests::test_conditional_recursive_verifier
    recursion::cyclic_recursion::tests::test_cyclic_recursion
    recursion::recursive_verifier::tests::test_recursive_recursive_verifier
    recursion::recursive_verifier::tests::test_recursive_verifier
    recursion::recursive_verifier::tests::test_recursive_verifier_multi_hash
    recursion::recursive_verifier::tests::test_recursive_verifier_one_lookup
    recursion::recursive_verifier::tests::test_recursive_verifier_too_many_rows
    recursion::recursive_verifier::tests::test_recursive_verifier_two_luts

test result: FAILED. 85 passed; 9 failed; 1 ignored; 0 measured; 0 filtered out; finished in 59.47s
```
Note that I disabled jemalloc to be able to run in 32-bit mode.

After the fix all tests pass in 32-bit mode.