### PR TITLE
Fix typos in struct names

### DIFF
--- a/plonky2/src/batch_fri/prover.rs
+++ b/plonky2/src/batch_fri/prover.rs
@@ -10,7 +10,7 @@ use plonky2_util::{log2_strict, reverse_index_bits_in_place};
 use crate::field::extension::{unflatten, Extendable};
 use crate::field::polynomial::{PolynomialCoeffs, PolynomialValues};
 use crate::fri::proof::{FriInitialTreeProof, FriProof, FriQueryRound, FriQueryStep};
-use crate::fri::prover::{fri_proof_of_work, FriCommitedTrees};
+use crate::fri::prover::{fri_proof_of_work, FriCommittedTrees};
 use crate::fri::FriParams;
 use crate::hash::batch_merkle_tree::BatchMerkleTree;
 use crate::hash::hash_types::RichField;
@@ -94,7 +94,7 @@ pub(crate) fn batch_fri_committed_trees<
     values: &[PolynomialValues<F::Extension>],
     challenger: &mut Challenger<F, C::Hasher>,
     fri_params: &FriParams,
-) -> FriCommitedTrees<F, C, D> {
+) -> FriCommittedTrees<F, C, D> {
     let mut trees = Vec::with_capacity(fri_params.reduction_arity_bits.len());
     let mut shift = F::MULTIPLICATIVE_GROUP_GENERATOR;
     let mut polynomial_index = 1;

--- a/plonky2/src/fri/prover.rs
+++ b/plonky2/src/fri/prover.rs
@@ -69,7 +69,7 @@ pub fn fri_proof<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const
     }
 }
 
-pub(crate) type FriCommitedTrees<F, C, const D: usize> = (
+pub(crate) type FriCommittedTrees<F, C, const D: usize> = (
     Vec<MerkleTree<F, <C as GenericConfig<D>>::Hasher>>,
     PolynomialCoeffs<<F as Extendable<D>>::Extension>,
 );
@@ -88,7 +88,7 @@ fn fri_committed_trees<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>,
     fri_params: &FriParams,
     final_poly_coeff_len: Option<usize>,
     max_num_query_steps: Option<usize>,
-) -> FriCommitedTrees<F, C, D> {
+) -> FriCommittedTrees<F, C, D> {
     let mut trees = Vec::with_capacity(fri_params.reduction_arity_bits.len());
 
     let mut shift = F::MULTIPLICATIVE_GROUP_GENERATOR;

--- a/projects/cache-friendly-fft/__init__.py
+++ b/projects/cache-friendly-fft/__init__.py
@@ -174,7 +174,7 @@ def _fft_inplace(x, scratch):
         _fft_inplace_evenpow(x, scratch)
 
 
-def _scrach_length(lb_n):
+def _scratch_length(lb_n):
     """Find the amount of scratch space required to run the FFT.
 
     Layers where the input's length is an even power of two do not
@@ -206,7 +206,7 @@ def fft(x):
     # We have one scratch buffer for the whole algorithm. If we were to
     # parallelize it, we'd need one thread-local buffer for each worker
     # thread.
-    scratch_len = _scrach_length(lb_n)
+    scratch_len = _scratch_length(lb_n)
     if scratch_len == 0:
         scratch = None
     else:


### PR DESCRIPTION
- Fixed `Commited` to `Committed` in the `FriCommitedTrees` struct.
- Corrected `scrach` to `scratch` in the `_scrach_length` function.