### PR TITLE
Enhance Merkle tree tests with multiple parameters

### DIFF
--- a/plonky2/src/hash/merkle_tree.rs
+++ b/plonky2/src/hash/merkle_tree.rs
@@ -301,11 +301,20 @@ pub(crate) mod tests {
         type C = PoseidonGoldilocksConfig;
         type F = <C as GenericConfig<D>>::F;
 
-        let log_n = 8;
-        let n = 1 << log_n;
-        let leaves = random_data::<F>(n, 7);
-
-        verify_all_leaves::<F, C, D>(leaves, 1)?;
+        // Test with different log_n values (tree sizes)
+        for log_n in [4, 6, 8] {
+            let n = 1 << log_n;
+            
+            // Use different leaf sizes
+            for leaf_size in [3, 7, 12] {
+                let leaves = random_data::<F>(n, leaf_size);
+                
+                // Test with different cap heights
+                for cap_height in 1..=log_n {
+                    verify_all_leaves::<F, C, D>(leaves.clone(), cap_height)?;
+                }
+            }
+        }
 
         Ok(())
     }


### PR DESCRIPTION
Improves the test_merkle_trees test by:
- Testing with different tree sizes (16, 64, and 256 leaves)
- Validating with different leaf data sizes (3, 7, and 12 elements)
- Testing all possible cap heights for each tree size (1..=log_n)

This change significantly increases test coverage by exercising the Merkle tree 
implementation across a broader range of parameters, which helps ensure robustness
and correctness for all supported configurations.