### PR TITLE
No-Random Feature

### DIFF
--- a/field/Cargo.toml
+++ b/field/Cargo.toml
@@ -14,7 +14,8 @@ categories.workspace = true
 anyhow = { workspace = true }
 itertools = { workspace = true, features = ["use_alloc"] }
 num = { workspace = true, features = ["alloc"] }
-rand = { workspace = true, features = ["getrandom"] }
+
+rand = { workspace = true, features = ["getrandom"], optional = true }
 serde = { workspace = true, features = ["alloc"] }
 static_assertions = { workspace = true }
 unroll = { workspace = true }
@@ -29,3 +30,7 @@ rustdoc-args = ["--html-in-header", ".cargo/katex-header.html"]
 
 [lints]
 workspace = true
+
+[features]
+default = ["rand"]
+no_random = []

--- a/field/src/extension/algebra.rs
+++ b/field/src/extension/algebra.rs
@@ -190,6 +190,7 @@ impl<F: OEF<D>, const D: usize> PolynomialCoeffsAlgebra<F, D> {
 }
 
 #[cfg(test)]
+#[cfg(not(feature = "no_random"))]
 mod tests {
     use alloc::vec::Vec;
 

--- a/field/src/extension/quadratic.rs
+++ b/field/src/extension/quadratic.rs
@@ -50,6 +50,7 @@ impl<F: Extendable<2>> From<F> for QuadraticExtension<F> {
 
 impl<F: Extendable<2>> Sample for QuadraticExtension<F> {
     #[inline]
+    #[cfg(not(feature = "no_random"))]
     fn sample<R>(rng: &mut R) -> Self
     where
         R: rand::RngCore + ?Sized,

--- a/field/src/extension/quartic.rs
+++ b/field/src/extension/quartic.rs
@@ -51,6 +51,7 @@ impl<F: Extendable<4>> From<F> for QuarticExtension<F> {
 
 impl<F: Extendable<4>> Sample for QuarticExtension<F> {
     #[inline]
+    #[cfg(not(feature = "no_random"))]
     fn sample<R>(rng: &mut R) -> Self
     where
         R: rand::RngCore + ?Sized,

--- a/field/src/extension/quintic.rs
+++ b/field/src/extension/quintic.rs
@@ -51,6 +51,7 @@ impl<F: Extendable<5>> From<F> for QuinticExtension<F> {
 
 impl<F: Extendable<5>> Sample for QuinticExtension<F> {
     #[inline]
+    #[cfg(not(feature = "no_random"))]
     fn sample<R>(rng: &mut R) -> Self
     where
         R: rand::RngCore + ?Sized,

--- a/field/src/fft.rs
+++ b/field/src/fft.rs
@@ -222,7 +222,7 @@ mod tests {
         // "random", the last degree_padded-degree of them are zero.
         let coeffs = (0..degree)
             .map(|i| F::from_canonical_usize(i * 1337 % 100))
-            .chain(core::iter::repeat(F::ZERO).take(degree_padded - degree))
+            .chain(core::iter::repeat_n(F::ZERO, degree_padded - degree))
             .collect::<Vec<_>>();
         assert_eq!(coeffs.len(), degree_padded);
         let coefficients = PolynomialCoeffs { coeffs };

--- a/field/src/fft.rs
+++ b/field/src/fft.rs
@@ -222,7 +222,7 @@ mod tests {
         // "random", the last degree_padded-degree of them are zero.
         let coeffs = (0..degree)
             .map(|i| F::from_canonical_usize(i * 1337 % 100))
-            .chain(core::iter::repeat_n(F::ZERO, degree_padded - degree))
+            .chain(core::iter::repeat(F::ZERO).take(degree_padded - degree))
             .collect::<Vec<_>>();
         assert_eq!(coeffs.len(), degree_padded);
         let coefficients = PolynomialCoeffs { coeffs };

--- a/field/src/field_testing.rs
+++ b/field/src/field_testing.rs
@@ -60,6 +60,7 @@ macro_rules! test_field_arithmetic {
             }
 
             #[test]
+            #[cfg(not(feature = "no_random"))]
             fn exponentiation() {
                 type F = $field;
 
@@ -84,6 +85,7 @@ macro_rules! test_field_arithmetic {
             }
 
             #[test]
+            #[cfg(not(feature = "no_random"))]
             fn exponentiation_large() {
                 type F = $field;
 
@@ -101,6 +103,7 @@ macro_rules! test_field_arithmetic {
             }
 
             #[test]
+            #[cfg(not(feature = "no_random"))]
             fn inverses() {
                 type F = $field;
 
@@ -117,6 +120,7 @@ macro_rules! test_field_arithmetic {
 }
 
 #[allow(clippy::eq_op)]
+#[cfg(not(feature = "no_random"))]
 pub(crate) fn test_add_neg_sub_mul<BF: Extendable<D>, const D: usize>() {
     let x = BF::Extension::rand();
     let y = BF::Extension::rand();
@@ -133,6 +137,7 @@ pub(crate) fn test_add_neg_sub_mul<BF: Extendable<D>, const D: usize>() {
     assert_eq!(x * (y + z), x * y + x * z);
 }
 
+#[cfg(not(feature = "no_random"))]
 pub(crate) fn test_inv_div<BF: Extendable<D>, const D: usize>() {
     let x = BF::Extension::rand();
     let y = BF::Extension::rand();
@@ -145,6 +150,7 @@ pub(crate) fn test_inv_div<BF: Extendable<D>, const D: usize>() {
     assert_eq!((x * y) / z, x * (y / z));
 }
 
+#[cfg(not(feature = "no_random"))]
 pub(crate) fn test_frobenius<BF: Extendable<D>, const D: usize>() {
     let x = BF::Extension::rand();
     assert_eq!(x.exp_biguint(&BF::order()), x.frobenius());
@@ -156,6 +162,7 @@ pub(crate) fn test_frobenius<BF: Extendable<D>, const D: usize>() {
     }
 }
 
+#[cfg(not(feature = "no_random"))]
 pub(crate) fn test_field_order<BF: Extendable<D>, const D: usize>() {
     let x = BF::Extension::rand();
     assert_eq!(
@@ -182,18 +189,22 @@ macro_rules! test_field_extension {
     ($field:ty, $d:expr) => {
         mod field_extension {
             #[test]
+            #[cfg(not(feature = "no_random"))]
             fn test_add_neg_sub_mul() {
                 $crate::field_testing::test_add_neg_sub_mul::<$field, $d>();
             }
             #[test]
+            #[cfg(not(feature = "no_random"))]
             fn test_inv_div() {
                 $crate::field_testing::test_inv_div::<$field, $d>();
             }
             #[test]
+            #[cfg(not(feature = "no_random"))]
             fn test_frobenius() {
                 $crate::field_testing::test_frobenius::<$field, $d>();
             }
             #[test]
+            #[cfg(not(feature = "no_random"))]
             fn test_field_order() {
                 $crate::field_testing::test_field_order::<$field, $d>();
             }

--- a/field/src/goldilocks_field.rs
+++ b/field/src/goldilocks_field.rs
@@ -58,6 +58,7 @@ impl Debug for GoldilocksField {
 
 impl Sample for GoldilocksField {
     #[inline]
+    #[cfg(not(feature = "no_random"))]
     fn sample<R>(rng: &mut R) -> Self
     where
         R: rand::RngCore + ?Sized,

--- a/field/src/interpolation.rs
+++ b/field/src/interpolation.rs
@@ -76,6 +76,7 @@ pub fn interpolate2<F: Field>(points: [(F, F); 2], x: F) -> F {
 }
 
 #[cfg(test)]
+#[cfg(not(feature = "no_random"))]
 mod tests {
     use super::*;
     use crate::extension::quartic::QuarticExtension;

--- a/field/src/polynomial/division.rs
+++ b/field/src/polynomial/division.rs
@@ -133,6 +133,7 @@ impl<F: Field> PolynomialCoeffs<F> {
 }
 
 #[cfg(test)]
+#[cfg(not(feature = "no_random"))]
 mod tests {
     use rand::rngs::OsRng;
     use rand::Rng;

--- a/field/src/polynomial/mod.rs
+++ b/field/src/polynomial/mod.rs
@@ -437,6 +437,7 @@ impl<F: Field> Mul for &PolynomialCoeffs<F> {
 }
 
 #[cfg(test)]
+#[cfg(not(feature = "no_random"))]
 mod tests {
     use std::time::Instant;
 

--- a/field/src/prime_field_testing.rs
+++ b/field/src/prime_field_testing.rs
@@ -160,7 +160,8 @@ macro_rules! test_prime_field_arithmetic {
             fn subtraction_double_wraparound() {
                 type F = $field;
 
-                let (a, b) = (F::from_canonical_u64(F::ORDER.div_ceil(2u64)), F::TWO);                let x = a * b;
+                let (a, b) = (F::from_canonical_u64(F::ORDER.div_ceil(2u64)), F::TWO);
+                let x = a * b;
                 assert_eq!(x, F::ONE);
                 assert_eq!(F::ZERO - x, F::NEG_ONE);
             }

--- a/field/src/prime_field_testing.rs
+++ b/field/src/prime_field_testing.rs
@@ -160,7 +160,7 @@ macro_rules! test_prime_field_arithmetic {
             fn subtraction_double_wraparound() {
                 type F = $field;
 
-                let (a, b) = (F::from_canonical_u64(F::ORDER.div_ceil(2u64)), F::TWO);
+                let (a, b) = (F::from_canonical_u64((F::ORDER + 1u64) / 2u64), F::TWO);
                 let x = a * b;
                 assert_eq!(x, F::ONE);
                 assert_eq!(F::ZERO - x, F::NEG_ONE);

--- a/field/src/prime_field_testing.rs
+++ b/field/src/prime_field_testing.rs
@@ -160,8 +160,7 @@ macro_rules! test_prime_field_arithmetic {
             fn subtraction_double_wraparound() {
                 type F = $field;
 
-                let (a, b) = (F::from_canonical_u64((F::ORDER + 1u64) / 2u64), F::TWO);
-                let x = a * b;
+                let (a, b) = (F::from_canonical_u64(F::ORDER.div_ceil(2u64)), F::TWO);                let x = a * b;
                 assert_eq!(x, F::ONE);
                 assert_eq!(F::ZERO - x, F::NEG_ONE);
             }

--- a/field/src/secp256k1_base.rs
+++ b/field/src/secp256k1_base.rs
@@ -67,6 +67,7 @@ impl Debug for Secp256K1Base {
 
 impl Sample for Secp256K1Base {
     #[inline]
+    #[cfg(not(feature = "no_random"))]
     fn sample<R>(rng: &mut R) -> Self
     where
         R: rand::RngCore + ?Sized,

--- a/field/src/secp256k1_scalar.rs
+++ b/field/src/secp256k1_scalar.rs
@@ -69,6 +69,7 @@ impl Debug for Secp256K1Scalar {
 
 impl Sample for Secp256K1Scalar {
     #[inline]
+    #[cfg(not(feature = "no_random"))]
     fn sample<R>(rng: &mut R) -> Self
     where
         R: rand::RngCore + ?Sized,

--- a/field/src/types.rs
+++ b/field/src/types.rs
@@ -8,6 +8,7 @@ use core::ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Sub, SubAss
 use num::bigint::BigUint;
 use num::{Integer, One, ToPrimitive, Zero};
 use plonky2_util::bits_u64;
+#[cfg(not(feature = "no_random"))]
 use rand::rngs::OsRng;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
@@ -18,24 +19,28 @@ use crate::ops::Square;
 /// Sampling
 pub trait Sample: Sized {
     /// Samples a single value using `rng`.
+    #[cfg(not(feature = "no_random"))]
     fn sample<R>(rng: &mut R) -> Self
     where
         R: rand::RngCore + ?Sized;
 
     /// Samples a single value using the [`OsRng`].
     #[inline]
+    #[cfg(not(feature = "no_random"))]
     fn rand() -> Self {
         Self::sample(&mut OsRng)
     }
 
     /// Samples a [`Vec`] of values of length `n` using [`OsRng`].
     #[inline]
+    #[cfg(not(feature = "no_random"))]
     fn rand_vec(n: usize) -> Vec<Self> {
         (0..n).map(|_| Self::rand()).collect()
     }
 
     /// Samples an array of values of length `N` using [`OsRng`].
     #[inline]
+    #[cfg(not(feature = "no_random"))]
     fn rand_array<const N: usize>() -> [Self; N] {
         Self::rand_vec(N)
             .try_into()

--- a/plonky2/Cargo.toml
+++ b/plonky2/Cargo.toml
@@ -12,11 +12,12 @@ keywords.workspace = true
 categories.workspace = true
 
 [features]
-default = ["gate_testing", "parallel", "rand_chacha", "std", "timing"]
+default = ["gate_testing", "parallel", "rand_chacha", "timing", "getrandom", "plonky2_field/default"]
 gate_testing = []
 parallel = ["hashbrown/rayon", "plonky2_maybe_rayon/parallel"]
 std = ["anyhow/std", "rand/std", "itertools/use_std"]
 timing = ["std", "dep:web-time"]
+no_random = ["plonky2_field/no_random"]
 
 [dependencies]
 ahash = { workspace = true }
@@ -39,8 +40,8 @@ plonky2_maybe_rayon = { version = "1.0.0", path = "../maybe_rayon", default-feat
 plonky2_util = { version = "1.0.0", path = "../util", default-features = false }
 
 
-[target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
-getrandom = { version = "0.2", default-features = false, features = ["js"] }
+[target.'cfg(all(target_arch = "wasm32", target_os = "unknown", not(feature = "no-random")))'.dependencies]
+getrandom = { version = "0.2", default-features = false, features = ["js"], optional = true }
 
 [dev-dependencies]
 criterion = { version = "0.5.1", default-features = false }

--- a/plonky2/examples/square_root.rs
+++ b/plonky2/examples/square_root.rs
@@ -137,9 +137,6 @@ fn main() -> Result<()> {
 
     // Randomly generate the value of x^2: any quadratic residue in the field works.
     let x_squared_value = {
-        #[cfg(feature = "no_random")]
-        let mut val = F::from_noncanonical_i64(-2);
-        #[cfg(not(feature = "no_random"))]
         let mut val = F::rand();
         while !val.is_quadratic_residue() {
             val = F::rand();

--- a/plonky2/src/batch_fri/oracle.rs
+++ b/plonky2/src/batch_fri/oracle.rs
@@ -249,6 +249,7 @@ impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
 }
 
 #[cfg(test)]
+#[cfg(not(feature = "no_random"))]
 mod test {
     #[cfg(not(feature = "std"))]
     use alloc::vec;

--- a/plonky2/src/batch_fri/prover.rs
+++ b/plonky2/src/batch_fri/prover.rs
@@ -339,6 +339,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(not(feature = "no_random"))]
     fn multiple_polynomials() -> Result<()> {
         let mut timing = TimingTree::default();
 

--- a/plonky2/src/fri/oracle.rs
+++ b/plonky2/src/fri/oracle.rs
@@ -117,10 +117,27 @@ impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
         blinding: bool,
         fft_root_table: Option<&FftRootTable<F>>,
     ) -> Vec<Vec<F>> {
+        if blinding {
+            #[cfg(not(feature = "no_random"))]
+            return Self::lde_blinded_values(polynomials, rate_bits, fft_root_table);
+            #[cfg(feature = "no_random")]
+            assert!(false, "Cannot set blinding with no_random feature");
+            [].into()
+        } else {
+            Self::lde_unblinded_values(polynomials, rate_bits, fft_root_table)
+        }
+    }
+
+    #[cfg(not(feature = "no_random"))]
+    fn lde_blinded_values(
+        polynomials: &[PolynomialCoeffs<F>],
+        rate_bits: usize,
+        fft_root_table: Option<&FftRootTable<F>>
+    ) -> Vec<Vec<F>> {
         let degree = polynomials[0].len();
 
         // If blinding, salt with two random elements to each leaf vector.
-        let salt_size = if blinding { SALT_SIZE } else { 0 };
+        let salt_size = SALT_SIZE;
 
         polynomials
             .par_iter()
@@ -135,6 +152,24 @@ impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
                     .into_par_iter()
                     .map(|_| F::rand_vec(degree << rate_bits)),
             )
+            .collect()
+    }
+
+    fn lde_unblinded_values(
+        polynomials: &[PolynomialCoeffs<F>],
+        rate_bits: usize,
+        fft_root_table: Option<&FftRootTable<F>>
+    ) -> Vec<Vec<F>> {
+        let degree = polynomials[0].len();
+
+        polynomials
+            .par_iter()
+            .map(|p| {
+                assert_eq!(p.len(), degree, "Polynomial degrees inconsistent");
+                p.lde(rate_bits)
+                    .coset_fft_with_options(F::coset_shift(), Some(rate_bits), fft_root_table)
+                    .values
+            })
             .collect()
     }
 

--- a/plonky2/src/fri/oracle.rs
+++ b/plonky2/src/fri/oracle.rs
@@ -136,9 +136,6 @@ impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
     ) -> Vec<Vec<F>> {
         let degree = polynomials[0].len();
 
-        // If blinding, salt with two random elements to each leaf vector.
-        let salt_size = SALT_SIZE;
-
         polynomials
             .par_iter()
             .map(|p| {
@@ -148,7 +145,7 @@ impl<F: RichField + Extendable<D>, C: GenericConfig<D, F = F>, const D: usize>
                     .values
             })
             .chain(
-                (0..salt_size)
+                (0..SALT_SIZE)
                     .into_par_iter()
                     .map(|_| F::rand_vec(degree << rate_bits)),
             )

--- a/plonky2/src/gadgets/arithmetic_extension.rs
+++ b/plonky2/src/gadgets/arithmetic_extension.rs
@@ -615,6 +615,7 @@ pub(crate) struct ExtensionArithmeticOperation<F: Field64 + Extendable<D>, const
 }
 
 #[cfg(test)]
+#[cfg(not(feature = "no_random"))]
 mod tests {
     use anyhow::Result;
 

--- a/plonky2/src/gadgets/interpolation.rs
+++ b/plonky2/src/gadgets/interpolation.rs
@@ -38,6 +38,7 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
 }
 
 #[cfg(test)]
+#[cfg(not(feature = "no_random"))]
 mod tests {
     #[cfg(not(feature = "std"))]
     use alloc::vec::Vec;

--- a/plonky2/src/gadgets/random_access.rs
+++ b/plonky2/src/gadgets/random_access.rs
@@ -121,6 +121,7 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
 }
 
 #[cfg(test)]
+#[cfg(not(feature = "no_random"))]
 mod tests {
     use anyhow::Result;
 

--- a/plonky2/src/gadgets/select.rs
+++ b/plonky2/src/gadgets/select.rs
@@ -37,6 +37,7 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
 }
 
 #[cfg(test)]
+#[cfg(not(feature = "no_random"))]
 mod tests {
     use anyhow::Result;
 

--- a/plonky2/src/gates/arithmetic_base.rs
+++ b/plonky2/src/gates/arithmetic_base.rs
@@ -252,6 +252,7 @@ impl<F: RichField + Extendable<D>, const D: usize> SimpleGenerator<F, D>
 }
 
 #[cfg(test)]
+#[cfg(not(feature = "no_random"))]
 mod tests {
     use anyhow::Result;
 

--- a/plonky2/src/gates/arithmetic_extension.rs
+++ b/plonky2/src/gates/arithmetic_extension.rs
@@ -245,6 +245,7 @@ impl<F: RichField + Extendable<D>, const D: usize> SimpleGenerator<F, D>
 }
 
 #[cfg(test)]
+#[cfg(not(feature = "no_random"))]
 mod tests {
     use anyhow::Result;
 

--- a/plonky2/src/gates/base_sum.rs
+++ b/plonky2/src/gates/base_sum.rs
@@ -231,6 +231,7 @@ impl<F: RichField + Extendable<D>, const B: usize, const D: usize> SimpleGenerat
 }
 
 #[cfg(test)]
+#[cfg(not(feature = "no_random"))]
 mod tests {
     use anyhow::Result;
 

--- a/plonky2/src/gates/constant.rs
+++ b/plonky2/src/gates/constant.rs
@@ -130,6 +130,7 @@ impl<F: RichField + Extendable<D>, const D: usize> PackedEvaluableBase<F, D> for
 }
 
 #[cfg(test)]
+#[cfg(not(feature = "no_random"))]
 mod tests {
     use anyhow::Result;
 

--- a/plonky2/src/gates/coset_interpolation.rs
+++ b/plonky2/src/gates/coset_interpolation.rs
@@ -643,6 +643,7 @@ fn partial_interpolate_ext_algebra_target<F: RichField + Extendable<D>, const D:
 }
 
 #[cfg(test)]
+#[cfg(not(feature = "no_random"))]
 mod tests {
     use anyhow::Result;
     use plonky2_field::polynomial::PolynomialValues;

--- a/plonky2/src/gates/exponentiation.rs
+++ b/plonky2/src/gates/exponentiation.rs
@@ -318,6 +318,7 @@ impl<F: RichField + Extendable<D>, const D: usize> SimpleGenerator<F, D>
 }
 
 #[cfg(test)]
+#[cfg(not(feature = "no_random"))]
 mod tests {
     use anyhow::Result;
     use rand::rngs::OsRng;

--- a/plonky2/src/gates/gate_testing.rs
+++ b/plonky2/src/gates/gate_testing.rs
@@ -21,6 +21,7 @@ const WITNESS_DEGREE: usize = WITNESS_SIZE - 1;
 
 /// Tests that the constraints imposed by the given gate are low-degree by applying them to random
 /// low-degree witness polynomials.
+#[cfg(not(feature = "no_random"))]
 pub fn test_low_degree<F: RichField + Extendable<D>, G: Gate<F, D>, const D: usize>(gate: G) {
     let rate_bits = log2_ceil(gate.degree() + 1);
 
@@ -66,6 +67,7 @@ pub fn test_low_degree<F: RichField + Extendable<D>, G: Gate<F, D>, const D: usi
     );
 }
 
+#[cfg(not(feature = "no_random"))]
 fn random_low_degree_matrix<F: Field>(num_polys: usize, rate_bits: usize) -> Vec<Vec<F>> {
     let polys = (0..num_polys)
         .map(|_| random_low_degree_values(rate_bits))
@@ -79,6 +81,7 @@ fn random_low_degree_matrix<F: Field>(num_polys: usize, rate_bits: usize) -> Vec
     }
 }
 
+#[cfg(not(feature = "no_random"))]
 fn random_low_degree_values<F: Field>(rate_bits: usize) -> Vec<F> {
     PolynomialCoeffs::new(F::rand_vec(WITNESS_SIZE))
         .lde(rate_bits)
@@ -86,6 +89,7 @@ fn random_low_degree_values<F: Field>(rate_bits: usize) -> Vec<F> {
         .values
 }
 
+#[cfg(not(feature = "no_random"))]
 pub fn test_eval_fns<
     F: RichField + Extendable<D>,
     C: GenericConfig<D, F = F>,

--- a/plonky2/src/gates/multiplication_extension.rs
+++ b/plonky2/src/gates/multiplication_extension.rs
@@ -215,6 +215,7 @@ impl<F: RichField + Extendable<D>, const D: usize> SimpleGenerator<F, D>
 }
 
 #[cfg(test)]
+#[cfg(not(feature = "no_random"))]
 mod tests {
     use anyhow::Result;
 

--- a/plonky2/src/gates/noop.rs
+++ b/plonky2/src/gates/noop.rs
@@ -70,6 +70,7 @@ impl<F: RichField + Extendable<D>, const D: usize> Gate<F, D> for NoopGate {
 }
 
 #[cfg(test)]
+#[cfg(not(feature = "no_random"))]
 mod tests {
     use crate::field::goldilocks_field::GoldilocksField;
     use crate::gates::gate_testing::{test_eval_fns, test_low_degree};

--- a/plonky2/src/gates/poseidon.rs
+++ b/plonky2/src/gates/poseidon.rs
@@ -543,6 +543,7 @@ impl<F: RichField + Extendable<D> + Poseidon, const D: usize> SimpleGenerator<F,
 }
 
 #[cfg(test)]
+#[cfg(not(feature = "no_random"))]
 mod tests {
     use anyhow::Result;
     use plonky2_field::goldilocks_field::GoldilocksField;

--- a/plonky2/src/gates/poseidon_mds.rs
+++ b/plonky2/src/gates/poseidon_mds.rs
@@ -278,6 +278,7 @@ impl<F: RichField + Extendable<D> + Poseidon, const D: usize> SimpleGenerator<F,
 }
 
 #[cfg(test)]
+#[cfg(not(feature = "no_random"))]
 mod tests {
     use crate::gates::gate_testing::{test_eval_fns, test_low_degree};
     use crate::gates::poseidon_mds::PoseidonMdsGate;

--- a/plonky2/src/gates/public_input.rs
+++ b/plonky2/src/gates/public_input.rs
@@ -114,6 +114,7 @@ impl<F: RichField + Extendable<D>, const D: usize> PackedEvaluableBase<F, D> for
 }
 
 #[cfg(test)]
+#[cfg(not(feature = "no_random"))]
 mod tests {
     use crate::field::goldilocks_field::GoldilocksField;
     use crate::gates::gate_testing::{test_eval_fns, test_low_degree};

--- a/plonky2/src/gates/random_access.rs
+++ b/plonky2/src/gates/random_access.rs
@@ -420,6 +420,7 @@ impl<F: RichField + Extendable<D>, const D: usize> SimpleGenerator<F, D>
 }
 
 #[cfg(test)]
+#[cfg(not(feature = "no_random"))]
 mod tests {
     use anyhow::Result;
     use rand::rngs::OsRng;

--- a/plonky2/src/gates/reducing.rs
+++ b/plonky2/src/gates/reducing.rs
@@ -250,6 +250,7 @@ impl<F: RichField + Extendable<D>, const D: usize> SimpleGenerator<F, D> for Red
 }
 
 #[cfg(test)]
+#[cfg(not(feature = "no_random"))]
 mod tests {
     use anyhow::Result;
 

--- a/plonky2/src/gates/reducing_extension.rs
+++ b/plonky2/src/gates/reducing_extension.rs
@@ -245,6 +245,7 @@ impl<F: RichField + Extendable<D>, const D: usize> SimpleGenerator<F, D> for Red
 }
 
 #[cfg(test)]
+#[cfg(not(feature = "no_random"))]
 mod tests {
     use anyhow::Result;
 

--- a/plonky2/src/hash/batch_merkle_tree.rs
+++ b/plonky2/src/hash/batch_merkle_tree.rs
@@ -294,6 +294,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(not(feature = "no_random"))]
     fn test_batch_merkle_trees() -> Result<()> {
         let leaves_1 = crate::hash::merkle_tree::tests::random_data::<F>(1024, 7);
         let leaves_2 = crate::hash::merkle_tree::tests::random_data::<F>(64, 3);
@@ -317,6 +318,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(not(feature = "no_random"))]
     fn test_batch_merkle_trees_cap_at_leaves_height() -> Result<()> {
         let leaves_1 = crate::hash::merkle_tree::tests::random_data::<F>(16, 7);
 

--- a/plonky2/src/hash/hash_types.rs
+++ b/plonky2/src/hash/hash_types.rs
@@ -68,6 +68,7 @@ where
     F: Field,
 {
     #[inline]
+    #[cfg(not(feature = "no_random"))]
     fn sample<R>(rng: &mut R) -> Self
     where
         R: rand::RngCore + ?Sized,
@@ -162,6 +163,7 @@ pub struct BytesHash<const N: usize>(pub [u8; N]);
 
 impl<const N: usize> Sample for BytesHash<N> {
     #[inline]
+    #[cfg(not(feature = "no_random"))]
     fn sample<R>(rng: &mut R) -> Self
     where
         R: rand::RngCore + ?Sized,

--- a/plonky2/src/hash/merkle_proofs.rs
+++ b/plonky2/src/hash/merkle_proofs.rs
@@ -313,6 +313,7 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
 }
 
 #[cfg(test)]
+#[cfg(not(feature = "no_random"))]
 mod tests {
     use rand::rngs::OsRng;
     use rand::Rng;

--- a/plonky2/src/hash/merkle_tree.rs
+++ b/plonky2/src/hash/merkle_tree.rs
@@ -238,6 +238,7 @@ impl<F: RichField, H: Hasher<F>> MerkleTree<F, H> {
 }
 
 #[cfg(test)]
+#[cfg(not(feature = "no_random"))]
 pub(crate) mod tests {
     use anyhow::Result;
 

--- a/plonky2/src/hash/path_compression.rs
+++ b/plonky2/src/hash/path_compression.rs
@@ -113,6 +113,7 @@ pub(crate) fn decompress_merkle_proofs<F: RichField, H: Hasher<F>>(
 }
 
 #[cfg(test)]
+#[cfg(not(feature = "no_random"))]
 mod tests {
     use rand::rngs::OsRng;
     use rand::Rng;

--- a/plonky2/src/iop/challenger.rs
+++ b/plonky2/src/iop/challenger.rs
@@ -293,6 +293,7 @@ impl<F: RichField + Extendable<D>, H: AlgebraicHasher<F>, const D: usize>
 }
 
 #[cfg(test)]
+#[cfg(not(feature = "no_random"))]
 mod tests {
     #[cfg(not(feature = "std"))]
     use alloc::vec::Vec;

--- a/plonky2/src/iop/generator.rs
+++ b/plonky2/src/iop/generator.rs
@@ -313,10 +313,12 @@ impl<F: RichField + Extendable<D>, const D: usize> SimpleGenerator<F, D> for Cop
 
 /// A generator for including a random value
 #[derive(Debug, Default)]
+#[cfg(not(feature = "no_random"))]
 pub struct RandomValueGenerator {
     pub(crate) target: Target,
 }
 
+#[cfg(not(feature = "no_random"))]
 impl<F: RichField + Extendable<D>, const D: usize> SimpleGenerator<F, D> for RandomValueGenerator {
     fn id(&self) -> String {
         "RandomValueGenerator".to_string()

--- a/plonky2/src/plonk/proof.rs
+++ b/plonky2/src/plonk/proof.rs
@@ -472,6 +472,7 @@ mod tests {
     use crate::plonk::verifier::verify;
 
     #[test]
+    #[cfg(not(feature = "no_random"))]
     fn test_proof_compression() -> Result<()> {
         const D: usize = 2;
         type C = PoseidonGoldilocksConfig;

--- a/plonky2/src/recursion/conditional_recursive_verifier.rs
+++ b/plonky2/src/recursion/conditional_recursive_verifier.rs
@@ -343,6 +343,7 @@ impl<F: RichField + Extendable<D>, const D: usize> CircuitBuilder<F, D> {
 }
 
 #[cfg(test)]
+#[cfg(not(feature = "no_random"))]
 mod tests {
     #[cfg(not(feature = "std"))]
     use alloc::vec;

--- a/plonky2/src/recursion/recursive_verifier.rs
+++ b/plonky2/src/recursion/recursive_verifier.rs
@@ -220,6 +220,7 @@ mod tests {
     use crate::util::timing::TimingTree;
 
     #[test]
+    #[cfg(not(feature = "no_random"))]
     fn test_recursive_verifier() -> Result<()> {
         init_logger();
         const D: usize = 2;
@@ -236,6 +237,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(not(feature = "no_random"))]
     fn test_recursive_verifier_one_lookup() -> Result<()> {
         init_logger();
         const D: usize = 2;

--- a/plonky2/src/util/reducing.rs
+++ b/plonky2/src/util/reducing.rs
@@ -273,6 +273,7 @@ impl<const D: usize> ReducingFactorTarget<D> {
 }
 
 #[cfg(test)]
+#[cfg(not(feature = "no_random"))]
 mod tests {
     use anyhow::Result;
 

--- a/plonky2/src/util/serialization/generator_serialization.rs
+++ b/plonky2/src/util/serialization/generator_serialization.rs
@@ -121,8 +121,10 @@ pub mod default {
     use crate::gates::reducing_extension::ReducingGenerator as ReducingExtensionGenerator;
     use crate::hash::hash_types::RichField;
     use crate::iop::generator::{
-        ConstantGenerator, CopyGenerator, NonzeroTestGenerator, RandomValueGenerator,
+        ConstantGenerator, CopyGenerator, NonzeroTestGenerator,
     };
+    #[cfg(not(feature = "no_random"))]
+    use crate::iop::generator::RandomValueGenerator;
     use crate::plonk::config::{AlgebraicHasher, GenericConfig};
     use crate::recursion::dummy_circuit::DummyProofGenerator;
     use crate::util::serialization::WitnessGeneratorSerializer;
@@ -151,6 +153,34 @@ pub mod default {
         C: GenericConfig<D, F = F> + 'static,
         C::Hasher: AlgebraicHasher<F>,
     {
+        #[cfg(feature = "no_random")]
+        impl_generator_serializer! {
+            DefaultGeneratorSerializer,
+            ArithmeticBaseGenerator<F, D>,
+            ArithmeticExtensionGenerator<F, D>,
+            BaseSplitGenerator<2>,
+            BaseSumGenerator<2>,
+            ConstantGenerator<F>,
+            CopyGenerator,
+            DummyProofGenerator<F, C, D>,
+            EqualityGenerator,
+            ExponentiationGenerator<F, D>,
+            InterpolationGenerator<F, D>,
+            LookupGenerator,
+            LookupTableGenerator,
+            LowHighGenerator,
+            MulExtensionGenerator<F, D>,
+            NonzeroTestGenerator,
+            PoseidonGenerator<F, D>,
+            PoseidonMdsGenerator<D>,
+            QuotientGeneratorExtension<D>,
+            RandomAccessGenerator<F, D>,
+            ReducingGenerator<D>,
+            ReducingExtensionGenerator<D>,
+            SplitGenerator,
+            WireSplitGenerator
+        }
+        #[cfg(not(feature = "no_random"))]
         impl_generator_serializer! {
             DefaultGeneratorSerializer,
             ArithmeticBaseGenerator<F, D>,


### PR DESCRIPTION
This PR adds a feature to both plonky2_field and plonky2 subcrates called "no_random", which removes any randomness from the library. This is ideal in use-cases where the verifier is on a blockchain. In our case, substrate's build process itself will not allow randomness. Of course disabling randomness requires disabling many tests and significantly impacts the prover side of things, but the feature is designed for verifiers.

This PR addresses this issue: https://github.com/0xPolygonZero/plonky2/issues/1659

The general strategy was to gut the Sample trait, but leave it defined, then put everything that uses those functions behind cfg flags. There were a couple other places that deserve mention, I will point them out in the code. 

Probably many of these tests could be salvaged by using the hash of some default value or something but it didn't seem worth doing.