### PR TITLE
Update LICENSE-MIT

### DIFF
--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2022 The Plonky2 Authors
+Copyright (c) 2025 The Plonky2 Authors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Updated the copyright year from 2022 to 2025 in the LICENSE file