### PR TITLE
Make impl_gate_serializer work without needing to import read_gate_impl etc.

### DIFF
--- a/plonky2/examples/square_root.rs
+++ b/plonky2/examples/square_root.rs
@@ -6,6 +6,7 @@ use plonky2::gates::arithmetic_base::ArithmeticBaseGenerator;
 use plonky2::gates::poseidon::PoseidonGenerator;
 use plonky2::gates::poseidon_mds::PoseidonMdsGenerator;
 use plonky2::hash::hash_types::RichField;
+use plonky2::impl_generator_serializer;
 use plonky2::iop::generator::{
     ConstantGenerator, GeneratedValues, RandomValueGenerator, SimpleGenerator,
 };
@@ -18,7 +19,6 @@ use plonky2::recursion::dummy_circuit::DummyProofGenerator;
 use plonky2::util::serialization::{
     Buffer, DefaultGateSerializer, IoResult, Read, WitnessGeneratorSerializer, Write,
 };
-use plonky2::{get_generator_tag_impl, impl_generator_serializer, read_generator_impl};
 use plonky2_field::extension::Extendable;
 
 /// A generator used by the prover to calculate the square root (`x`) of a given value

--- a/plonky2/src/util/serialization/gate_serialization.rs
+++ b/plonky2/src/util/serialization/gate_serialization.rs
@@ -75,7 +75,7 @@ macro_rules! impl_gate_serializer {
             common: &$crate::plonk::circuit_data::CommonCircuitData<F, D>,
         ) -> $crate::util::serialization::IoResult<$crate::gates::gate::GateRef<F, D>> {
             let tag = $crate::util::serialization::Read::read_u32(buf)?;
-            read_gate_impl!(buf, tag, common, $($gate_types),+)
+            $crate::read_gate_impl!(buf, tag, common, $($gate_types),+)
         }
 
         fn write_gate(
@@ -84,7 +84,7 @@ macro_rules! impl_gate_serializer {
             gate: &$crate::gates::gate::GateRef<F, D>,
             common: &$crate::plonk::circuit_data::CommonCircuitData<F, D>,
         ) -> $crate::util::serialization::IoResult<()> {
-            let tag = get_gate_tag_impl!(gate, $($gate_types),+)?;
+            let tag = $crate::get_gate_tag_impl!(gate, $($gate_types),+)?;
 
             $crate::util::serialization::Write::write_u32(buf, tag)?;
             gate.0.serialize(buf, common)?;

--- a/plonky2/src/util/serialization/generator_serialization.rs
+++ b/plonky2/src/util/serialization/generator_serialization.rs
@@ -55,8 +55,8 @@ macro_rules! get_generator_tag_impl {
             Ok(tag)
         } else)*
         {
-            log::log!(
-                log::Level::Error,
+            $crate::util::serialization::gate_serialization::log::log!(
+                $crate::util::serialization::gate_serialization::log::Level::Error,
                 "attempted to serialize generator with id {} which is unsupported by this generator serializer",
                 $generator.0.id()
             );
@@ -78,7 +78,7 @@ macro_rules! impl_generator_serializer {
             common: &$crate::plonk::circuit_data::CommonCircuitData<F, D>,
         ) -> $crate::util::serialization::IoResult<$crate::iop::generator::WitnessGeneratorRef<F, D>> {
             let tag = $crate::util::serialization::Read::read_u32(buf)?;
-            read_generator_impl!(buf, tag, common, $($generator_types),+)
+            $crate::read_generator_impl!(buf, tag, common, $($generator_types),+)
         }
 
         fn write_generator(
@@ -87,7 +87,7 @@ macro_rules! impl_generator_serializer {
             generator: &$crate::iop::generator::WitnessGeneratorRef<F, D>,
             common: &$crate::plonk::circuit_data::CommonCircuitData<F, D>,
         ) -> $crate::util::serialization::IoResult<()> {
-            let tag = get_generator_tag_impl!(generator, $($generator_types),+)?;
+            let tag = $crate::get_generator_tag_impl!(generator, $($generator_types),+)?;
 
             $crate::util::serialization::Write::write_u32(buf, tag)?;
             generator.0.serialize(buf, common)?;


### PR DESCRIPTION
Currently, the `impl_gate_serializer` macro only works if `read_gate_impl` and `get_gate_tag_impl` are also imported.  The `impl_generator_serializer` macro has a similar issue.  This patch fixes these issues.